### PR TITLE
[Feature] Disabling documents

### DIFF
--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -15,6 +15,7 @@ import { X } from 'react-feather';
 
 interface Props extends CommonProps {
   type?: string | 'success' | 'warning' | 'danger';
+  disableClosing?: boolean;
 }
 
 export function Alert(props: Props) {
@@ -40,9 +41,11 @@ export function Alert(props: Props) {
         >
           <div className="flex items-center justify-between">
             <span>{props.children}</span>
-            <button type="button" className="px-4">
-              <X onClick={() => setVisible(false)} />
-            </button>
+            {!props.disableClosing && (
+              <button type="button" className="px-4">
+                <X onClick={() => setVisible(false)} />
+              </button>
+            )}
           </div>
         </div>
       </div>

--- a/src/pages/settings/company/documents/components/Upload.tsx
+++ b/src/pages/settings/company/documents/components/Upload.tsx
@@ -35,6 +35,8 @@ export function Upload(props: Props) {
 
   const [formData, setFormData] = useState(new FormData());
 
+  const showPlanAlert = !enterprisePlan() && isHosted();
+
   const formik = useFormik({
     enableReinitialize: true,
     initialValues: {},
@@ -59,7 +61,7 @@ export function Upload(props: Props) {
   });
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
-    disabled: !enterprisePlan() && isHosted(),
+    disabled: showPlanAlert,
     onDrop: (acceptedFiles) => {
       formData.append('_method', 'PUT');
 
@@ -73,7 +75,7 @@ export function Upload(props: Props) {
 
   const planWarning = (
     <Alert className="mb-4" type="warning" disableClosing>
-      {t('documents_upgrade_plan')}
+      {t('upgrade_to_upload_images')}
 
       {user?.company_user && (
         <Link
@@ -90,7 +92,7 @@ export function Upload(props: Props) {
   if (props.widgetOnly) {
     return (
       <>
-        {!enterprisePlan() && isHosted() && planWarning}
+        {showPlanAlert && planWarning}
 
         <div
           {...getRootProps()}
@@ -112,7 +114,7 @@ export function Upload(props: Props) {
 
   return (
     <>
-      {!enterprisePlan() && isHosted() && planWarning}
+      {showPlanAlert && planWarning}
 
       <Card title={t('upload')}>
         <Element leftSide={t('upload')}>

--- a/src/pages/settings/company/documents/components/Upload.tsx
+++ b/src/pages/settings/company/documents/components/Upload.tsx
@@ -36,8 +36,6 @@ export function Upload(props: Props) {
 
   const [formData, setFormData] = useState(new FormData());
 
-  const showPlanAlert = !enterprisePlan() && isHosted();
-
   const formik = useFormik({
     enableReinitialize: true,
     initialValues: {},
@@ -62,7 +60,7 @@ export function Upload(props: Props) {
   });
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
-    disabled: showPlanAlert,
+    disabled: !enterprisePlan() && isHosted(),
     onDrop: (acceptedFiles) => {
       formData.append('_method', 'PUT');
 
@@ -74,30 +72,28 @@ export function Upload(props: Props) {
     },
   });
 
-  const planWarning = (
-    <Alert className="mb-4" type="warning" disableClosing>
-      <div className="flex items-center">
-        <MdInfoOutline className="mr-2" fontSize={20} />
-
-        {t('upgrade_to_upload_images')}
-
-        {user?.company_user && (
-          <Link
-            className="ml-10"
-            external
-            to={user.company_user.ninja_portal_url}
-          >
-            {t('plan_change')}
-          </Link>
-        )}
-      </div>
-    </Alert>
-  );
-
   if (props.widgetOnly) {
     return (
       <>
-        {showPlanAlert && planWarning}
+        {!enterprisePlan() && isHosted() && (
+          <Alert className="mb-4" type="warning" disableClosing>
+            <div className="flex items-center">
+              <MdInfoOutline className="mr-2" fontSize={20} />
+
+              {t('upgrade_to_upload_images')}
+
+              {user?.company_user && (
+                <Link
+                  className="ml-10"
+                  external
+                  to={user.company_user.ninja_portal_url}
+                >
+                  {t('plan_change')}
+                </Link>
+              )}
+            </div>
+          </Alert>
+        )}
 
         <div
           {...getRootProps()}
@@ -119,7 +115,25 @@ export function Upload(props: Props) {
 
   return (
     <>
-      {showPlanAlert && planWarning}
+      {!enterprisePlan() && isHosted() && (
+        <Alert className="mb-4" type="warning" disableClosing>
+          <div className="flex items-center">
+            <MdInfoOutline className="mr-2" fontSize={20} />
+
+            {t('upgrade_to_upload_images')}
+
+            {user?.company_user && (
+              <Link
+                className="ml-10"
+                external
+                to={user.company_user.ninja_portal_url}
+              >
+                {t('plan_change')}
+              </Link>
+            )}
+          </div>
+        </Alert>
+      )}
 
       <Card title={t('upload')}>
         <Element leftSide={t('upload')}>

--- a/src/pages/settings/company/documents/components/Upload.tsx
+++ b/src/pages/settings/company/documents/components/Upload.tsx
@@ -21,6 +21,7 @@ import { Alert } from 'components/Alert';
 import { useCurrentUser } from 'common/hooks/useCurrentUser';
 import { Link } from '@invoiceninja/forms';
 import { toast } from 'common/helpers/toast/toast';
+import { MdInfoOutline } from 'react-icons/md';
 
 interface Props {
   endpoint: string;
@@ -75,17 +76,21 @@ export function Upload(props: Props) {
 
   const planWarning = (
     <Alert className="mb-4" type="warning" disableClosing>
-      {t('upgrade_to_upload_images')}
+      <div className="flex items-center">
+        <MdInfoOutline className="mr-2" fontSize={20} />
 
-      {user?.company_user && (
-        <Link
-          className="ml-10"
-          external
-          to={user.company_user.ninja_portal_url}
-        >
-          {t('plan_change')}
-        </Link>
-      )}
+        {t('upgrade_to_upload_images')}
+
+        {user?.company_user && (
+          <Link
+            className="ml-10"
+            external
+            to={user.company_user.ninja_portal_url}
+          >
+            {t('plan_change')}
+          </Link>
+        )}
+      </div>
     </Alert>
   );
 

--- a/src/pages/settings/company/documents/components/Upload.tsx
+++ b/src/pages/settings/company/documents/components/Upload.tsx
@@ -8,7 +8,6 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
-import toast from 'react-hot-toast';
 import { Card, Element } from '@invoiceninja/cards';
 import { useFormik } from 'formik';
 import { useState } from 'react';
@@ -16,6 +15,12 @@ import { useDropzone } from 'react-dropzone';
 import { Image } from 'react-feather';
 import { useTranslation } from 'react-i18next';
 import { request } from 'common/helpers/request';
+import { enterprisePlan } from 'common/guards/guards/enterprise-plan';
+import { isHosted } from 'common/helpers';
+import { Alert } from 'components/Alert';
+import { useCurrentUser } from 'common/hooks/useCurrentUser';
+import { Link } from '@invoiceninja/forms';
+import { toast } from 'common/helpers/toast/toast';
 
 interface Props {
   endpoint: string;
@@ -25,19 +30,22 @@ interface Props {
 
 export function Upload(props: Props) {
   const [t] = useTranslation();
+
+  const user = useCurrentUser();
+
   const [formData, setFormData] = useState(new FormData());
 
   const formik = useFormik({
     enableReinitialize: true,
     initialValues: {},
     onSubmit: () => {
-      const toastId = toast.loading(t('processing'));
+      toast.processing();
 
       request('POST', props.endpoint, formData, {
         headers: { 'Content-Type': 'multipart/form-data' },
       })
         .then(() => {
-          toast.success(t('uploaded_document'), { id: toastId });
+          toast.success('uploaded_document');
 
           setFormData(new FormData());
 
@@ -45,13 +53,13 @@ export function Upload(props: Props) {
         })
         .catch((error) => {
           console.error(error);
-
-          toast.error(t('error_title'), { id: toastId });
+          toast.error();
         });
     },
   });
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    disabled: !enterprisePlan() && isHosted(),
     onDrop: (acceptedFiles) => {
       formData.append('_method', 'PUT');
 
@@ -63,28 +71,27 @@ export function Upload(props: Props) {
     },
   });
 
+  const planWarning = (
+    <Alert className="mb-4" type="warning" disableClosing>
+      {t('documents_upgrade_plan')}
+
+      {user?.company_user && (
+        <Link
+          className="ml-10"
+          external
+          to={user.company_user.ninja_portal_url}
+        >
+          {t('plan_change')}
+        </Link>
+      )}
+    </Alert>
+  );
+
   if (props.widgetOnly) {
     return (
-      <div
-        {...getRootProps()}
-        className="flex flex-col md:flex-row md:items-center"
-      >
-        <div className="relative block w-full border-2 border-gray-300 border-dashed rounded-lg p-12 text-center hover:border-gray-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
-          <input {...getInputProps()} />
-          <Image className="mx-auto h-12 w-12 text-gray-400" />
-          <span className="mt-2 block text-sm font-medium text-gray-900">
-            {isDragActive
-              ? 'drop_your_files_here'
-              : t('dropzone_default_message')}
-          </span>
-        </div>
-      </div>
-    );
-  }
+      <>
+        {!enterprisePlan() && isHosted() && planWarning}
 
-  return (
-    <Card title={t('upload')}>
-      <Element leftSide={t('upload')}>
         <div
           {...getRootProps()}
           className="flex flex-col md:flex-row md:items-center"
@@ -99,7 +106,32 @@ export function Upload(props: Props) {
             </span>
           </div>
         </div>
-      </Element>
-    </Card>
+      </>
+    );
+  }
+
+  return (
+    <>
+      {!enterprisePlan() && isHosted() && planWarning}
+
+      <Card title={t('upload')}>
+        <Element leftSide={t('upload')}>
+          <div
+            {...getRootProps()}
+            className="flex flex-col md:flex-row md:items-center"
+          >
+            <div className="relative block w-full border-2 border-gray-300 border-dashed rounded-lg p-12 text-center hover:border-gray-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+              <input {...getInputProps()} />
+              <Image className="mx-auto h-12 w-12 text-gray-400" />
+              <span className="mt-2 block text-sm font-medium text-gray-900">
+                {isDragActive
+                  ? 'drop_your_files_here'
+                  : t('dropzone_default_message')}
+              </span>
+            </div>
+          </div>
+        </Element>
+      </Card>
+    </>
   );
 }


### PR DESCRIPTION
Here are two screenshots of the document tab when the user does not have permission to upload them:

![Screenshot 2022-12-25 at 18 43 39](https://user-images.githubusercontent.com/51542191/209477508-ce41a7b1-d3ef-4a37-b3ef-b7e599f7de27.png)

![Screenshot 2022-12-25 at 18 44 33](https://user-images.githubusercontent.com/51542191/209477515-09e058fd-b851-4e99-abe7-4bc3352afbd8.png)

@turbo124 The uploading area is disabled when the user plan is different from `Enterprise` and this includes only `HOSTED` users. Apart from these two screenshots, this warning message will be placed on all routes where we have this kind of upload. The upgrade plan link is set to `user.company_user.ninja_portal_url`. I used `upgrade_to_upload_images` translation keyword (Upgrade to the enterprise plan to upload images). IMO it might be better to change the images keywords to documents since we can actually upload any type of file, but let me know your thoughts.