### PR TITLE
[Feature] Purchase Order Filters

### DIFF
--- a/src/pages/purchase-orders/common/hooks.tsx
+++ b/src/pages/purchase-orders/common/hooks.tsx
@@ -24,6 +24,7 @@ import { PurchaseOrder } from 'common/interfaces/purchase-order';
 import { ValidationBag } from 'common/interfaces/validation-bag';
 import { CopyToClipboard } from 'components/CopyToClipboard';
 import { customField } from 'components/CustomField';
+import { SelectOption } from 'components/datatables/Actions';
 import { EntityStatus } from 'components/EntityStatus';
 import { StatusBadge } from 'components/StatusBadge';
 import { DataTableColumnsExtended } from 'pages/invoices/common/hooks/useInvoiceColumns';
@@ -289,4 +290,43 @@ export function usePurchaseOrderColumns() {
   return columns
     .filter((column) => list.includes(column.column))
     .sort((a, b) => list.indexOf(a.column) - list.indexOf(b.column));
+}
+
+export function usePurchaseOrderFilters() {
+  const [t] = useTranslation();
+
+  const filters: SelectOption[] = [
+    {
+      label: t('all'),
+      value: 'all',
+      color: 'black',
+      backgroundColor: '#e4e4e4',
+    },
+    {
+      label: t('draft'),
+      value: 'draft',
+      color: 'white',
+      backgroundColor: '#6B7280',
+    },
+    {
+      label: t('sent'),
+      value: 'sent',
+      color: 'white',
+      backgroundColor: '#93C5FD',
+    },
+    {
+      label: t('accepted'),
+      value: 'accepted',
+      color: 'white',
+      backgroundColor: '#1D4ED8',
+    },
+    {
+      label: t('cancelled'),
+      value: 'cancelled',
+      color: 'white',
+      backgroundColor: '#e6b05c',
+    },
+  ];
+
+  return filters;
 }

--- a/src/pages/purchase-orders/index/PurchaseOrders.tsx
+++ b/src/pages/purchase-orders/index/PurchaseOrders.tsx
@@ -18,6 +18,7 @@ import {
   defaultColumns,
   purchaseOrderColumns,
   usePurchaseOrderColumns,
+  usePurchaseOrderFilters,
 } from '../common/hooks';
 
 export function PurchaseOrders() {
@@ -31,6 +32,8 @@ export function PurchaseOrders() {
 
   const columns = usePurchaseOrderColumns();
 
+  const filters = usePurchaseOrderFilters();
+
   return (
     <Default title={documentTitle} breadcrumbs={pages}>
       <DataTable
@@ -40,6 +43,9 @@ export function PurchaseOrders() {
         linkToCreate="/purchase_orders/create"
         linkToEdit="/purchase_orders/:id/edit"
         columns={columns}
+        customFilters={filters}
+        customFilterQueryKey="client_status"
+        customFilterPlaceholder="purchase_order_status"
         withResourcefulActions
         leftSideChevrons={
           <DataTableColumnsPicker

--- a/src/pages/purchase-orders/index/PurchaseOrders.tsx
+++ b/src/pages/purchase-orders/index/PurchaseOrders.tsx
@@ -45,7 +45,7 @@ export function PurchaseOrders() {
         columns={columns}
         customFilters={filters}
         customFilterQueryKey="client_status"
-        customFilterPlaceholder="purchase_order_status"
+        customFilterPlaceholder="status"
         withResourcefulActions
         leftSideChevrons={
           <DataTableColumnsPicker


### PR DESCRIPTION
Here is the screenshot of implemented solution for custom Purchase Order filters:

![Screenshot 2022-12-20 at 17 13 50](https://user-images.githubusercontent.com/51542191/208714633-2faa5f9a-4bb0-40a1-8fd2-6b4529a36d6b.png)

@turbo124 I set `purchase_order_status` as a placeholder for this dropdown. So we're missing that in the translation files. If you agree with this keyword, just add it.