### PR TITLE
[Bugfix] Marking invoice sent success message

### DIFF
--- a/src/pages/invoices/edit/hooks/useMarkSent.ts
+++ b/src/pages/invoices/edit/hooks/useMarkSent.ts
@@ -11,17 +11,15 @@
 import { endpoint } from 'common/helpers';
 import { request } from 'common/helpers/request';
 import { Invoice } from 'common/interfaces/invoice';
-import toast from 'react-hot-toast';
-import { useTranslation } from 'react-i18next';
 import { useQueryClient } from 'react-query';
 import { route } from 'common/helpers/route';
+import { toast } from 'common/helpers/toast/toast';
 
 export function useMarkSent() {
-  const [t] = useTranslation();
   const queryClient = useQueryClient();
 
   return (invoice: Invoice) => {
-    const toastId = toast.loading(t('processing'));
+    toast.processing();
 
     request(
       'PUT',
@@ -29,7 +27,7 @@ export function useMarkSent() {
       invoice
     )
       .then(() => {
-        toast.success(t('notification_invoice_sent'), { id: toastId });
+        toast.success('marked_invoice_as_sent');
 
         queryClient.invalidateQueries('/api/v1/invoices');
 
@@ -38,7 +36,7 @@ export function useMarkSent() {
         );
       })
       .catch((error) => {
-        toast.error(t('error_title'), { id: toastId });
+        toast.error();
 
         console.error(error);
       });


### PR DESCRIPTION
@turbo124 We had the `notification_invoice_sent` keyword when we marked the invoice as sent, I didn't find a similar keyword for your recommendation on the Jira ticket (:invoice marked sent...). I search everything with the word :invoice, but there is no good keyword for our purpose. But I found `marked_invoice_as_sent` which I believe gives us exactly what we need, message: `Successfully marked invoice as sent`.