### PR TITLE
[Feature] Disable email template

### DIFF
--- a/src/pages/settings/templates-and-reminders/TemplatesAndReminders.tsx
+++ b/src/pages/settings/templates-and-reminders/TemplatesAndReminders.tsx
@@ -9,12 +9,13 @@
  */
 
 import { Card, Element } from '@invoiceninja/cards';
-import { InputField, SelectField } from '@invoiceninja/forms';
+import { Button, InputField, Link, SelectField } from '@invoiceninja/forms';
 import { freePlan } from 'common/guards/guards/free-plan';
 import { endpoint, isHosted, isSelfHosted } from 'common/helpers';
 import { generateEmailPreview } from 'common/helpers/emails/generate-email-preview';
 import { request } from 'common/helpers/request';
 import { EmailTemplate } from 'common/hooks/emails/useResolveTemplate';
+import { useCurrentUser } from 'common/hooks/useCurrentUser';
 import { useInjectCompanyChanges } from 'common/hooks/useInjectCompanyChanges';
 import { useTitle } from 'common/hooks/useTitle';
 import { Settings as CompanySettings } from 'common/interfaces/company.interface';
@@ -46,6 +47,7 @@ export function TemplatesAndReminders() {
   const handleChange = useHandleCurrentCompanyChangeProperty();
   const handleSave = useHandleCompanySave();
   const handleCancel = useHandleCancel();
+  const user = useCurrentUser();
 
   const { data: statics } = useStaticsQuery();
   const [templateId, setTemplateId] = useState('invoice');
@@ -196,8 +198,8 @@ export function TemplatesAndReminders() {
           />
         </Element>
 
-        {canChangeEmailTemplate && (
-          <Element leftSide={t('body')}>
+        <Element leftSide={t('body')}>
+          {canChangeEmailTemplate ? (
             <MarkdownEditor
               value={templateBody?.body}
               onChange={(value) =>
@@ -206,8 +208,22 @@ export function TemplatesAndReminders() {
                 )
               }
             />
-          </Element>
-        )}
+          ) : (
+            <div className="flex flex-col items-start">
+              <span className=" text-gray-500" style={{ fontSize: 12 }}>
+                Email body template can be changed on{' '}
+                <strong>Enterprise/Pro</strong> plan.
+              </span>
+              <Link
+                className="mt-2"
+                external
+                to={user?.company_user?.ninja_portal_url || ''}
+              >
+                <Button>{t('plan_change')}</Button>
+              </Link>
+            </div>
+          )}
+        </Element>
       </Card>
 
       {preview && (

--- a/src/pages/settings/templates-and-reminders/TemplatesAndReminders.tsx
+++ b/src/pages/settings/templates-and-reminders/TemplatesAndReminders.tsx
@@ -10,7 +10,8 @@
 
 import { Card, Element } from '@invoiceninja/cards';
 import { InputField, SelectField } from '@invoiceninja/forms';
-import { endpoint } from 'common/helpers';
+import { freePlan } from 'common/guards/guards/free-plan';
+import { endpoint, isHosted, isSelfHosted } from 'common/helpers';
 import { generateEmailPreview } from 'common/helpers/emails/generate-email-preview';
 import { request } from 'common/helpers/request';
 import { EmailTemplate } from 'common/hooks/emails/useResolveTemplate';
@@ -50,6 +51,7 @@ export function TemplatesAndReminders() {
   const [templateId, setTemplateId] = useState('invoice');
   const [templateBody, setTemplateBody] = useState<TemplateBody>();
   const [preview, setPreview] = useState<EmailTemplate>();
+  const canChangeEmailTemplate = (isHosted() && !freePlan()) || isSelfHosted();
 
   useEffect(() => {
     if (statics?.templates && company) {
@@ -194,16 +196,18 @@ export function TemplatesAndReminders() {
           />
         </Element>
 
-        <Element leftSide={t('body')}>
-          <MarkdownEditor
-            value={templateBody?.body}
-            onChange={(value) =>
-              setTemplateBody(
-                (current) => current && { ...current, body: value }
-              )
-            }
-          />
-        </Element>
+        {canChangeEmailTemplate && (
+          <Element leftSide={t('body')}>
+            <MarkdownEditor
+              value={templateBody?.body}
+              onChange={(value) =>
+                setTemplateBody(
+                  (current) => current && { ...current, body: value }
+                )
+              }
+            />
+          </Element>
+        )}
       </Card>
 
       {preview && (

--- a/src/pages/settings/templates-and-reminders/TemplatesAndReminders.tsx
+++ b/src/pages/settings/templates-and-reminders/TemplatesAndReminders.tsx
@@ -210,9 +210,12 @@ export function TemplatesAndReminders() {
             />
           ) : (
             <div className="flex flex-col items-start">
-              <span className=" text-gray-500" style={{ fontSize: 12 }}>
-                Email body template can be changed on{' '}
-                <strong>Enterprise/Pro</strong> plan.
+              <span className="text-gray-500 text-sm">
+                {t('email_template_change')}{' '}
+                <strong>
+                  {t('enterprise')}/{t('pro')}
+                </strong>{' '}
+                {t('plan')}.
               </span>
               <Link
                 className="mt-2"


### PR DESCRIPTION
@beganovich I've been looking for a solution to disable the MDEditor component from the @uiw/react-md-editor npm package, but I haven't found one. Here's a link to the source where I found it's not yet possible for this component: https://github.com/jrm2k6/react-markdown-editor/issues/56. Please let me know if I'm wrong.

@turbo124 Regarding this situation that I don't have permission to disable this component, I decided not to show this component if the user is not allowed to do so. Please let me know if you agree with this kind of solution if Ben confirms that disabling is not possible.

Here is the screenshot of how it looks without body template:

![image](https://user-images.githubusercontent.com/51542191/202852773-f723954a-40c5-491f-9e13-ae32c501aebe.png)