### PR TITLE
[Bugfix] Settings responsiveness

### DIFF
--- a/src/components/layouts/Default.tsx
+++ b/src/components/layouts/Default.tsx
@@ -366,7 +366,7 @@ export function Default(props: Props) {
               </div>
             )}
 
-            <div className="p-4 md:p-8 dark:text-gray-100">
+            <div className="p-4 md:py-8 xl:p-8 dark:text-gray-100">
               {props.children}
             </div>
           </main>

--- a/src/components/layouts/Settings.tsx
+++ b/src/components/layouts/Settings.tsx
@@ -163,7 +163,7 @@ export function Settings(props: Props) {
       disableSaveButton={props.disableSaveButton}
     >
       <div className="grid grid-cols-12 lg:gap-10">
-        <div className="col-span-12 md:col-span-4 lg:col-span-3">
+        <div className="col-span-12 lg:col-span-3">
           <a className="flex items-center py-4 px-3 text-xs uppercase font-medium text-gray-600">
             <span className="truncate">{t('basic_settings')}</span>
           </a>
@@ -266,7 +266,7 @@ export function Settings(props: Props) {
           </nav>
         </div>
 
-        <div className="col-span-12 md:col-span-8 lg:col-start-4 space-y-6 mt-5">
+        <div className="col-span-12 lg:col-start-4 space-y-6 mt-5">
           {props.breadcrumbs && <Breadcrumbs pages={props.breadcrumbs} />}
 
           {errors && <ValidationAlert errors={errors} />}

--- a/src/components/layouts/Settings.tsx
+++ b/src/components/layouts/Settings.tsx
@@ -12,7 +12,7 @@ import { Breadcrumbs, Page } from 'components/Breadcrumbs';
 import { useAtom } from 'jotai';
 import { ReactNode, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { classNames } from '../../common/helpers';
 import { SelectField } from '../forms';
 import { Default } from './Default';
@@ -41,6 +41,8 @@ export function Settings(props: Props) {
   const [t] = useTranslation();
 
   const location = useLocation();
+
+  const navigate = useNavigate();
 
   const [errors, setErrors] = useAtom(companySettingsErrorsAtom);
 
@@ -168,19 +170,14 @@ export function Settings(props: Props) {
             <span className="truncate">{t('basic_settings')}</span>
           </a>
 
-          <SelectField className="lg:hidden">
+          <SelectField
+            className="lg:hidden"
+            value={location.pathname}
+            onValueChange={(value) => navigate(value)}
+            withBlank
+          >
             {basic.map((item) => (
-              <option
-                key={item.name}
-                value={item.href}
-                className={classNames(
-                  item.current
-                    ? 'bg-gray-200 text-gray-900'
-                    : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900',
-                  'flex items-center px-3 py-2 text-sm font-medium rounded'
-                )}
-                aria-current={item.current ? 'page' : undefined}
-              >
+              <option key={item.name} value={item.href}>
                 {item.name}
               </option>
             ))}
@@ -208,19 +205,14 @@ export function Settings(props: Props) {
             <span className="truncate">{t('advanced_settings')}</span>
           </a>
 
-          <SelectField className="lg:hidden">
+          <SelectField
+            className="lg:hidden"
+            value={location.pathname}
+            onValueChange={(value) => navigate(value)}
+            withBlank
+          >
             {advanced.map((item) => (
-              <option
-                key={item.name}
-                value={item.href}
-                className={classNames(
-                  item.current
-                    ? 'bg-gray-200 text-gray-900'
-                    : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900',
-                  'flex items-center px-3 py-2 text-sm font-medium rounded'
-                )}
-                aria-current={item.current ? 'page' : undefined}
-              >
+              <option key={item.name} value={item.href}>
                 {item.name}
               </option>
             ))}


### PR DESCRIPTION
Here are screenshots of the Settings page on different screen sizes:

Lg:

![Screenshot 2023-01-18 at 19 23 10](https://user-images.githubusercontent.com/51542191/213264202-5eca2146-a5a7-47b2-affd-f4e175f5009e.png)

Md:

![Screenshot 2023-01-18 at 19 23 22](https://user-images.githubusercontent.com/51542191/213264240-f4f55514-c867-4a26-ac4a-d9a24d0426e1.png)

@turbo124 In my opinion, this is the clearest solution for our case. If we want everything to fit on the md screen we will have to get smaller text and other things and it won't look good. Let me know how this looks for you now.