### PR TITLE
Improving client & product selectors

### DIFF
--- a/src/components/clients/ClientSelector.tsx
+++ b/src/components/clients/ClientSelector.tsx
@@ -46,6 +46,7 @@ export function ClientSelector(props: ClientSelectorProps) {
         initiallyVisible={props.initiallyVisible}
         actionLabel={t('new_client')}
         onActionClick={() => setIsModalOpen(true)}
+        sortBy="display_name|asc"
       />
     </>
   );

--- a/src/components/forms/DebouncedCombobox.tsx
+++ b/src/components/forms/DebouncedCombobox.tsx
@@ -50,6 +50,7 @@ interface Props {
   queryAdditional?: boolean;
   initiallyVisible?: boolean;
   withProperty?: string;
+  sortBy?: string;
 }
 
 export function DebouncedCombobox(props: Props) {
@@ -68,6 +69,7 @@ export function DebouncedCombobox(props: Props) {
     withoutEvents: true,
   });
 
+  const [sortBy] = useState(props.sortBy || 'created_at|desc');
   const [defaultValueProperty, setDefaultValueProperty] = useState('');
   const openDropdownButton = useRef<HTMLButtonElement | undefined>();
   const queryClient = useQueryClient();
@@ -93,7 +95,7 @@ export function DebouncedCombobox(props: Props) {
       url.searchParams.set('with', props.defaultValue.toString());
     }
 
-    url.searchParams.set('sort', 'created_at|desc');
+    url.searchParams.set('sort', sortBy);
     url.searchParams.set('is_deleted', 'false');
 
     const array: Record[] = [];

--- a/src/components/products/ProductSelector.tsx
+++ b/src/components/products/ProductSelector.tsx
@@ -31,7 +31,7 @@ export function ProductSelector(props: Props) {
   return (
     <>
       <DebouncedCombobox
-        endpoint="/api/v1/products"
+        endpoint="/api/v1/products?limit=500"
         label="product_key"
         onChange={(record: Record<Product>) =>
           props.onChange && props.onChange(record)

--- a/src/components/products/ProductSelector.tsx
+++ b/src/components/products/ProductSelector.tsx
@@ -43,6 +43,7 @@ export function ProductSelector(props: Props) {
         clearButton={props.clearButton}
         onClearButtonClick={props.onClearButtonClick}
         onInputFocus={props.onInputFocus}
+        sortBy="product_key|asc"
         withShadowRecord
       />
 


### PR DESCRIPTION
Changes:
- We pull default of 500 products. 
- Products are sorted a-z by product key.
- Clients are sorted  a-z by display name. 

(ref. 363)