### PR TITLE
[Bugfix] Clients query caching - Recurring expense pages

### DIFF
--- a/src/pages/recurring-expenses/components/Details.tsx
+++ b/src/pages/recurring-expenses/components/Details.tsx
@@ -78,6 +78,7 @@ export function Details(props: Props) {
             onClearButtonClick={() => handleChange('client_id', '')}
             onChange={(client) => handleChange('client_id', client.id)}
             errorMessage={errors?.errors.client_id}
+            staleTime={Infinity}
           />
         </Element>
       )}


### PR DESCRIPTION
@turbo124 @beganovich As with `Expenses`, the query from the `ClientSelector` component is cached on the Create/Edit `Recurring Expenses` pages.