### PR TITLE
[Bugfix] Confirm email modal showing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,7 @@ export function App() {
 
   const location = useLocation();
 
-  const [isEmailVerified, setIsEmailVerified] = useState(false);
+  const [isEmailVerified, setIsEmailVerified] = useState<boolean>(true);
 
   const resolveLanguage = useResolveLanguage();
 
@@ -67,7 +67,7 @@ export function App() {
   }, [darkMode, resolvedLanguage]);
 
   useEffect(() => {
-    if (user) {
+    if (user && Object.keys(user).length) {
       setIsEmailVerified(Boolean(user.email_verified_at));
     }
   }, [user]);
@@ -76,8 +76,8 @@ export function App() {
     <div className="App">
       <VerifyModal
         visible={
-          Boolean(user) &&
           !location.pathname.startsWith('/login') &&
+          !location.pathname.startsWith('/register') &&
           !isEmailVerified &&
           isHosted()
         }


### PR DESCRIPTION
@beganovich @turbo124 This PR only slightly changes the modal displaying logic. Currently in production, we show the modal by default, but if the user has verified their email, we hide it. On this PR we just reversed the logic to avoid the current behavior to avoid unnecessary rendering of this modal.