### PR TITLE
Fixes for recurring invoice start date

### DIFF
--- a/src/pages/recurring-invoices/common/components/InvoiceDetails.tsx
+++ b/src/pages/recurring-invoices/common/components/InvoiceDetails.tsx
@@ -52,7 +52,7 @@ export function InvoiceDetails(props: Props) {
           <InputField
             type="date"
             onValueChange={(value) => handleChange('next_send_date', value)}
-            value={invoice?.date || new Date().toISOString().split('T')[0]}
+            value={invoice?.next_send_date ? invoice?.next_send_date.slice(0,10) : new Date().toISOString().split('T')[0]}
             min={new Date().toISOString().split('T')[0]}
           />
         </Element>

--- a/src/pages/recurring-invoices/common/components/InvoiceDetails.tsx
+++ b/src/pages/recurring-invoices/common/components/InvoiceDetails.tsx
@@ -17,6 +17,7 @@ import { ChangeEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSetCurrentRecurringInvoiceProperty } from '../hooks/useSetCurrentRecurringInvoiceProperty';
 import frequencies from 'common/constants/frequency';
+import dayjs from 'dayjs';
 
 interface Props {
   autoBill?: string;
@@ -52,7 +53,7 @@ export function InvoiceDetails(props: Props) {
           <InputField
             type="date"
             onValueChange={(value) => handleChange('next_send_date', value)}
-            value={invoice?.next_send_date ? invoice?.next_send_date.slice(0,10) : new Date().toISOString().split('T')[0]}
+            value={invoice?.next_send_date ? dayjs(invoice?.next_send_date).format('YYYY-MM-DD') : new Date().toISOString().split('T')[0]}
             min={new Date().toISOString().split('T')[0]}
           />
         </Element>


### PR DESCRIPTION
Changing this from `date` to `next_send_date`

One point to note is using native date javascript functions are adjusting the props to the client timezone.. this is wrong, we need to show the date as returned from the API.

I'm am simplying slicing the string if it exists, but this is something we'll want to be careful of elsewhere in the application.
 