### PR TITLE
set default remaining cycles to endless

### DIFF
--- a/src/pages/recurring-invoices/create/Create.tsx
+++ b/src/pages/recurring-invoices/create/Create.tsx
@@ -49,7 +49,11 @@ export function Create() {
 
   useEffect(() => {
     if (recurringInvoice?.data.data) {
-      dispatch(setCurrentRecurringInvoice(recurringInvoice.data.data));
+      const recurringInvoiceCopy: RecurringInvoice = {
+        ...recurringInvoice.data.data,
+      };
+      recurringInvoiceCopy.remaining_cycles = -1;
+      dispatch(setCurrentRecurringInvoice(recurringInvoiceCopy));
     }
   }, [recurringInvoice]);
 


### PR DESCRIPTION
This would be a lot cleaner if done by the api itself when returning blank invoice.