### PR TITLE
[Feature] Hide sensitive data

### DIFF
--- a/src/components/forms/InputField.tsx
+++ b/src/components/forms/InputField.tsx
@@ -84,7 +84,7 @@ export function InputField(props: Props) {
         />
 
         {isInitialTypePassword && (
-          <span className="absolute top-1/4 right-5 cursor-pointer">
+          <span className="absolute top-1/4 right-3 cursor-pointer">
             {isEyeOpen ? (
               <AiFillEye
                 className="text-gray-400"

--- a/src/components/forms/InputField.tsx
+++ b/src/components/forms/InputField.tsx
@@ -10,7 +10,9 @@
 
 import classNames from 'classnames';
 import { Alert } from 'components/Alert';
+import { useState } from 'react';
 import { DebounceInput } from 'react-debounce-input';
+import { AiFillEye, AiFillEyeInvisible } from 'react-icons/ai';
 
 import CommonProps from '../../common/interfaces/common-props.interface';
 import { InputLabel } from './InputLabel';
@@ -35,6 +37,10 @@ interface Props extends CommonProps {
 }
 
 export function InputField(props: Props) {
+  const isInitialTypePassword = props.type === 'password';
+
+  const [isEyeOpen, setIsEyeOpen] = useState<boolean>(true);
+
   return (
     <section>
       {props.label && (
@@ -44,31 +50,57 @@ export function InputField(props: Props) {
         </InputLabel>
       )}
 
-      <DebounceInput
-        min={props.min}
-        disabled={props.disabled}
-        element={props.element || 'input'}
-        inputRef={props.innerRef}
-        debounceTimeout={props.debounceTimeout ?? 300}
-        required={props.required}
-        id={props.id}
-        type={props.type}
-        className={classNames(
-          `w-full py-2 px-3 rounded text-sm text-gray-900 dark:bg-gray-800 dark:border-transparent dark:text-gray-100 disabled:bg-gray-100 disabled:cursor-not-allowed ${props.className}`,
-          {
-            'border border-gray-300': props.border !== false,
+      <div className="relative">
+        <DebounceInput
+          min={props.min}
+          disabled={props.disabled}
+          element={props.element || 'input'}
+          inputRef={props.innerRef}
+          debounceTimeout={props.debounceTimeout ?? 300}
+          required={props.required}
+          id={props.id}
+          type={
+            isInitialTypePassword && isEyeOpen
+              ? 'password'
+              : isInitialTypePassword && !isEyeOpen
+              ? 'text'
+              : props.type
           }
+          className={classNames(
+            `w-full py-2 px-3 rounded text-sm text-gray-900 dark:bg-gray-800 dark:border-transparent dark:text-gray-100 disabled:bg-gray-100 disabled:cursor-not-allowed ${props.className}`,
+            {
+              'border border-gray-300': props.border !== false,
+            }
+          )}
+          placeholder={props.placeholder}
+          onChange={(event) => {
+            props.onValueChange && props.onValueChange(event.target.value);
+            props.onChange && props.onChange(event);
+          }}
+          value={props.value}
+          list={props.list}
+          rows={props.textareaRows || 5}
+          step={props.step}
+        />
+
+        {isInitialTypePassword && (
+          <span className="absolute top-1/4 right-5 cursor-pointer">
+            {isEyeOpen ? (
+              <AiFillEye
+                className="text-gray-400"
+                fontSize={19}
+                onClick={() => setIsEyeOpen(false)}
+              />
+            ) : (
+              <AiFillEyeInvisible
+                className="text-gray-400"
+                fontSize={19}
+                onClick={() => setIsEyeOpen(true)}
+              />
+            )}
+          </span>
         )}
-        placeholder={props.placeholder}
-        onChange={(event) => {
-          props.onValueChange && props.onValueChange(event.target.value);
-          props.onChange && props.onChange(event);
-        }}
-        value={props.value}
-        list={props.list}
-        rows={props.textareaRows || 5}
-        step={props.step}
-      />
+      </div>
 
       {props.errorMessage && (
         <Alert className="mt-2" type="danger">

--- a/src/components/forms/InputField.tsx
+++ b/src/components/forms/InputField.tsx
@@ -10,11 +10,10 @@
 
 import classNames from 'classnames';
 import { Alert } from 'components/Alert';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { DebounceInput } from 'react-debounce-input';
 import { AiFillEye, AiFillEyeInvisible } from 'react-icons/ai';
-
-import CommonProps from '../../common/interfaces/common-props.interface';
+  import CommonProps from '../../common/interfaces/common-props.interface';
 import { InputLabel } from './InputLabel';
 
 interface Props extends CommonProps {
@@ -39,7 +38,19 @@ interface Props extends CommonProps {
 export function InputField(props: Props) {
   const isInitialTypePassword = props.type === 'password';
 
-  const [isEyeOpen, setIsEyeOpen] = useState<boolean>(true);
+  const [isInputMasked, setIsInputMasked] = useState(true);
+
+  const inputType = useMemo(() => {
+    if (props.type === 'password' && isInputMasked) {
+      return 'password';
+    }
+
+    if (props.type === 'password' && !isInputMasked) {
+      return 'text';
+    }
+
+    return props.type;
+  }, [props.type, isInputMasked]);
 
   return (
     <section>
@@ -59,13 +70,7 @@ export function InputField(props: Props) {
           debounceTimeout={props.debounceTimeout ?? 300}
           required={props.required}
           id={props.id}
-          type={
-            isInitialTypePassword && isEyeOpen
-              ? 'password'
-              : isInitialTypePassword && !isEyeOpen
-              ? 'text'
-              : props.type
-          }
+          type={inputType}
           className={classNames(
             `w-full py-2 px-3 rounded text-sm text-gray-900 dark:bg-gray-800 dark:border-transparent dark:text-gray-100 disabled:bg-gray-100 disabled:cursor-not-allowed ${props.className}`,
             {
@@ -85,17 +90,17 @@ export function InputField(props: Props) {
 
         {isInitialTypePassword && (
           <span className="absolute top-1/4 right-3 cursor-pointer">
-            {isEyeOpen ? (
+            {isInputMasked ? (
               <AiFillEye
                 className="text-gray-400"
                 fontSize={19}
-                onClick={() => setIsEyeOpen(false)}
+                onClick={() => setIsInputMasked(false)}
               />
             ) : (
               <AiFillEyeInvisible
                 className="text-gray-400"
                 fontSize={19}
-                onClick={() => setIsEyeOpen(true)}
+                onClick={() => setIsInputMasked(true)}
               />
             )}
           </span>

--- a/src/pages/settings/gateways/create/hooks/useResolveInputField.tsx
+++ b/src/pages/settings/gateways/create/hooks/useResolveInputField.tsx
@@ -66,8 +66,15 @@ export function useResolveInputField(
     }
 
     if (typeof value === 'string') {
+      const isSecureField =
+        property.toLowerCase().includes('key') ||
+        property.toLowerCase().includes('password') ||
+        property.toLowerCase().includes('secret') ||
+        property.toLowerCase().includes('id');
+
       return (
         <InputField
+          type={isSecureField ? 'password' : 'text'}
           onChange={(event: ChangeEvent<HTMLInputElement>) =>
             handleChange(property as keyof Field, event.target.value)
           }


### PR DESCRIPTION
Here is an implemented solution for hiding sensitive data on payment gateway cards and the ability to display them if the user wants when the field type is password!

<img width="1512" alt="Screenshot 2022-12-04 at 16 36 53" src="https://user-images.githubusercontent.com/51542191/205501059-601d059b-7a8a-43c5-bf6d-6da050053b6c.png">

The solution also applies to all password type fields such as the login/registration form!

<img width="357" alt="Screenshot 2022-12-04 at 16 45 12" src="https://user-images.githubusercontent.com/51542191/205501100-dfb838ef-4a5d-4ab6-9d0a-785b78e34f98.png">

@beganovich  I've been trying to find if the DebounceInput component contains a property to add some icons to the field, but I haven't found anything in the documentation and other resources. So I think this component does not contain that and implemented this solution. Some MUI TextField components contain properties like end adornment that we can use to implement this functionality, but we're not using MUI so this isn't available.

@turbo124 This workaround is implemented on all input fields on the Credential tab (the other tabs do not contain any sensitive data) that contain a `key`, `password`, `secret`, or `id` in the property name.