### PR TITLE
[Cleanup] Tax rate formatting

### DIFF
--- a/src/pages/settings/tax-rates/TaxRates.tsx
+++ b/src/pages/settings/tax-rates/TaxRates.tsx
@@ -7,112 +7,21 @@
  *
  * @license https://www.elastic.co/licensing/elastic-license
  */
-import { Button, Link } from '@invoiceninja/forms';
-import {
-  Pagination,
-  Table as TableComponent,
-  Tbody,
-  Td,
-  Th,
-  Thead,
-  Tr,
-} from '@invoiceninja/tables';
-import { AxiosError } from 'axios';
-import { TaxRate } from 'common/interfaces/tax-rate';
-import { bulk, useTaxRatesQuery } from 'common/queries/tax-rates';
-import { Dropdown } from 'components/dropdown/Dropdown';
-import { DropdownElement } from 'components/dropdown/DropdownElement';
-import { useState } from 'react';
-import toast from 'react-hot-toast';
-import { useTranslation } from 'react-i18next';
-import { useQueryClient } from 'react-query';
-import { route } from 'common/helpers/route';
+
+import { DataTable } from 'components/DataTable';
+import { useTaxRateColumns } from './common/hooks/useTaxRateColumns';
 
 export function TaxRates() {
-  const [t] = useTranslation();
-  const queryClient = useQueryClient();
-
-  const [currentPage, setCurrentPage] = useState<number>(1);
-  const [perPage, setPerPage] = useState<string>('10');
-
-  const sort = 'id|asc';
-
-  const { data } = useTaxRatesQuery({
-    currentPage,
-    perPage,
-    sort,
-  });
-
-  const archive = (id: string) => {
-    toast.loading(t('processing'));
-
-    bulk([id], 'archive')
-      .then(() => {
-        toast.dismiss();
-        toast.success(t('archived_tax_rate'));
-      })
-      .catch((error: AxiosError) => {
-        toast.dismiss();
-        toast.success(t('error_title'));
-
-        console.error(error);
-      })
-      .finally(() => queryClient.invalidateQueries('/api/v1/tax_rates'));
-  };
+  const columns = useTaxRateColumns();
 
   return (
-    <>
-      <div className="flex justify-end mt-8">
-        <Button to="/settings/tax_rates/create">{t('create_tax_rate')}</Button>
-      </div>
-
-      <TableComponent>
-        <Thead>
-          <Th>{t('name')}</Th>
-          <Th>{t('rate')}</Th>
-          <Th></Th>
-        </Thead>
-        <Tbody data={data} showHelperPlaceholders>
-          {data &&
-            data.data.data.map((taxRate: TaxRate) => (
-              <Tr key={taxRate.id}>
-                <Td>
-                  <Link
-                    to={route('/settings/tax_rates/:id/edit', {
-                      id: taxRate.id,
-                    })}
-                  >
-                    {taxRate.name}
-                  </Link>
-                </Td>
-                <Td>{taxRate.rate}</Td>
-                <Td>
-                  <Dropdown label={t('actions')}>
-                    <DropdownElement
-                      to={route('/settings/tax_rates/:id/edit', {
-                        id: taxRate.id,
-                      })}
-                    >
-                      {t('edit_tax_rate')}
-                    </DropdownElement>
-                    <DropdownElement onClick={() => archive(taxRate.id)}>
-                      {t('archive_tax_rate')}
-                    </DropdownElement>
-                  </Dropdown>
-                </Td>
-              </Tr>
-            ))}
-        </Tbody>
-      </TableComponent>
-
-      {data && (
-        <Pagination
-          currentPage={currentPage}
-          onPageChange={setCurrentPage}
-          onRowsChange={setPerPage}
-          totalPages={data.data.meta.pagination.total_pages}
-        />
-      )}
-    </>
+    <DataTable
+      resource="tax_rate"
+      endpoint="/api/v1/tax_rates"
+      columns={columns}
+      linkToCreate="/settings/tax_rates/create"
+      linkToEdit="/settings/tax_rates/:id/edit"
+      withResourcefulActions
+    />
   );
 }

--- a/src/pages/settings/tax-rates/common/hooks/useTaxRateColumns.tsx
+++ b/src/pages/settings/tax-rates/common/hooks/useTaxRateColumns.tsx
@@ -1,0 +1,42 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { Link } from '@invoiceninja/forms';
+import { route } from 'common/helpers/route';
+import { TaxRate } from 'common/interfaces/tax-rate';
+import { DataTableColumns } from 'components/DataTable';
+import { useTranslation } from 'react-i18next';
+
+export const useTaxRateColumns = () => {
+  const [t] = useTranslation();
+
+  const columns: DataTableColumns<TaxRate> = [
+    {
+      id: 'name',
+      label: t('name'),
+      format: (field, resource) => (
+        <Link
+          to={route('/settings/tax_rates/:id/edit', {
+            id: resource.id,
+          })}
+        >
+          {resource?.name}
+        </Link>
+      ),
+    },
+    {
+      id: 'rate',
+      label: t('rate'),
+      format: (value) => <span>{value}%</span>,
+    },
+  ];
+
+  return columns;
+};


### PR DESCRIPTION
Here is the screenshot of reafactored table and columns for tax rates:

<img width="1512" alt="Screenshot 2022-12-11 at 15 37 36" src="https://user-images.githubusercontent.com/51542191/206910370-f2e8a0ad-5cbf-4954-8035-90ae9ca01f0f.png">

@turbo124 @beganovich Also, I noticed that this table is not consistent with other tables and through testing I didn't notice any difference or specific case why we don't use the same table as for other features, so I refactored it. If there is no reason why we used a custom table, there are two new keywords to add, `delete_tax_rate` and `restore_tax_rate`. One small thing about keywords, as you can see in the screenshot `edit_tax_rate` the keyword has a value of `Edit tax rate` so I recommend that you change all the words to uppercase as well as the other tax rate related keywords.

One more thing about the UI for tax rates. On the edit page we have archive and delete functionality, if we have those functionalities in the more-actions dropdown menu in the table, I recommend removing it from the edit page. Here's a screenshot:

<img width="1512" alt="Screenshot 2022-12-11 at 15 38 16" src="https://user-images.githubusercontent.com/51542191/206910809-1cd095ba-c2ef-431b-ac1e-2587d1b6b5ea.png">