### PR TITLE
[Feature] Clone to purchase order

### DIFF
--- a/src/pages/purchase-orders/common/hooks.tsx
+++ b/src/pages/purchase-orders/common/hooks.tsx
@@ -25,11 +25,15 @@ import { ValidationBag } from 'common/interfaces/validation-bag';
 import { CopyToClipboard } from 'components/CopyToClipboard';
 import { customField } from 'components/CustomField';
 import { SelectOption } from 'components/datatables/Actions';
+import { DropdownElement } from 'components/dropdown/DropdownElement';
 import { EntityStatus } from 'components/EntityStatus';
+import { Action } from 'components/ResourceActions';
 import { StatusBadge } from 'components/StatusBadge';
+import { useAtom } from 'jotai';
 import { DataTableColumnsExtended } from 'pages/invoices/common/hooks/useInvoiceColumns';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
+import { purchaseOrderAtom } from './atoms';
 
 interface CreateProps {
   setErrors: (validationBag?: ValidationBag) => unknown;
@@ -329,4 +333,28 @@ export function usePurchaseOrderFilters() {
   ];
 
   return filters;
+}
+
+export function useActions() {
+  const [t] = useTranslation();
+
+  const navigate = useNavigate();
+
+  const [, setPurchaseOrder] = useAtom(purchaseOrderAtom);
+
+  const cloneToPurchaseOrder = (purchaseOrder: PurchaseOrder) => {
+    setPurchaseOrder({ ...purchaseOrder, number: '', documents: [] });
+
+    navigate('/purchase_orders/create');
+  };
+
+  const actions: Action<PurchaseOrder>[] = [
+    (purchaseOrder) => (
+      <DropdownElement onClick={() => cloneToPurchaseOrder(purchaseOrder)}>
+        {t('clone')}
+      </DropdownElement>
+    ),
+  ];
+
+  return actions;
 }

--- a/src/pages/purchase-orders/common/hooks.tsx
+++ b/src/pages/purchase-orders/common/hooks.tsx
@@ -161,7 +161,9 @@ export function usePurchaseOrderColumns() {
         label: t('expense'),
         format: (field, purchaseOrder) =>
           purchaseOrder.expense && (
-            <Link to={route('/expenses/:id', { id: purchaseOrder.expense.id })}>
+            <Link
+              to={route('/expenses/:id/edit', { id: purchaseOrder.expense.id })}
+            >
               {purchaseOrder.expense.number}
             </Link>
           ),

--- a/src/pages/purchase-orders/common/hooks.tsx
+++ b/src/pages/purchase-orders/common/hooks.tsx
@@ -27,11 +27,13 @@ import { customField } from 'components/CustomField';
 import { SelectOption } from 'components/datatables/Actions';
 import { DropdownElement } from 'components/dropdown/DropdownElement';
 import { EntityStatus } from 'components/EntityStatus';
+import { Icon } from 'components/icons/Icon';
 import { Action } from 'components/ResourceActions';
 import { StatusBadge } from 'components/StatusBadge';
 import { useAtom } from 'jotai';
 import { DataTableColumnsExtended } from 'pages/invoices/common/hooks/useInvoiceColumns';
 import { useTranslation } from 'react-i18next';
+import { MdControlPointDuplicate } from 'react-icons/md';
 import { useNavigate } from 'react-router-dom';
 import { purchaseOrderAtom } from './atoms';
 
@@ -352,7 +354,10 @@ export function useActions() {
 
   const actions: Action<PurchaseOrder>[] = [
     (purchaseOrder) => (
-      <DropdownElement onClick={() => cloneToPurchaseOrder(purchaseOrder)}>
+      <DropdownElement
+        onClick={() => cloneToPurchaseOrder(purchaseOrder)}
+        icon={<Icon element={MdControlPointDuplicate} />}
+      >
         {t('clone')}
       </DropdownElement>
     ),

--- a/src/pages/purchase-orders/create/Create.tsx
+++ b/src/pages/purchase-orders/create/Create.tsx
@@ -48,8 +48,6 @@ export function Create() {
     },
   ];
 
-  let mounted = false;
-
   const [purchaseOrder, setPurchaseOrder] = useAtom(purchaseOrderAtom);
 
   const { data } = useBlankPurchaseOrderQuery({
@@ -73,17 +71,9 @@ export function Create() {
 
       setPurchaseOrder(po);
     }
-  }, [data]);
 
-  useEffect(() => {
-    if (mounted) {
-      return () => {
-        setPurchaseOrder(undefined);
-      };
-    } else {
-      mounted = true;
-    }
-  }, []);
+    return () => setPurchaseOrder(undefined);
+  }, [data]);
 
   const [invoiceSum, setInvoiceSum] = useState<InvoiceSum>();
   const [errors, setErrors] = useState<ValidationBag>();

