### PR TITLE
[Cleanup] Statics query enabling 

### DIFF
--- a/src/common/queries/statics.ts
+++ b/src/common/queries/statics.ts
@@ -12,17 +12,17 @@ import { endpoint } from 'common/helpers';
 import { request } from 'common/helpers/request';
 import { Statics } from 'common/interfaces/statics';
 import { useQuery } from 'react-query';
-import { useLocation } from 'react-router-dom';
 
 export function useStaticsQuery() {
-  const location = useLocation();
-
   return useQuery<Statics>(
     '/api/v1/statics',
     () =>
       request('GET', endpoint('/api/v1/statics')).then(
         (response) => response.data
       ),
-    { enabled: !location.pathname.startsWith('/login'), staleTime: Infinity }
+    {
+      enabled: Boolean(localStorage.getItem('X-NINJA-TOKEN')),
+      staleTime: Infinity,
+    }
   );
 }


### PR DESCRIPTION
@turbo124 As I can see, `X-NINJA-TOKEN` is stored in local storage after login to the app. When the user logs out it will be removed. So I used it as a condition to enable the `/api/v1/static query`. If we have that query in local storage, we will enable this query, if we don't have it, it will be disabled.