### PR TITLE
[Cleanup] Danger zone CTA

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -88,27 +88,29 @@ export function Modal(props: Props) {
                 }
               )}
             >
-              <div className="flex justify-between items-start">
-                <div>
+              <div className="flex flex-col justify-between items-start">
+                <div className="flex w-full justify-between">
                   <Dialog.Title
                     as="h3"
                     className="text-lg leading-6 font-medium text-gray-900"
                   >
                     {props.title}
                   </Dialog.Title>
-                  <div className="mt-2">
-                    {props.text && (
-                      <p className="text-sm text-gray-500">{props.text}</p>
-                    )}
-                  </div>
+
+                  {!props.disableClosing && (
+                    <X
+                      className="cursor-pointer"
+                      onClick={() => props.onClose(false)}
+                      fontSize={22}
+                    />
+                  )}
                 </div>
 
-                {!props.disableClosing && (
-                  <X
-                    className="cursor-pointer"
-                    onClick={() => props.onClose(false)}
-                  />
-                )}
+                <div className="mt-2">
+                  {props.text && (
+                    <p className="text-sm text-gray-500">{props.text}</p>
+                  )}
+                </div>
               </div>
 
               {props.children && (

--- a/src/pages/settings/account-management/component/DangerZone.tsx
+++ b/src/pages/settings/account-management/component/DangerZone.tsx
@@ -109,8 +109,14 @@ export function DangerZone() {
       </Modal>
 
       <Modal
-        title={t('cancel_account')}
-        text={t('cancel_account_message')}
+        title={
+          state?.api.length > 1 ? t('delete_company') : t('cancel_account')
+        }
+        text={
+          state?.api.length > 1
+            ? `${t('delete_company_message')} (${company?.settings.name})`
+            : t('cancel_account_message')
+        }
         visible={isDeleteModalOpen}
         onClose={setIsDeleteModalOpen}
       >
@@ -158,10 +164,7 @@ export function DangerZone() {
         </ClickableElement>
 
         <span className="flex pl-6 mb-2">
-          <i className="text-xs font-semibold">
-            * This action will permanently delete data from the currently
-            selected company ({company?.settings.name}).
-          </i>
+          <i className="text-xs font-semibold">* {t('purge_data_message')}</i>
         </span>
 
         <ClickableElement
@@ -175,8 +178,8 @@ export function DangerZone() {
           <i className="text-xs font-semibold">
             *{' '}
             {state?.api.length > 1
-              ? `This action will permanently delete the currently selected company (${company?.settings.name}).`
-              : 'This action will permanently delete your Invoice Ninja account.'}
+              ? `${t('delete_company_message')} (${company?.settings.name})`
+              : t('cancel_account_message')}
           </i>
         </span>
       </Card>

--- a/src/pages/settings/account-management/component/DangerZone.tsx
+++ b/src/pages/settings/account-management/component/DangerZone.tsx
@@ -14,11 +14,11 @@ import { request } from 'common/helpers/request';
 import { useCurrentCompany } from 'common/hooks/useCurrentCompany';
 import { Modal } from 'components/Modal';
 import { ChangeEvent, useState } from 'react';
-import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { route } from 'common/helpers/route';
 import { useSelector } from 'react-redux';
 import { RootState } from 'common/stores/store';
+import { toast } from 'common/helpers/toast/toast';
 
 export function DangerZone() {
   const [t] = useTranslation();
@@ -36,7 +36,7 @@ export function DangerZone() {
   const [purgeInputField, setPurgeInputField] = useState('');
 
   const purge = () => {
-    const toastId = toast.loading(t('processing'));
+    toast.processing();
 
     request(
       'POST',
@@ -46,17 +46,17 @@ export function DangerZone() {
       { cancellation_message: feedback },
       { headers: { 'X-Api-Password': password } }
     )
-      .then(() => toast.success(t('purge_successful'), { id: toastId }))
+      .then(() => toast.success('purge_successful'))
       .catch((error) => {
         console.error(error);
 
-        toast.error(t('error_title'), { id: toastId });
+        toast.error();
       })
       .finally(() => setIsPurgeModalOpen(false));
   };
 
   const destroy = () => {
-    const toastId = toast.loading(t('processing'));
+    toast.processing();
 
     request(
       'DELETE',
@@ -70,7 +70,7 @@ export function DangerZone() {
       .catch((error) => {
         console.error(error);
 
-        toast.error(t('error_title'), { id: toastId });
+        toast.error();
       });
   };
 
@@ -155,7 +155,7 @@ export function DangerZone() {
         )}
       </Modal>
 
-      <Card title="Danger Zone">
+      <Card title={t('danger_zone')}>
         <ClickableElement
           onClick={() => setIsPurgeModalOpen(true)}
           className="text-red-500 hover:text-red-600"
@@ -163,25 +163,12 @@ export function DangerZone() {
           {t('purge_data')}
         </ClickableElement>
 
-        <span className="flex pl-6 mb-2">
-          <i className="text-xs font-semibold">* {t('purge_data_message')}</i>
-        </span>
-
         <ClickableElement
           onClick={() => setIsDeleteModalOpen(true)}
           className="text-red-500 hover:text-red-600"
         >
           {state?.api.length > 1 ? t('delete_company') : t('cancel_account')}
         </ClickableElement>
-
-        <span className="flex pl-6 mb-2">
-          <i className="text-xs font-semibold">
-            *{' '}
-            {state?.api.length > 1
-              ? `${t('delete_company_message')} (${company?.settings.name})`
-              : t('cancel_account_message')}
-          </i>
-        </span>
       </Card>
     </>
   );

--- a/src/pages/settings/account-management/component/DangerZone.tsx
+++ b/src/pages/settings/account-management/component/DangerZone.tsx
@@ -25,7 +25,7 @@ export function DangerZone() {
 
   const company = useCurrentCompany();
 
-  const state = useSelector((state: RootState) => state.companyUsers);
+  const companyUsers = useSelector((state: RootState) => state.companyUsers);
 
   const [password, setPassword] = useState('');
   const [feedback, setFeedback] = useState('');
@@ -110,10 +110,12 @@ export function DangerZone() {
 
       <Modal
         title={
-          state?.api.length > 1 ? t('delete_company') : t('cancel_account')
+          companyUsers?.api.length > 1
+            ? t('delete_company')
+            : t('cancel_account')
         }
         text={
-          state?.api.length > 1
+          companyUsers?.api.length > 1
             ? `${t('delete_company_message')} (${company?.settings.name})`
             : t('cancel_account_message')
         }
@@ -167,7 +169,9 @@ export function DangerZone() {
           onClick={() => setIsDeleteModalOpen(true)}
           className="text-red-500 hover:text-red-600"
         >
-          {state?.api.length > 1 ? t('delete_company') : t('cancel_account')}
+          {companyUsers?.api.length > 1
+            ? t('delete_company')
+            : t('cancel_account')}
         </ClickableElement>
       </Card>
     </>

--- a/src/pages/settings/account-management/component/DangerZone.tsx
+++ b/src/pages/settings/account-management/component/DangerZone.tsx
@@ -17,11 +17,15 @@ import { ChangeEvent, useState } from 'react';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { route } from 'common/helpers/route';
+import { useSelector } from 'react-redux';
+import { RootState } from 'common/stores/store';
 
 export function DangerZone() {
   const [t] = useTranslation();
 
   const company = useCurrentCompany();
+
+  const state = useSelector((state: RootState) => state.companyUsers);
 
   const [password, setPassword] = useState('');
   const [feedback, setFeedback] = useState('');
@@ -153,12 +157,28 @@ export function DangerZone() {
           {t('purge_data')}
         </ClickableElement>
 
+        <span className="flex pl-6 mb-2">
+          <i className="text-xs font-semibold">
+            * This action will permanently delete data from the currently
+            selected company ({company?.settings.name}).
+          </i>
+        </span>
+
         <ClickableElement
           onClick={() => setIsDeleteModalOpen(true)}
           className="text-red-500 hover:text-red-600"
         >
-          {t('cancel_account')}
+          {state?.api.length > 1 ? t('delete_company') : t('cancel_account')}
         </ClickableElement>
+
+        <span className="flex pl-6 mb-2">
+          <i className="text-xs font-semibold">
+            *{' '}
+            {state?.api.length > 1
+              ? `This action will permanently delete the currently selected company (${company?.settings.name}).`
+              : 'This action will permanently delete your Invoice Ninja account.'}
+          </i>
+        </span>
       </Card>
     </>
   );


### PR DESCRIPTION
Here is a screenshot of the danger zone when we only have one company created on the account:

![Screenshot 2023-01-08 at 01 23 33](https://user-images.githubusercontent.com/51542191/211175175-ebc44b92-dac5-42a3-8fc3-c3e3c75f57d6.png)

Here is a screenshot of the danger zone when we have multiple companies created on the account:

![Screenshot 2023-01-08 at 01 25 07](https://user-images.githubusercontent.com/51542191/211175179-6a5a633b-521a-4678-bbdf-ebf8e3267855.png)

@turbo124 Just one thing to mention as my suggestion. We already have the same help text on the modal after clicking one of those actions, it might be better to avoid one place to put the help text. IMO, it's good to have right below the action buttons or just on the modal. The text messages on modals are also adjusted. Here are screenshots of the modal:

![Screenshot 2023-01-08 at 01 42 45](https://user-images.githubusercontent.com/51542191/211175540-b248ebd0-c00f-455d-8c6c-d2b9f208a71e.png)

![Screenshot 2023-01-08 at 01 41 56](https://user-images.githubusercontent.com/51542191/211175545-e1f5bd15-627c-428b-8e46-d6f5499053d3.png)

![Screenshot 2023-01-08 at 01 41 18](https://user-images.githubusercontent.com/51542191/211175552-349b7717-f3e8-4f24-8067-6fa01ca85a77.png)