### PR TITLE
[Feature] View delivery note action

### DIFF
--- a/src/pages/invoices/edit/components/Actions.tsx
+++ b/src/pages/invoices/edit/components/Actions.tsx
@@ -129,7 +129,7 @@ export function useActions() {
         to={route('/invoices/:id/pdf?delivery_note=true', { id: invoice.id })}
         icon={<Icon element={MdPictureAsPdf} />}
       >
-        ${t('view_delivery_note')} (${t('pdf')})
+        {t('view_delivery_note')} ({t('pdf')})
       </DropdownElement>
     ),
     (invoice: Invoice) => (

--- a/src/pages/invoices/edit/components/Actions.tsx
+++ b/src/pages/invoices/edit/components/Actions.tsx
@@ -126,6 +126,14 @@ export function useActions() {
     ),
     (invoice: Invoice) => (
       <DropdownElement
+        to={route('/invoices/:id/pdf?delivery_note=true', { id: invoice.id })}
+        icon={<Icon element={MdPictureAsPdf} />}
+      >
+        {`${t('view_delivery_note')} (${t('pdf')})`}
+      </DropdownElement>
+    ),
+    (invoice: Invoice) => (
+      <DropdownElement
         onClick={() => downloadPdf(invoice)}
         icon={<Icon element={MdDownload} />}
       >

--- a/src/pages/invoices/edit/components/Actions.tsx
+++ b/src/pages/invoices/edit/components/Actions.tsx
@@ -129,7 +129,7 @@ export function useActions() {
         to={route('/invoices/:id/pdf?delivery_note=true', { id: invoice.id })}
         icon={<Icon element={MdPictureAsPdf} />}
       >
-        {`${t('view_delivery_note')} (${t('pdf')})`}
+        ${t('view_delivery_note')} (${t('pdf')})
       </DropdownElement>
     ),
     (invoice: Invoice) => (

--- a/src/pages/invoices/pdf/Pdf.tsx
+++ b/src/pages/invoices/pdf/Pdf.tsx
@@ -15,7 +15,7 @@ import { Default } from 'components/layouts/Default';
 import { Spinner } from 'components/Spinner';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
 import { InvoiceViewer } from '../common/components/InvoiceViewer';
 import { useGeneratePdfUrl } from '../common/hooks/useGeneratePdfUrl';
 import { Actions } from './components/Actions';
@@ -29,11 +29,19 @@ export function Pdf() {
   const [blobUrl, setBlobUrl] = useState('');
   const [invoice, setInvoice] = useState<Invoice>();
 
+  const [deliveryNote, setDeliveryNote] = useState<boolean>(false);
+
+  const [searchParams] = useSearchParams();
+
   const url = useGeneratePdfUrl({ resourceType: 'invoice' });
 
   useEffect(() => {
     if (data) {
       setInvoice(data);
+
+      if (searchParams.has('delivery_note')) {
+        setDeliveryNote(true);
+      }
     }
   }, [data]);
 
@@ -54,7 +62,12 @@ export function Pdf() {
           <Actions
             invoice={invoice}
             blobUrl={blobUrl}
-            onHandleDeliveryNote={(value, isDeliveryNote) =>
+            deliveryNote={deliveryNote}
+            setDeliveryNote={setDeliveryNote}
+            onHandleDeliveryNote={(
+              value,
+              isDeliveryNote = deliveryNote || false
+            ) =>
               isDeliveryNote
                 ? setPdfUrl(value)
                 : setPdfUrl(url(invoice as Invoice))

--- a/src/pages/invoices/pdf/Pdf.tsx
+++ b/src/pages/invoices/pdf/Pdf.tsx
@@ -64,10 +64,7 @@ export function Pdf() {
             blobUrl={blobUrl}
             deliveryNote={deliveryNote}
             setDeliveryNote={setDeliveryNote}
-            onHandleDeliveryNote={(
-              value,
-              isDeliveryNote = deliveryNote || false
-            ) =>
+            onHandleDeliveryNote={(value, isDeliveryNote = deliveryNote) =>
               isDeliveryNote
                 ? setPdfUrl(value)
                 : setPdfUrl(url(invoice as Invoice))

--- a/src/pages/invoices/pdf/components/Actions.tsx
+++ b/src/pages/invoices/pdf/components/Actions.tsx
@@ -16,12 +16,15 @@ import { DropdownElement } from 'components/dropdown/DropdownElement';
 import Toggle from 'components/forms/Toggle';
 import { Icon } from 'components/icons/Icon';
 import { useDownloadPdf } from 'pages/invoices/common/hooks/useDownloadPdf';
+import { Dispatch, SetStateAction, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MdDownload, MdSend } from 'react-icons/md';
 import { useParams } from 'react-router-dom';
 
 interface Props {
   blobUrl: string;
+  deliveryNote: boolean;
+  setDeliveryNote: Dispatch<SetStateAction<boolean>>;
   onHandleDeliveryNote: (url: string, isDeliveryNote: boolean) => unknown;
   invoice: Invoice;
 }
@@ -31,7 +34,9 @@ export function Actions(props: Props) {
   const { id } = useParams();
   const downloadPdf = useDownloadPdf({ resource: 'invoice' });
 
-  const handleDeliveryNoteChange = (value: boolean) =>
+  const handleDeliveryNoteChange = (value: boolean) => {
+    props.setDeliveryNote(value);
+
     value
       ? props.onHandleDeliveryNote(
           endpoint('/api/v1/invoices/:id/delivery_note?per_page=999999', {
@@ -40,12 +45,18 @@ export function Actions(props: Props) {
           true
         )
       : props.onHandleDeliveryNote(props.blobUrl, false);
+  };
+
+  useEffect(() => {
+    handleDeliveryNoteChange(props.deliveryNote);
+  }, [props.deliveryNote]);
 
   return (
     <>
       <span className="inline-flex items-center">
         <Toggle
           label={t('delivery_note')}
+          checked={props.deliveryNote}
           onChange={handleDeliveryNoteChange}
         />
       </span>

--- a/src/pages/invoices/pdf/components/Actions.tsx
+++ b/src/pages/invoices/pdf/components/Actions.tsx
@@ -49,7 +49,7 @@ export function Actions(props: Props) {
 
   useEffect(() => {
     handleDeliveryNoteChange(props.deliveryNote);
-  }, [props.deliveryNote]);
+  }, []);
 
   return (
     <>

--- a/src/pages/invoices/pdf/components/Actions.tsx
+++ b/src/pages/invoices/pdf/components/Actions.tsx
@@ -31,24 +31,34 @@ interface Props {
 
 export function Actions(props: Props) {
   const [t] = useTranslation();
+
   const { id } = useParams();
+
   const downloadPdf = useDownloadPdf({ resource: 'invoice' });
 
+  const {
+    deliveryNote,
+    setDeliveryNote,
+    blobUrl,
+    invoice,
+    onHandleDeliveryNote,
+  } = props;
+
   const handleDeliveryNoteChange = (value: boolean) => {
-    props.setDeliveryNote(value);
+    setDeliveryNote(value);
 
     value
-      ? props.onHandleDeliveryNote(
+      ? onHandleDeliveryNote(
           endpoint('/api/v1/invoices/:id/delivery_note?per_page=999999', {
             id,
           }),
           true
         )
-      : props.onHandleDeliveryNote(props.blobUrl, false);
+      : onHandleDeliveryNote(blobUrl, false);
   };
 
   useEffect(() => {
-    handleDeliveryNoteChange(props.deliveryNote);
+    handleDeliveryNoteChange(deliveryNote);
   }, []);
 
   return (
@@ -56,7 +66,7 @@ export function Actions(props: Props) {
       <span className="inline-flex items-center">
         <Toggle
           label={t('delivery_note')}
-          checked={props.deliveryNote}
+          checked={deliveryNote}
           onChange={handleDeliveryNoteChange}
         />
       </span>
@@ -70,7 +80,7 @@ export function Actions(props: Props) {
         </DropdownElement>
 
         <DropdownElement
-          onClick={() => downloadPdf(props.invoice)}
+          onClick={() => downloadPdf(invoice)}
           icon={<Icon element={MdDownload} />}
         >
           {t('download')}


### PR DESCRIPTION
Here is the screenshot of implemented view delivery action for invoice:

![Screenshot 2023-01-15 at 23 04 15](https://user-images.githubusercontent.com/51542191/212570025-d0942876-943c-45a5-9182-a25fe2274177.png)

@turbo124 @beganovich The action is performed as easily as possible. For me the best way to do this was something like creating an entity from the client overview page, with search parameters, so in this case the URL would look like `http://localhost:3000/#/invoices/M7e5yXYe2v/pdf?delivery_note=true`. Everything after that is handled in code. I've included two keywords in the dropdown menu for this action: `view_delivery_note` and `pdf`. So the action would be like this `View Delivery Note (PDF)`, because it's also in PDF as a regular `view_pdf` action. I hope you agree with me. I can not find the `view_delivery_note` keyword in the translation files so please just add it.

The same action we have from the table as well.