### PR TITLE
Improve dashboard cards styles

### DIFF
--- a/src/components/cards/Card.tsx
+++ b/src/components/cards/Card.tsx
@@ -51,10 +51,10 @@ export function Card(props: Props) {
       <form onSubmit={props.onFormSubmit}>
         {props.title && (
           <div
-            className={classNames('px-4 sm:px-6 border-b border-gray-200', {
+            className={classNames('border-b border-gray-200', {
               'bg-white sticky top-0': props.withScrollableBody,
-              'py-3': padding == 'small',
-              'py-5': padding == 'regular',
+              'px-4 py-3': padding == 'small',
+              'px-4 sm:px-6 py-5': padding == 'regular',
             })}
           >
             <h3

--- a/src/components/cards/Card.tsx
+++ b/src/components/cards/Card.tsx
@@ -32,10 +32,13 @@ interface Props {
   additionalAction?: ReactNode;
   isLoading?: boolean;
   withoutBodyPadding?: boolean;
+  padding?: 'small' | 'regular';
 }
 
 export function Card(props: Props) {
   const [t] = useTranslation();
+
+  const { padding = 'regular' } = props;
 
   return (
     <div
@@ -48,12 +51,18 @@ export function Card(props: Props) {
       <form onSubmit={props.onFormSubmit}>
         {props.title && (
           <div
-            className={classNames(
-              'px-4 py-5 sm:px-6 border-b border-gray-200',
-              { 'bg-white sticky top-0': props.withScrollableBody }
-            )}
+            className={classNames('px-4 sm:px-6 border-b border-gray-200', {
+              'bg-white sticky top-0': props.withScrollableBody,
+              'py-3': padding == 'small',
+              'py-5': padding == 'regular',
+            })}
           >
-            <h3 className="text-lg leading-6 font-medium text-gray-900">
+            <h3
+              className={classNames('leading-6 font-medium text-gray-900', {
+                'text-lg': padding == 'regular',
+                'text-md': padding == 'small',
+              })}
+            >
               {props.title}
             </h3>
             {props.description && (

--- a/src/components/cards/Card.tsx
+++ b/src/components/cards/Card.tsx
@@ -73,7 +73,13 @@ export function Card(props: Props) {
           </div>
         )}
 
-        <div className={classNames({ 'py-4': !props.withoutBodyPadding })}>
+        <div
+          className={classNames({
+            'py-0': props.withoutBodyPadding,
+            'py-4': padding == 'regular',
+            'py-2': padding == 'small',
+          })}
+        >
           {props.isLoading && <Element leftSide={<Spinner />} />}
 
           {props.withContainer ? (

--- a/src/components/cards/NonClickableElement.tsx
+++ b/src/components/cards/NonClickableElement.tsx
@@ -8,16 +8,26 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
+import classNames from 'classnames';
 import CommonProps from 'common/interfaces/common-props.interface';
 
 interface Props extends CommonProps {
   className?: string;
+  padding?: 'small' | 'regular';
 }
 
 export function NonClickableElement(props: Props) {
+  const { padding = 'regular', className } = props;
+
   return (
     <div
-      className={`w-full text-left px-4 sm:px-6 block hover:bg-gray-50 py-4 text-gray-700 hover:text-gray-900 text-sm ${props.className}`}
+      className={classNames(
+        `w-full text-leftblock hover:bg-gray-50 text-gray-700 hover:text-gray-900 text-sm ${className}`,
+        {
+          'px-4 sm:px-6 py-4': padding == 'regular',
+          'px-4 py-2': padding == 'small',
+        }
+      )}
     >
       {props.children}
     </div>

--- a/src/pages/dashboard/components/Activity.tsx
+++ b/src/pages/dashboard/components/Activity.tsx
@@ -30,7 +30,12 @@ export function Activity() {
   const activityElement = useGenerateActivityElement();
 
   return (
-    <Card title={t('activity')} className="h-96" withScrollableBody>
+    <Card
+      title={t('activity')}
+      className="h-96"
+      padding="small"
+      withScrollableBody
+    >
       {isLoading && (
         <NonClickableElement>
           <Spinner />

--- a/src/pages/dashboard/components/Chart.tsx
+++ b/src/pages/dashboard/components/Chart.tsx
@@ -195,14 +195,14 @@ export function Chart(props: Props) {
         <Area
           name={t('payments')}
           dataKey="payments"
-          stroke={TotalColors.Red}
+          stroke={TotalColors.Green}
           fill="url(#payments)"
           fillOpacity={1}
         />
         <Area
           name={t('expenses')}
           dataKey="expenses"
-          stroke={TotalColors.Green}
+          stroke={TotalColors.Red}
           fill="url(#expenses)"
           fillOpacity={1}
         />

--- a/src/pages/dashboard/components/PastDueInvoices.tsx
+++ b/src/pages/dashboard/components/PastDueInvoices.tsx
@@ -66,6 +66,7 @@ export function PastDueInvoices() {
     <Card
       title={t('past_due_invoices')}
       className="h-96"
+      padding="small"
       withScrollableBody
       withoutBodyPadding
     >

--- a/src/pages/dashboard/components/RecentPayments.tsx
+++ b/src/pages/dashboard/components/RecentPayments.tsx
@@ -18,6 +18,7 @@ import { Link } from 'components/forms/Link';
 import { Payment } from 'common/interfaces/payment';
 import { useCurrentCompany } from 'common/hooks/useCurrentCompany';
 import { Card } from '@invoiceninja/cards';
+import { generatePath } from 'react-router-dom';
 
 export function RecentPayments() {
   const { dateFormat } = useCurrentCompanyDateFormats();
@@ -57,9 +58,18 @@ export function RecentPayments() {
     },
     {
       id: 'invoice_number',
-      label: t('invoice_number'),
+      label: t('invoice'),
       format: (value, payment) =>
-        payment.invoices && payment.invoices[0]?.number,
+        payment.invoices &&
+        payment.invoices[0] && (
+          <Link
+            to={generatePath('/invoices/:id/edit', {
+              id: payment.invoices[0].id,
+            })}
+          >
+            {payment.invoices[0].number}
+          </Link>
+        ),
     },
     {
       id: 'date',
@@ -72,6 +82,7 @@ export function RecentPayments() {
     <Card
       title={t('recent_payments')}
       className="h-96"
+      padding="small"
       withoutBodyPadding
       withScrollableBody
     >

--- a/src/pages/dashboard/components/UpcomingInvoices.tsx
+++ b/src/pages/dashboard/components/UpcomingInvoices.tsx
@@ -66,6 +66,7 @@ export function UpcomingInvoices() {
     <Card
       title={t('upcoming_invoices')}
       className="h-96"
+      padding="small"
       withScrollableBody
       withoutBodyPadding
     >

--- a/src/pages/dashboard/hooks/useGenerateActivityElement.tsx
+++ b/src/pages/dashboard/hooks/useGenerateActivityElement.tsx
@@ -152,12 +152,12 @@ export function useGenerateActivityElement() {
   };
 
   return (activity: ActivityRecord) => (
-    <NonClickableElement>
-      {generate(activity)}
+    <NonClickableElement padding="small" className="space-x-1">
+      <span className="text-gray-500 text-xs italic">
+        {date(activity.created_at, dateFormat)} &#183;
+      </span>
 
-      <p className="text-gray-500 text-xs">
-        {date(activity.created_at, dateFormat)} &#183; {activity.ip}
-      </p>
+      <span>{generate(activity)}</span>
     </NonClickableElement>
   );
 }


### PR DESCRIPTION
As per task requirements (RU-298), following had to be implemented.

- [x] Making all boxes same height
- [x] Cards needs to have less padding
- [x] For recent payments, rename "Invoice number" to "Invoice"
- [x] Remove IP address
- [ ] Implement activities on the client page itself

Skipped:
- Card titlebars should use primary color: This is totally off when it comes to rest of the app. Putting accent color on the card makes every other card look incoherent.

- Sub cards need to be grayish color: I think we should keep tables headers accent color. Not change them to gray, because previously mentioned task isn't implemented. Gray on white doesn't create enough contrast for such important element.

Missing:
- [ ] IP address have been removed, as proposed, we should implement this functionality by adding "Activities" tab on the client page itself.