### PR TITLE
[Cleanup] Missing fields in total section

### DIFF
--- a/src/common/helpers/invoices/invoice-sum.ts
+++ b/src/common/helpers/invoices/invoice-sum.ts
@@ -16,8 +16,14 @@ import { NumberFormatter } from '../number-formatter';
 import { RecurringInvoice } from 'common/interfaces/recurring-invoice';
 import { PurchaseOrder } from 'common/interfaces/purchase-order';
 
+export interface TaxItem {
+  key?: string;
+  name: string;
+  total: number;
+}
+
 export class InvoiceSum {
-  protected taxMap = collect();
+  public taxMap = collect<TaxItem>();
   protected totalTaxMap: Record<string, unknown>[] = [];
 
   public declare invoiceItems: InvoiceItemSum;
@@ -176,24 +182,25 @@ export class InvoiceSum {
 
     this.taxMap = collect();
 
-    const keys = this.invoiceItems.taxCollection.pluck('key').unique();
-    const values = this.invoiceItems.taxCollection;
+    let taxCollection = collect<TaxItem>();
+    taxCollection = this.invoiceItems.taxCollection.pluck('items');
+
+    const keys = taxCollection.pluck('key').unique();
 
     keys.map((key) => {
-      const taxName = values
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        .filter((value) => value[key as string] == key)
-        .pluck('tax_name')
+      const taxName = taxCollection
+        .filter((item) => item.key === key)
+        .pluck('name')
         .first();
 
-      const totalLineTax = values
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        .filter((value) => value[key as string] === key)
+      const totalLineTax = taxCollection
+        .filter((item) => item.key === key)
         .sum('total');
 
-      this.taxMap.push({ name: taxName, total: totalLineTax });
+      this.taxMap.push({
+        name: taxName as string,
+        total: totalLineTax as number,
+      });
 
       this.totalTaxes += this.invoiceItems.totalTaxes;
     });

--- a/src/common/helpers/invoices/invoice-sum.ts
+++ b/src/common/helpers/invoices/invoice-sum.ts
@@ -23,7 +23,7 @@ export interface TaxItem {
 }
 
 export class InvoiceSum {
-  public taxMap = collect<TaxItem>();
+  protected taxMap = collect<TaxItem>();
   protected totalTaxMap: Record<string, unknown>[] = [];
 
   public declare invoiceItems: InvoiceItemSum;
@@ -52,6 +52,10 @@ export class InvoiceSum {
       .calculatePartial();
 
     return this;
+  }
+
+  public getTaxMap() {
+    return this.taxMap;
   }
 
   protected calculateLineItems() {

--- a/src/common/helpers/invoices/invoice-sum.ts
+++ b/src/common/helpers/invoices/invoice-sum.ts
@@ -201,9 +201,9 @@ export class InvoiceSum {
         name: taxName as string,
         total: totalLineTax as number,
       });
-
-      this.totalTaxes += this.invoiceItems.totalTaxes;
     });
+
+    this.totalTaxes += this.invoiceItems.totalTaxes;
 
     return this;
   }

--- a/src/pages/invoices/common/hooks/useResolveTotalVariable.tsx
+++ b/src/pages/invoices/common/hooks/useResolveTotalVariable.tsx
@@ -87,6 +87,7 @@ export function useResolveTotalVariable(props: Props) {
         </Element>
       );
     }
+
     if (variable == '$line_taxes' && invoiceSum) {
       return (
         <Element leftSide={resolveTranslation(variable, '$')}>
@@ -99,6 +100,35 @@ export function useResolveTotalVariable(props: Props) {
       return (
         <Element leftSide={resolveTranslation(variable, '$')}>
           {formatMoney(invoiceSum.total)}
+        </Element>
+      );
+    }
+
+    if (variable == '$paid_to_date' && invoiceSum) {
+      return (
+        <Element leftSide={resolveTranslation(variable, '$')}>
+          {formatMoney(invoiceSum.invoice.paid_to_date)}
+        </Element>
+      );
+    }
+
+    if (variable == '$balance' && invoiceSum) {
+      return (
+        <Element leftSide={resolveTranslation(variable, '$')}>
+          {formatMoney(invoiceSum.invoice.balance)}
+        </Element>
+      );
+    }
+
+    if (variable == '$taxes' && invoiceSum) {
+      return (
+        <Element leftSide={`${resolveTranslation(variable, '$')}:`}>
+          {invoiceSum?.taxMap.map((item, index) => (
+            <div key={index} className="flex space-x-6">
+              <span>{item.name}</span>
+              <span>{formatMoney(item.total)}</span>
+            </div>
+          ))}
         </Element>
       );
     }

--- a/src/pages/invoices/common/hooks/useResolveTotalVariable.tsx
+++ b/src/pages/invoices/common/hooks/useResolveTotalVariable.tsx
@@ -123,7 +123,7 @@ export function useResolveTotalVariable(props: Props) {
     if (variable == '$taxes' && invoiceSum) {
       return (
         <Element leftSide={`${resolveTranslation(variable, '$')}:`}>
-          {invoiceSum?.taxMap.map((item, index) => (
+          {invoiceSum?.getTaxMap().map((item, index) => (
             <div key={index} className="flex space-x-6">
               <span>{item.name}</span>
               <span>{formatMoney(item.total)}</span>

--- a/src/pages/invoices/common/hooks/useTotalVariables.ts
+++ b/src/pages/invoices/common/hooks/useTotalVariables.ts
@@ -56,6 +56,9 @@ export function useTotalVariables() {
     }
 
     variables.push('$total');
+    variables.push('$paid_to_date');
+    variables.push('$balance');
+    variables.push('$taxes');
 
     setColumns(variables);
   }, [company]);

--- a/tests/unit/helpers/invoice-sum.test.ts
+++ b/tests/unit/helpers/invoice-sum.test.ts
@@ -28,8 +28,8 @@ describe('InvoiceSum test invoice calculation', () => {
   it('Line Item Calc', () => {
     const invoiceSum = new InvoiceSum(invoice, USD).build();
 
-    expect(invoiceSum.invoice.amount).toEqual(3723);
-    expect(invoiceSum.invoice.balance).toEqual(3723);
+    expect(invoiceSum.invoice.amount).toEqual(3963.9);
+    expect(invoiceSum.invoice.balance).toEqual(3963.9);
   });
 
   it('Single line item', () => {

--- a/tests/unit/helpers/invoice-sum.test.ts
+++ b/tests/unit/helpers/invoice-sum.test.ts
@@ -28,8 +28,8 @@ describe('InvoiceSum test invoice calculation', () => {
   it('Line Item Calc', () => {
     const invoiceSum = new InvoiceSum(invoice, USD).build();
 
-    expect(invoiceSum.invoice.amount).toEqual(3963.9);
-    expect(invoiceSum.invoice.balance).toEqual(3963.9);
+    expect(invoiceSum.invoice.amount).toEqual(3723);
+    expect(invoiceSum.invoice.balance).toEqual(3723);
   });
 
   it('Single line item', () => {


### PR DESCRIPTION
Here is the screenshot of implemented solution for additonal fields in the total section:

![Screenshot 2023-01-17 at 22 31 32](https://user-images.githubusercontent.com/51542191/213017011-b103bf7c-72ba-4f1a-9b2f-23da4f8cc4d8.png)

@turbo124 I was a bit confused about what this task was about. But I hope I understood correctly what we need to finish here https://invoiceninja.atlassian.net/browse/RU-451. Totals section has been updated with new fields you mentioned in the Jira's ticket. Let me know your thoughts.