### PR TITLE
[Cleanup] Company name displaying in dropdown

### DIFF
--- a/src/components/CompanySwitcher.tsx
+++ b/src/components/CompanySwitcher.tsx
@@ -149,7 +149,8 @@ export function CompanySwitcher() {
                     <DropdownElement onClick={() => switchCompany(index)}>
                       <div className="flex items-center space-x-3">
                         <span>
-                          {record.company.settings.name || t('new_company')}
+                          {record.company.settings.name ||
+                            t('untitled_company')}
                         </span>
 
                         {state.currentIndex === index && <Check size={18} />}


### PR DESCRIPTION
Here is the screenshot of how it looks when we do not have any name set for specific company:

![Screenshot 2023-01-18 at 18 54 49](https://user-images.githubusercontent.com/51542191/213258459-87831705-899d-45d0-80b3-b2ba20ad3646.png)

@turbo124 You mentioned in the ticket that maybe we can use `company.settings.name`, but I'm not sure that's possible and that's good logic. Here we only have a list of all available companies and that company has no name set now we set `untitled_company`. If I set `company.settings.name` we will get what we have in the settings of the currently selected company, regardless of whether other companies may not have that name. I hope that you agree with me.

Before opening dropdown the logic is to display `untitled_company` if there is no entered name:

![Screenshot 2023-01-18 at 19 01 36](https://user-images.githubusercontent.com/51542191/213259206-c93e5372-58b9-4002-a827-8e0e3f59f9ce.png)