### PR TITLE
Changed redirection URL for connect accounts

### DIFF
--- a/src/pages/settings/bank-accounts/index/BankAccounts.tsx
+++ b/src/pages/settings/bank-accounts/index/BankAccounts.tsx
@@ -38,7 +38,7 @@ export function BankAccounts() {
       { context: 'yodlee', platform: 'react' }
     );
     window.open(
-      route('/yodlee/onboard/:hash', {
+      route('https://invoicing.co/yodlee/onboard/:hash', {
         hash: tokenResponse?.data?.hash,
       })
     );


### PR DESCRIPTION
@turbo124 gave me a feedback that the base URL is not okay for purpose of this feature and that should look like: 

https://invoicing.co/yodlee/onboard/mb4mvHNH1l6Hv3afamgoHmq3qj0EeZwgowVPAiOfez6gTgS3IKriH5JVteMnAGNt

So, I just changed the redirection URL.