--- a/src/pages/purchase-orders/create/Create.tsx
+++ b/src/pages/purchase-orders/create/Create.tsx
@@ -48,6 +48,8 @@ export function Create() {
     },
   ];
 
+  let mounted = false;
+
   const [purchaseOrder, setPurchaseOrder] = useAtom(purchaseOrderAtom);
 
   const { data } = useBlankPurchaseOrderQuery({
@@ -55,7 +57,7 @@ export function Create() {
   });
 
   useEffect(() => {
-    if (typeof data !== 'undefined' && typeof purchaseOrder === 'undefined') {
+    if (data && !purchaseOrder) {
       const po = cloneDeep(data);
 
       if (typeof po.line_items === 'string') {
@@ -71,11 +73,17 @@ export function Create() {
 
       setPurchaseOrder(po);
     }
-
-    return () => {
-      setPurchaseOrder(undefined);
-    };
   }, [data]);
+
+  useEffect(() => {
+    if (mounted) {
+      return () => {
+        setPurchaseOrder(undefined);
+      };
+    } else {
+      mounted = true;
+    }
+  }, []);
 
   const [invoiceSum, setInvoiceSum] = useState<InvoiceSum>();
   const [errors, setErrors] = useState<ValidationBag>();
@@ -123,11 +131,13 @@ export function Create() {
           errorMessage={errors?.errors.vendor_id}
         />
 
-        <Details
-          purchaseOrder={purchaseOrder}
-          handleChange={handleChange}
-          errors={errors}
-        />
+        {purchaseOrder && (
+          <Details
+            purchaseOrder={purchaseOrder}
+            handleChange={handleChange}
+            errors={errors}
+          />
+        )}
 
         <div className="col-span-12">
           {purchaseOrder ? (
@@ -154,21 +164,23 @@ export function Create() {
           )}
         </div>
 
-        <Footer
-          purchaseOrder={purchaseOrder}
-          handleChange={handleChange}
-          errors={errors}
-        />
-
         {purchaseOrder && (
-          <InvoiceTotals
-            relationType="vendor_id"
-            resource={purchaseOrder}
-            invoiceSum={invoiceSum}
-            onChange={(property, value) =>
-              handleChange(property as keyof PurchaseOrder, value as string)
-            }
-          />
+          <>
+            <Footer
+              purchaseOrder={purchaseOrder}
+              handleChange={handleChange}
+              errors={errors}
+            />
+
+            <InvoiceTotals
+              relationType="vendor_id"
+              resource={purchaseOrder}
+              invoiceSum={invoiceSum}
+              onChange={(property, value) =>
+                handleChange(property as keyof PurchaseOrder, value as string)
+              }
+            />
+          </>
         )}
       </div>
 

--- a/src/pages/purchase-orders/edit/Edit.tsx
+++ b/src/pages/purchase-orders/edit/Edit.tsx
@@ -16,7 +16,6 @@ import { ValidationBag } from 'common/interfaces/validation-bag';
 import { Page } from 'components/Breadcrumbs';
 import { Default } from 'components/layouts/Default';
 import { Spinner } from 'components/Spinner';
-import { useAtom } from 'jotai';
 import { cloneDeep } from 'lodash';
 import { InvoicePreview } from 'pages/invoices/common/components/InvoicePreview';
 import { InvoiceTotals } from 'pages/invoices/common/components/InvoiceTotals';
@@ -26,7 +25,6 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { v4 } from 'uuid';
-import { purchaseOrderAtom } from '../common/atoms';
 import { usePurchaseOrderQuery } from '../common/queries';
 import { Actions } from './components/Actions';
 import { Details } from './components/Details';
@@ -53,7 +51,7 @@ export function Edit() {
     },
   ];
 
-  const [purchaseOrder, setPurchaseOrder] = useAtom(purchaseOrderAtom);
+  const [purchaseOrder, setPurchaseOrder] = useState<PurchaseOrder>();
 
   useEffect(() => {
     if (data) {

--- a/src/pages/purchase-orders/edit/Edit.tsx
+++ b/src/pages/purchase-orders/edit/Edit.tsx
@@ -120,11 +120,13 @@ export function Edit() {
           errorMessage={errors?.errors.vendor_id}
         />
 
-        <Details
-          purchaseOrder={purchaseOrder}
-          handleChange={handleChange}
-          errors={errors}
-        />
+        {purchaseOrder && (
+          <Details
+            purchaseOrder={purchaseOrder}
+            handleChange={handleChange}
+            errors={errors}
+          />
+        )}
 
         <div className="col-span-12">
           {purchaseOrder ? (
@@ -151,21 +153,23 @@ export function Edit() {
           )}
         </div>
 
-        <Footer
-          purchaseOrder={purchaseOrder}
-          handleChange={handleChange}
-          errors={errors}
-        />
-
         {purchaseOrder && (
-          <InvoiceTotals
-            relationType="vendor_id"
-            resource={purchaseOrder}
-            invoiceSum={invoiceSum}
-            onChange={(property, value) =>
-              handleChange(property as keyof PurchaseOrder, value as string)
-            }
-          />
+          <>
+            <Footer
+              purchaseOrder={purchaseOrder}
+              handleChange={handleChange}
+              errors={errors}
+            />
+
+            <InvoiceTotals
+              relationType="vendor_id"
+              resource={purchaseOrder}
+              invoiceSum={invoiceSum}
+              onChange={(property, value) =>
+                handleChange(property as keyof PurchaseOrder, value as string)
+              }
+            />
+          </>
         )}
       </div>
 

--- a/src/pages/purchase-orders/edit/components/Actions.tsx
+++ b/src/pages/purchase-orders/edit/components/Actions.tsx
@@ -127,7 +127,7 @@ export function useActions() {
         hideIf: po.expense_id.length <= 0,
       }),
       (po) => ({
-        label: t('clone_to_purchase_order'),
+        label: t('clone'),
         onClick: () => cloneToPurchaseOrder(po),
       }),
       (po) => ({

--- a/src/pages/purchase-orders/edit/components/Actions.tsx
+++ b/src/pages/purchase-orders/edit/components/Actions.tsx
@@ -16,9 +16,11 @@ import { toast } from 'common/helpers/toast/toast';
 import { PurchaseOrder } from 'common/interfaces/purchase-order';
 import { Dropdown } from 'components/dropdown/Dropdown';
 import { DropdownElement } from 'components/dropdown/DropdownElement';
+import { useAtom } from 'jotai';
 import { BulkAction } from 'pages/expenses/edit/hooks/useBulk';
 import { openClientPortal } from 'pages/invoices/common/helpers/open-client-portal';
 import { useDownloadPdf } from 'pages/invoices/common/hooks/useDownloadPdf';
+import { purchaseOrderAtom } from 'pages/purchase-orders/common/atoms';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from 'react-query';
 import { useNavigate } from 'react-router-dom';
@@ -30,11 +32,25 @@ export type Action = (po: PurchaseOrder) => {
 };
 
 export function useActions() {
-  const { t } = useTranslation();
+  const [t] = useTranslation();
 
   const navigate = useNavigate();
-  const downloadPdf = useDownloadPdf({ resource: 'purchase_order' });
+
   const queryClient = useQueryClient();
+
+  const downloadPdf = useDownloadPdf({ resource: 'purchase_order' });
+
+  const [, setPurchaseOrder] = useAtom(purchaseOrderAtom);
+
+  const cloneToPurchaseOrder = (purchaseOrder: PurchaseOrder) => {
+    setPurchaseOrder({
+      ...purchaseOrder,
+      number: '',
+      documents: [],
+    });
+
+    navigate('/purchase_orders/create');
+  };
 
   const invalidateCache = (id: string) => {
     queryClient.invalidateQueries(
@@ -112,8 +128,7 @@ export function useActions() {
       }),
       (po) => ({
         label: t('clone_to_purchase_order'),
-        onClick: () =>
-          navigate(route('/purchase_orders/:id/clone', { id: po.id })),
+        onClick: () => cloneToPurchaseOrder(po),
       }),
       (po) => ({
         label: t('vendor_portal'),

--- a/src/pages/purchase-orders/edit/components/Details.tsx
+++ b/src/pages/purchase-orders/edit/components/Details.tsx
@@ -14,9 +14,10 @@ import { PurchaseOrder } from 'common/interfaces/purchase-order';
 import { ValidationBag } from 'common/interfaces/validation-bag';
 import { Inline } from 'components/Inline';
 import { useTranslation } from 'react-i18next';
+import { date as formatDate } from 'common/helpers';
 
 export interface PurchaseOrderCardProps {
-  purchaseOrder?: PurchaseOrder;
+  purchaseOrder: PurchaseOrder;
   handleChange: <T extends keyof PurchaseOrder>(
     property: T,
     value: PurchaseOrder[T]
@@ -25,7 +26,8 @@ export interface PurchaseOrderCardProps {
 }
 
 export function Details(props: PurchaseOrderCardProps) {
-  const { t } = useTranslation();
+  const [t] = useTranslation();
+
   const { purchaseOrder, handleChange, errors } = props;
 
   return (
@@ -34,7 +36,7 @@ export function Details(props: PurchaseOrderCardProps) {
         <Element leftSide={t('purchase_order_date')}>
           <InputField
             type="date"
-            value={purchaseOrder?.date}
+            value={purchaseOrder.date}
             onValueChange={(date) => handleChange('date', date)}
             errorMessage={errors?.errors.date}
           />
@@ -43,7 +45,7 @@ export function Details(props: PurchaseOrderCardProps) {
         <Element leftSide={t('due_date')}>
           <InputField
             type="date"
-            value={purchaseOrder?.due_date}
+            value={purchaseOrder.due_date}
             onValueChange={(date) => handleChange('due_date', date)}
             errorMessage={errors?.errors.due_date}
           />
@@ -51,7 +53,7 @@ export function Details(props: PurchaseOrderCardProps) {
 
         <Element leftSide={t('partial')}>
           <InputField
-            value={purchaseOrder?.partial}
+            value={purchaseOrder.partial}
             onValueChange={(partial) =>
               handleChange('partial', parseFloat(partial) || 0)
             }
@@ -63,7 +65,10 @@ export function Details(props: PurchaseOrderCardProps) {
           <Element leftSide={t('partial_due_date')}>
             <InputField
               type="date"
-              value={purchaseOrder.partial_due_date}
+              value={formatDate(
+                purchaseOrder.partial_due_date.toString(),
+                'YYYY-MM-DD'
+              )}
               onValueChange={(date) => handleChange('partial_due_date', date)}
               errorMessage={errors?.errors.partial_due_date}
             />
@@ -74,7 +79,7 @@ export function Details(props: PurchaseOrderCardProps) {
       <Card className="col-span-12 xl:col-span-4 h-max">
         <Element leftSide={t('po_number')}>
           <InputField
-            value={purchaseOrder?.number}
+            value={purchaseOrder.number}
             onValueChange={(value) => handleChange('number', value)}
             errorMessage={errors?.errors.number}
           />
@@ -84,7 +89,7 @@ export function Details(props: PurchaseOrderCardProps) {
           <Inline>
             <div className="w-full lg:w-1/2">
               <InputField
-                value={purchaseOrder?.discount}
+                value={purchaseOrder.discount}
                 onValueChange={(value) =>
                   handleChange('discount', parseFloat(value) || 0)
                 }
@@ -94,7 +99,7 @@ export function Details(props: PurchaseOrderCardProps) {
 
             <div className="w-full lg:w-1/2">
               <SelectField
-                value={purchaseOrder?.is_amount_discount.toString()}
+                value={purchaseOrder.is_amount_discount.toString()}
                 onValueChange={(value) =>
                   handleChange('is_amount_discount', JSON.parse(value))
                 }

--- a/src/pages/purchase-orders/edit/components/Footer.tsx
+++ b/src/pages/purchase-orders/edit/components/Footer.tsx
@@ -26,12 +26,15 @@ import { useLocation, useParams } from 'react-router-dom';
 import { PurchaseOrderCardProps } from './Details';
 
 export function Footer(props: PurchaseOrderCardProps) {
-  const { t } = useTranslation();
+  const [t] = useTranslation();
+
   const { id } = useParams();
-  const { purchaseOrder, handleChange } = props;
+
+  const location = useLocation();
 
   const queryClient = useQueryClient();
-  const location = useLocation();
+
+  const { purchaseOrder, handleChange } = props;
 
   const tabs = [
     t('terms'),
@@ -51,28 +54,28 @@ export function Footer(props: PurchaseOrderCardProps) {
       <TabGroup tabs={tabs}>
         <div>
           <MarkdownEditor
-            value={purchaseOrder?.terms || ''}
+            value={purchaseOrder.terms || ''}
             onChange={(value) => handleChange('terms', value)}
           />
         </div>
 
         <div>
           <MarkdownEditor
-            value={purchaseOrder?.footer || ''}
+            value={purchaseOrder.footer || ''}
             onChange={(value) => handleChange('footer', value)}
           />
         </div>
 
         <div>
           <MarkdownEditor
-            value={purchaseOrder?.public_notes || ''}
+            value={purchaseOrder.public_notes || ''}
             onChange={(value) => handleChange('public_notes', value)}
           />
         </div>
 
         <div>
           <MarkdownEditor
-            value={purchaseOrder?.private_notes || ''}
+            value={purchaseOrder.private_notes || ''}
             onChange={(value) => handleChange('private_notes', value)}
           />
         </div>
@@ -82,7 +85,7 @@ export function Footer(props: PurchaseOrderCardProps) {
             <div className="col-span-12 lg:col-span-6 space-y-6">
               <UserSelector
                 inputLabel={t('User')}
-                value={purchaseOrder?.assigned_user_id}
+                value={purchaseOrder.assigned_user_id}
                 onChange={(user) => handleChange('assigned_user_id', user.id)}
               />
             </div>
@@ -90,7 +93,7 @@ export function Footer(props: PurchaseOrderCardProps) {
             <div className="col-span-12 lg:col-span-6 space-y-6">
               <ProjectSelector
                 inputLabel={t('project')}
-                value={purchaseOrder?.project_id}
+                value={purchaseOrder.project_id}
                 onChange={(project) => handleChange('project_id', project.id)}
               />
             </div>
@@ -98,7 +101,7 @@ export function Footer(props: PurchaseOrderCardProps) {
             <div className="col-span-12 lg:col-span-6 space-y-6">
               <ClientSelector
                 inputLabel={t('client')}
-                value={purchaseOrder?.client_id}
+                value={purchaseOrder.client_id}
                 onChange={(client) => handleChange('client_id', client.id)}
               />
             </div>
@@ -106,7 +109,7 @@ export function Footer(props: PurchaseOrderCardProps) {
             <div className="col-span-12 lg:col-span-6 space-y-6">
               <InputField
                 label={t('exchange_rate')}
-                value={purchaseOrder?.exchange_rate || 1.0}
+                value={purchaseOrder.exchange_rate || 1.0}
                 onValueChange={(value) =>
                   handleChange('exchange_rate', parseFloat(value) || 1.0)
                 }
@@ -116,7 +119,7 @@ export function Footer(props: PurchaseOrderCardProps) {
             <div className="col-span-12 lg:col-span-6 space-y-6">
               <DesignSelector
                 inputLabel={t('design')}
-                value={purchaseOrder?.design_id}
+                value={purchaseOrder.design_id}
                 onChange={(design) => handleChange('design_id', design.id)}
               />
             </div>
@@ -136,7 +139,7 @@ export function Footer(props: PurchaseOrderCardProps) {
             />
 
             <DocumentsTable
-              documents={purchaseOrder?.documents || []}
+              documents={purchaseOrder.documents || []}
               onDocumentDelete={onSuccess}
             />
           </div>

--- a/src/pages/purchase-orders/index/PurchaseOrders.tsx
+++ b/src/pages/purchase-orders/index/PurchaseOrders.tsx
@@ -17,6 +17,7 @@ import { useTranslation } from 'react-i18next';
 import {
   defaultColumns,
   purchaseOrderColumns,
+  useActions,
   usePurchaseOrderColumns,
   usePurchaseOrderFilters,
 } from '../common/hooks';
@@ -34,6 +35,8 @@ export function PurchaseOrders() {
 
   const filters = usePurchaseOrderFilters();
 
+  const actions = useActions();
+
   return (
     <Default title={documentTitle} breadcrumbs={pages}>
       <DataTable
@@ -43,6 +46,7 @@ export function PurchaseOrders() {
         linkToCreate="/purchase_orders/create"
         linkToEdit="/purchase_orders/:id/edit"
         columns={columns}
+        customActions={actions}
         customFilters={filters}
         customFilterQueryKey="client_status"
         customFilterPlaceholder="status"


### PR DESCRIPTION
Here is the screenshot of implemented solution for cloning purchase orders:

![Screenshot 2023-01-02 at 02 15 17](https://user-images.githubusercontent.com/51542191/210189644-4758ec96-0f40-4d16-ab69-b8eeaa7ed333.png)

@beganovich @turbo124 Actually, this action was implemented earlier (atom and logic were created) and not implemented in all places where it is needed. In addition to the implementation of this solution, I noticed some minor bugs and solved them. In Flutter, the purchase order table has several more clone options, for invoice, quote, credit, recurring invoice. This PR probably shouldn't be about adding those cloning options, but if you specifically want them, I can include them here. This task may possibly include other cloning options: https://invoiceninja.atlassian.net/browse/RU-478. Let me know your thoughts.