### PR TITLE
[Bugfix] Recurring expense query include (vendor and client)

### DIFF
--- a/src/pages/clients/show/pages/RecurringExpenses.tsx
+++ b/src/pages/clients/show/pages/RecurringExpenses.tsx
@@ -23,7 +23,10 @@ export function RecurringExpenses() {
   return (
     <DataTable
       resource="recurring_expense"
-      endpoint={route('/api/v1/recurring_expenses?client_id=:id', { id })}
+      endpoint={route(
+        '/api/v1/recurring_expenses?include=client,vendor&client_id=:id',
+        { id }
+      )}
       columns={columns}
       withResourcefulActions
       bulkRoute="/api/v1/recurring_expenses/bulk"


### PR DESCRIPTION
@turbo124 On the Client overview page, in the query for Recurring expense table, the objects Vendor and Client are also included.