### PR TITLE
[Bugfix] Company activity toggle button

### DIFF
--- a/src/pages/settings/account-management/component/Overview.tsx
+++ b/src/pages/settings/account-management/component/Overview.tsx
@@ -36,9 +36,9 @@ export function Overview() {
         leftSideHelp={t('activate_company_help')}
       >
         <Toggle
-          checked={company?.is_disabled}
+          checked={!company?.is_disabled}
           onChange={(value: boolean) =>
-            handleToggleChange('is_disabled', value)
+            handleToggleChange('is_disabled', !value)
           }
         />
       </Element>


### PR DESCRIPTION
@turbo124 The logic is reversed for the Activate Company toggle button, if the company property `is_disabled` == false it will turn the switch on, but if `is_disabled` == true it will turn it off.