### PR TITLE
[Cleanup] Translation keywords changing

### DIFF
--- a/src/pages/invoices/edit/components/Actions.tsx
+++ b/src/pages/invoices/edit/components/Actions.tsx
@@ -129,7 +129,7 @@ export function useActions() {
         to={route('/invoices/:id/pdf?delivery_note=true', { id: invoice.id })}
         icon={<Icon element={MdPictureAsPdf} />}
       >
-        {t('view_delivery_note')} ({t('pdf')})
+        {t('delivery_note')} ({t('pdf')})
       </DropdownElement>
     ),
     (invoice: Invoice) => (


### PR DESCRIPTION
@turbo124 @beganovich Only one mistyped translation keyword of `view_delivery_note` to `delivery_note` has been changed here.

I additionally noticed that we don't have the `clone_to_recurring_invoice` keyword in the translation files. This is used for `Quotes` actions. Do we need to add this one or change to something else?