### PR TITLE
[Bug Fix] Payments sorting

### DIFF
--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -84,12 +84,22 @@ export function DataTable<T extends object>(props: Props<T>) {
   const [customFilter, setCustomFilter] = useState<string[]>([]);
   const [currentPage, setCurrentPage] = useState(1);
   const [perPage, setPerPage] = useAtom(datatablePerPageAtom);
-  const [sort, setSort] = useState('id|asc');
+  const [sort, setSort] = useState(
+    apiEndpoint.searchParams.get('sort') || 'id|asc'
+  );
   const [sortedBy, setSortedBy] = useState<string | undefined>(undefined);
   const [status, setStatus] = useState<string[]>(['active']);
   const [selected, setSelected] = useState<string[]>([]);
 
   const mainCheckbox = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const perPageParameter = apiEndpoint.searchParams.get('perPage');
+
+    if (perPageParameter) {
+      setPerPage(perPageParameter);
+    }
+  }, []);
 
   useEffect(() => {
     apiEndpoint.searchParams.set('per_page', perPage);


### PR DESCRIPTION
Here is the screenshot of resolved bug with payment sorting:

![Screenshot 2022-12-21 at 23 57 27](https://user-images.githubusercontent.com/51542191/209019048-9a756389-a65f-4c3f-bb85-10fb07bce21f.png)

@turbo124 We also had a bug with the perPage parameter. We sent 50 through the endpoint but only got 10 in the result (the default value). So this PR also includes a fix for this also.