### PR TITLE
[Feature] Task table - client overview page

### DIFF
--- a/src/pages/clients/index.ts
+++ b/src/pages/clients/index.ts
@@ -18,6 +18,6 @@ export * from './show/pages/Payments';
 export * from './show/pages/RecurringInvoices';
 export * from './show/pages/Credits';
 export * from './show/pages/Projects';
-export * from './show/pages/Tasks';
+export { Tasks } from './show/pages/Tasks';
 export * from './show/pages/Expenses';
 export { RecurringExpenses } from './show/pages/RecurringExpenses';

--- a/src/pages/clients/show/pages/Tasks.tsx
+++ b/src/pages/clients/show/pages/Tasks.tsx
@@ -25,7 +25,9 @@ export function Tasks() {
   return (
     <DataTable
       resource="task"
-      endpoint={route('/api/v1/tasks?client_id=:id', { id })}
+      endpoint={route('/api/v1/tasks?include=status,client&client_id=:id', {
+        id,
+      })}
       columns={columns}
       customFilters={filters}
       customFilterQueryKey="client_status"

--- a/src/pages/clients/show/pages/Tasks.tsx
+++ b/src/pages/clients/show/pages/Tasks.tsx
@@ -8,6 +8,33 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
+import { route } from 'common/helpers/route';
+import { DataTable } from 'components/DataTable';
+import { useTaskColumns, useTaskFilters } from 'pages/tasks/common/hooks';
+import { useParams } from 'react-router-dom';
+
+export const dataTableStaleTime = 50;
+
 export function Tasks() {
-  return <div>Tasks</div>;
+  const { id } = useParams();
+
+  const columns = useTaskColumns();
+
+  const filters = useTaskFilters();
+
+  return (
+    <DataTable
+      resource="task"
+      endpoint={route('/api/v1/tasks?client_id=:id', { id })}
+      columns={columns}
+      customFilters={filters}
+      customFilterQueryKey="client_status"
+      customFilterPlaceholder="status"
+      withResourcefulActions
+      bulkRoute="/api/v1/tasks/bulk"
+      linkToCreate={route('/tasks/create?client=:id', { id })}
+      linkToEdit="/tasks/:id/edit"
+      staleTime={dataTableStaleTime}
+    />
+  );
 }

--- a/src/pages/tasks/create/Create.tsx
+++ b/src/pages/tasks/create/Create.tsx
@@ -20,7 +20,7 @@ import { Default } from 'components/layouts/Default';
 import { useAtom } from 'jotai';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { taskAtom } from '../common/atoms';
 import { TaskDetails } from '../common/components/TaskDetails';
 import { TaskTable } from '../common/components/TaskTable';
@@ -30,6 +30,8 @@ export function Create() {
   const [t] = useTranslation();
 
   const { documentTitle } = useTitle('new_task');
+
+  const [searchParams] = useSearchParams();
 
   const { data } = useBlankTaskQuery();
 
@@ -59,6 +61,16 @@ export function Create() {
             ...prevState,
             status_id:
               taskStatuses.data.length > 0 ? taskStatuses.data[0].id : '',
+          }
+      );
+    }
+
+    if (searchParams.has('client')) {
+      setTask(
+        (prevState) =>
+          prevState && {
+            ...prevState,
+            client_id: searchParams.get('client') as string,
           }
       );
     }


### PR DESCRIPTION
Here is the screenshot of implemented solution for task table on the client overview page:

<img width="1260" alt="Screenshot 2023-01-15 at 15 13 53" src="https://user-images.githubusercontent.com/51542191/212545866-dadb4697-f6b4-46d7-b755-1713c1eda2b6.png">

@turbo124 A `status` filter is also implemented here, I thought if we can offer why not add to this `Task` table. Also, some other tables don't have the status filter implemented on the Client Overview page, but that's a minor change to add. Let me know your thoughts.