### PR TITLE
Improve tax rate settings clarity

### DIFF
--- a/src/pages/settings/tax-settings/components/Selector.tsx
+++ b/src/pages/settings/tax-settings/components/Selector.tsx
@@ -54,13 +54,18 @@ export function Selector() {
       {companyChanges?.enabled_tax_rates > 0 && (
         <Card>
           {companyChanges?.enabled_tax_rates > 0 && (
-            <Element leftSide={t('tax_rate1')}>
+            <Element leftSide={t('default_tax_rate')}>
               <SelectField
                 id="settings.tax_rate1"
                 onChange={handleChange}
                 value={companyChanges?.settings?.tax_name1 || '0'}
+                onValueChange={(value) => console.log(value)}
               >
-                <option value="0"></option>
+                <option
+                  data-rate={0}
+                  data-rate-name="settings.tax_name1"
+                  value="0"
+                />
                 {data &&
                   data.data.data.map((taxRate: TaxRate) => (
                     <option
@@ -77,13 +82,17 @@ export function Selector() {
           )}
 
           {companyChanges?.enabled_tax_rates > 1 && (
-            <Element leftSide={t('tax_rate2')}>
+            <Element leftSide={t('default_tax_rate')}>
               <SelectField
                 id="settings.tax_rate2"
                 onChange={handleChange}
                 value={companyChanges?.settings?.tax_name2 || '0'}
               >
-                <option value="0"></option>
+                <option
+                  data-rate={0}
+                  data-rate-name="settings.tax_name2"
+                  value="0"
+                />
                 {data &&
                   data.data.data.map((taxRate: TaxRate) => (
                     <option
@@ -100,13 +109,17 @@ export function Selector() {
           )}
 
           {companyChanges?.enabled_tax_rates > 2 && (
-            <Element leftSide={t('tax_rate3')}>
+            <Element leftSide={t('default_tax_rate')}>
               <SelectField
                 id="settings.tax_rate3"
                 onChange={handleChange}
                 value={companyChanges?.settings?.tax_name3 || '0'}
               >
-                <option value="0"></option>
+                <option
+                  data-rate={0}
+                  data-rate-name="settings.tax_name3"
+                  value="0"
+                />
                 {data &&
                   data.data.data.map((taxRate: TaxRate) => (
                     <option

--- a/src/pages/settings/tax-settings/components/Selector.tsx
+++ b/src/pages/settings/tax-settings/components/Selector.tsx
@@ -59,7 +59,6 @@ export function Selector() {
                 id="settings.tax_rate1"
                 onChange={handleChange}
                 value={companyChanges?.settings?.tax_name1 || '0'}
-                onValueChange={(value) => console.log(value)}
               >
                 <option
                   data-rate={0}


### PR DESCRIPTION
This makes three taxes selector same as Flutter version.

![image](https://user-images.githubusercontent.com/13711415/194811130-75bcd202-8ccb-4efc-a20f-e7c19fd22367.png)
![image](https://user-images.githubusercontent.com/13711415/194811164-bc7996b4-d31b-4abb-b932-3b842ab6de45.png)
