### PR TITLE
Fixes for custom labels dropdown

### DIFF
--- a/src/pages/settings/localization/components/CustomLabels.tsx
+++ b/src/pages/settings/localization/components/CustomLabels.tsx
@@ -88,7 +88,7 @@ export function CustomLabels() {
     );
 
     setDefaultLabelsFiltered(
-      defaultLabelsFiltered.filter(
+      defaultLabels.filter(
         (label) => !translations.includes(label.property)
       )
     );


### PR DESCRIPTION
This fixes the bug with a dropdown on the custom labels settings page.
After selecting a word from a dropdown and removing it from the list, the word was removed from the dropdown, this fix fixes this behavior.