### PR TITLE
[Bugfix] Purchase order line items text

### DIFF
--- a/src/pages/invoices/common/components/ProductsTable.tsx
+++ b/src/pages/invoices/common/components/ProductsTable.tsx
@@ -147,7 +147,7 @@ export function ProductsTable(props: Props) {
 
               {!resource?.[relationType] ? (
                 <Tr>
-                  <Td colSpan={100}>{t('no_client_selected')}.</Td>
+                  <Td colSpan={100}>{t('please_select_a_vendor')}.</Td>
                 </Tr>
               ) : (
                 <Fragment />

--- a/src/pages/invoices/common/components/ProductsTable.tsx
+++ b/src/pages/invoices/common/components/ProductsTable.tsx
@@ -147,7 +147,12 @@ export function ProductsTable(props: Props) {
 
               {!resource?.[relationType] ? (
                 <Tr>
-                  <Td colSpan={100}>{t('please_select_a_vendor')}.</Td>
+                  <Td colSpan={100}>
+                    {props.relationType === 'vendor_id'
+                      ? t('please_select_a_vendor')
+                      : t('please_select_a_client')}
+                    .
+                  </Td>
                 </Tr>
               ) : (
                 <Fragment />


### PR DESCRIPTION
Here is a screenshot of the updated UI for the product table when creating a purchase order:

![Screenshot 2023-01-07 at 19 08 44](https://user-images.githubusercontent.com/51542191/211164609-f13bcc75-9365-422a-99d5-feab43a5e379.png)