### PR TITLE
[Cleanup] Product notes - adjusting

### DIFF
--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,0 +1,83 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import classNames from 'classnames';
+import { ReactElement, useEffect, useRef, useState } from 'react';
+
+interface Props {
+  children: ReactElement;
+  message: string;
+  className?: string;
+  truncate?: boolean;
+  size?: 'small' | 'regular' | 'large';
+}
+
+export function Tooltip(props: Props) {
+  const parentChildrenElement = useRef<HTMLDivElement>(null);
+
+  const [messageWidth, setMessageWidth] = useState<number>(0);
+
+  const [includeLeading, setIncludeLeading] = useState<boolean>(false);
+
+  useEffect(() => {
+    const parentChildrenElementWidth =
+      parentChildrenElement?.current?.offsetWidth;
+
+    const hoverElement = parentChildrenElement?.current
+      ?.children[0] as HTMLElement;
+
+    if (hoverElement && parentChildrenElementWidth) {
+      if (hoverElement.offsetWidth > parentChildrenElementWidth) {
+        setMessageWidth(parentChildrenElementWidth + 10);
+        setIncludeLeading(true);
+      } else {
+        setMessageWidth(hoverElement.offsetWidth + 10);
+      }
+    }
+  }, [parentChildrenElement, props.message]);
+
+  return (
+    <div
+      className={classNames(`group ${props.className}`, {
+        'max-w-sm': props.size === undefined || props.size === 'small',
+        'max-w-md': props.size === 'regular',
+        'max-w-xl': props.size === 'large',
+      })}
+    >
+      <div
+        ref={parentChildrenElement}
+        className={classNames('cursor-pointer', {
+          'truncate w-full': props.truncate,
+        })}
+      >
+        {props.children}
+      </div>
+
+      <div className="flex absolute z-50">
+        <div className="absolute bottom-0 flex-col items-center hidden mb-6 group-hover:flex">
+          <span
+            className={classNames(
+              'relative p-2 text-xs text-center text-white rounded-md bg-gray-500 whitespace-normal',
+              {
+                'leading-1': includeLeading,
+                'leading-none': !includeLeading,
+              }
+            )}
+            style={{ width: messageWidth }}
+          >
+            {props.message}
+          </span>
+
+          <div className="w-3 h-3 -mt-2 rotate-45 opacity-90 bg-gray-500"></div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/products/common/hooks.tsx
+++ b/src/pages/products/common/hooks.tsx
@@ -38,6 +38,7 @@ import { productAtom } from './atoms';
 import { bulk } from 'common/queries/products';
 import { useQueryClient } from 'react-query';
 import { Divider } from 'components/cards/Divider';
+import { Tooltip } from 'components/Tooltip';
 
 export const productColumns = [
   'product_key',
@@ -103,6 +104,13 @@ export function useProductColumns() {
       column: 'description',
       id: 'notes',
       label: t('notes'),
+      format: (value) => {
+        return (
+          <Tooltip size="regular" truncate message={value as string}>
+            <span>{value}</span>
+          </Tooltip>
+        );
+      },
     },
     {
       column: 'price',


### PR DESCRIPTION
Here are three screenshots of implemented solution for `Tooltip` and truncated text for `Notes` column on `Products` table:

![Screenshot 2023-01-22 at 04 16 55](https://user-images.githubusercontent.com/51542191/213899147-18cccc30-0c84-4017-ae1d-7517ba2ef8c3.png)

![Screenshot 2023-01-22 at 04 15 09](https://user-images.githubusercontent.com/51542191/213899150-dcfdbe50-f416-4165-b8d1-048444dee955.png)

![Screenshot 2023-01-22 at 04 00 06](https://user-images.githubusercontent.com/51542191/213899158-75072ac7-2606-4880-90d3-e27cc938765e.png)

@beganovich @turbo124 The `Tooltip` will be displayed on truncated text.