### PR TITLE
[Bugfix] Quote error status badge

### DIFF
--- a/src/pages/quotes/common/components/QuoteStatus.tsx
+++ b/src/pages/quotes/common/components/QuoteStatus.tsx
@@ -31,7 +31,8 @@ export function QuoteStatus(props: Props) {
 
   if (
     props.entity.status_id === QuoteStatusEnum.Sent &&
-    new Date(props.entity.date) < new Date()
+    new Date(props.entity.date) < new Date() &&
+    props.entity.due_date
   )
     return <Badge variant="red">{t('expired')}</Badge>;
 

--- a/src/pages/quotes/common/components/QuoteStatus.tsx
+++ b/src/pages/quotes/common/components/QuoteStatus.tsx
@@ -30,9 +30,9 @@ export function QuoteStatus(props: Props) {
     return <Badge variant="green">{t('converted')}</Badge>;
 
   if (
+    props.entity.due_date &&
     props.entity.status_id === QuoteStatusEnum.Sent &&
-    new Date(props.entity.date) < new Date() &&
-    props.entity.due_date
+    new Date(props.entity.date) < new Date()
   )
     return <Badge variant="red">{t('expired')}</Badge>;
 

--- a/src/pages/quotes/common/components/QuoteStatus.tsx
+++ b/src/pages/quotes/common/components/QuoteStatus.tsx
@@ -43,6 +43,6 @@ export function QuoteStatus(props: Props) {
     case QuoteStatusEnum.Approved:
       return <Badge variant="dark-blue">{t('approved')}</Badge>;
     default:
-      return <Badge variant="light-blue">{t('error')}</Badge>;
+      return <Badge variant="light-blue">{t('due_date')}</Badge>;
   }
 }

--- a/src/pages/quotes/common/components/QuoteStatus.tsx
+++ b/src/pages/quotes/common/components/QuoteStatus.tsx
@@ -29,13 +29,6 @@ export function QuoteStatus(props: Props) {
   if (props.entity.invoice_id)
     return <Badge variant="green">{t('converted')}</Badge>;
 
-  if (
-    props.entity.due_date &&
-    props.entity.status_id === QuoteStatusEnum.Sent &&
-    new Date(props.entity.date) < new Date()
-  )
-    return <Badge variant="red">{t('expired')}</Badge>;
-
   switch (props.entity.status_id) {
     case QuoteStatusEnum.Draft:
       return <Badge variant="generic">{t('draft')}</Badge>;
@@ -43,7 +36,9 @@ export function QuoteStatus(props: Props) {
       return <Badge variant="light-blue">{t('sent')}</Badge>;
     case QuoteStatusEnum.Approved:
       return <Badge variant="dark-blue">{t('approved')}</Badge>;
+    case QuoteStatusEnum.Expired:
+      return <Badge variant="red">{t('expired')}</Badge>;
     default:
-      return <Badge variant="light-blue">{t('due_date')}</Badge>;
+      return <Badge variant="light-blue">{t('error')}</Badge>;
   }
 }


### PR DESCRIPTION
@turbo124 @beganovich Me and David were talking on Slack today about the `Sent` and `Expired` status code and we found a solution that the -1 status code is correct for the `Expired` Quote status.