### PR TITLE
[Feature] Payment gateway edit on more actions

### DIFF
--- a/src/pages/settings/gateways/index/Gateways.tsx
+++ b/src/pages/settings/gateways/index/Gateways.tsx
@@ -41,6 +41,7 @@ export function Gateways() {
       resource="company_gateway"
       endpoint="/api/v1/company_gateways"
       linkToCreate="/settings/gateways/create"
+      linkToEdit="/settings/gateways/:id/edit"
       withResourcefulActions
     />
   );


### PR DESCRIPTION
Here is screenshot of just added edit payement gateway functionality to more actions:

<img width="1512" alt="Screenshot 2022-12-04 at 23 02 09" src="https://user-images.githubusercontent.com/51542191/205518199-00f0e51f-5738-4867-bb53-cfefc374e0ff.png">

@beganovich  @turbo124 You can see in the screenshot that we disagree with the wording in the more-actions dropdown menu. My recommendation is to keep `edit_company_gateway` keyword as is and change the other two for archive and delete to 'Archive Gateway' and 'Delete Gateway', as it is obvious that we are on the payment gateway page. Also, as an example, on the `new_gateway` button we have 'New Gateway' but not 'New Payment Gateway'. Let me know your thoughts.