### PR TITLE
Drop `With selected`

### DIFF
--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -169,7 +169,7 @@ export function DataTable(props: Props) {
             </Inline>
           }
         >
-          <Dropdown label={t('actions')}>
+          <Dropdown label={t('bulk_action')}>
             <DropdownElement onClick={() => bulk('archive')}>
               {t('archive')}
             </DropdownElement>

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -169,8 +169,6 @@ export function DataTable(props: Props) {
             </Inline>
           }
         >
-          <span className="text-sm">{t('with_selected')}</span>
-
           <Dropdown label={t('actions')}>
             <DropdownElement onClick={() => bulk('archive')}>
               {t('archive')}


### PR DESCRIPTION
This drops "With selected" label next to datatable actions.

![image](https://user-images.githubusercontent.com/13711415/194571878-e56ed616-1676-4564-b48b-061629dfa669.png)
