### PR TITLE
Add validation errors to payments create page

### DIFF
--- a/src/pages/payments/create/Create.tsx
+++ b/src/pages/payments/create/Create.tsx
@@ -31,6 +31,7 @@ import { CustomField } from 'components/CustomField';
 import { DebouncedCombobox, Record } from 'components/forms/DebouncedCombobox';
 import Toggle from 'components/forms/Toggle';
 import { Default } from 'components/layouts/Default';
+import { ValidationAlert } from 'components/ValidationAlert';
 import { useEffect, useState } from 'react';
 import { X } from 'react-feather';
 import { useTranslation } from 'react-i18next';
@@ -189,6 +190,8 @@ export function Create() {
   return (
     <Default title={documentTitle} breadcrumbs={pages}>
       <Container>
+        {errors && <ValidationAlert errors={errors} />}
+
         <Card
           title={t('enter_payment')}
           onFormSubmit={(event) => {


### PR DESCRIPTION
This shows validation errors on the payment creation page.

![image](https://user-images.githubusercontent.com/13711415/203590709-cfc40cf2-6b79-491b-a0e9-d3cce25aa3ad.png)
