### PR TITLE
Set default stale time of DataTable to 5s

### DIFF
--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -89,7 +89,10 @@ export function DataTable(props: Props) {
 
   const { data, isLoading, isError } = useQuery(
     [apiEndpoint.pathname, perPage, currentPage, filter, sort, status],
-    () => request('GET', apiEndpoint.href)
+    () => request('GET', apiEndpoint.href),
+    {
+      staleTime: 5000,
+    }
   );
 
   const options: SelectOption[] = [


### PR DESCRIPTION
This defaults stale time of DataTables to 5 seconds.