### PR TITLE
[Bugfix] Invoice sent keyword when create user

### DIFF
--- a/src/pages/settings/users/edit/components/Notifications.tsx
+++ b/src/pages/settings/users/edit/components/Notifications.tsx
@@ -25,7 +25,7 @@ export function Notifications(props: Props) {
 
   const notifications = [
     { id: 'invoice_created', label: 'invoice_created' },
-    { id: 'invoice_sent', label: 'notification_invoice_sent' },
+    { id: 'invoice_sent', label: 'invoice_sent_notification_label' },
     { id: 'invoice_viewed', label: 'invoice_viewed' },
     { id: 'invoice_late', label: 'invoice_late' },
     { id: 'payment_success', label: 'payment_success' },


### PR DESCRIPTION
@turbo124 Changed `notification_invoice_sent` keyword to `invoice_sent_notification_label` when creating User.