### PR TITLE
[Feature] User details notification options

### DIFF
--- a/src/pages/settings/user/components/Notifications.tsx
+++ b/src/pages/settings/user/components/Notifications.tsx
@@ -78,6 +78,14 @@ export function Notifications() {
     { label: t('payment_success'), field: 'payment_success_all' },
     { label: t('payment_failure'), field: 'payment_failure_all' },
 
+    { label: t('purchase_order_created'), field: 'purchase_order_created_all' },
+    { label: t('purchase_order_sent'), field: 'purchase_order_sent_all' },
+    { label: t('purchase_order_viewed'), field: 'purchase_order_viewed_all' },
+    {
+      label: t('purchase_order_accepted'),
+      field: 'purchase_order_accepted_all',
+    },
+
     { label: t('quote_created'), field: 'quote_created_all' },
     { label: t('quote_sent'), field: 'quote_sent_all' },
     { label: t('quote_viewed'), field: 'quote_viewed_all' },

--- a/src/pages/settings/user/components/Notifications.tsx
+++ b/src/pages/settings/user/components/Notifications.tsx
@@ -8,6 +8,7 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
+import { trans } from 'common/helpers';
 import { injectInChangesWithData } from 'common/stores/slices/user';
 import { RootState } from 'common/stores/store';
 import { cloneDeep, set } from 'lodash';
@@ -71,7 +72,10 @@ export function Notifications() {
 
   const options: { label: string; field: string }[] = [
     { label: t('invoice_created'), field: 'invoice_created_all' },
-    { label: t('notification_invoice_sent'), field: 'invoice_sent_all' },
+    {
+      label: trans('invoice_sent', { count: '' }),
+      field: 'invoice_sent_all',
+    },
     { label: t('invoice_viewed'), field: 'invoice_viewed_all' },
     { label: t('invoice_late'), field: 'invoice_late_all' },
 

--- a/src/pages/settings/users/edit/components/Notifications.tsx
+++ b/src/pages/settings/users/edit/components/Notifications.tsx
@@ -30,6 +30,13 @@ export function Notifications(props: Props) {
     { id: 'invoice_late', label: 'invoice_late' },
     { id: 'payment_success', label: 'payment_success' },
     { id: 'payment_failure', label: 'payment_failure' },
+    { id: 'purchase_order_created', label: 'purchase_order_created' },
+    { id: 'purchase_order_sent', label: 'purchase_order_sent' },
+    { id: 'purchase_order_viewed', label: 'purchase_order_viewed' },
+    {
+      id: 'purchase_order_accepted',
+      label: 'purchase_order_accepted',
+    },
     { id: 'quote_created', label: 'quote_created' },
     { id: 'quote_sent', label: 'quote_sent' },
     { id: 'quote_viewed', label: 'quote_viewed' },


### PR DESCRIPTION
Here is the screenshot where we have added missing options for user details:

![Screenshot 2022-12-31 at 03 25 44](https://user-images.githubusercontent.com/51542191/210122430-d297d4d6-7ca4-4d31-85cb-34121ce4f3fb.png)

@turbo124 As you can notice on the second option we don't have a proper label, there we used the `notification_invoice_sent` keyword, to fix this label bug I replaced it with `invoice_sent`, but this one contains the `:count` parameter. Also, this one parameter has been replaced with '', but now our label is `invoice sent` instead of `Invoice sent`. If you agree with this type of translation implementation, just update the `invoice_sent` keyword.

Here is the screenshot with updated translation keyword:

![Screenshot 2022-12-31 at 03 38 28](https://user-images.githubusercontent.com/51542191/210122601-5e2ed5f1-7c9e-40f6-98e0-d6ff457389f5.png)