### PR TITLE
[Bugfix] Expense category creation stickying

### DIFF
--- a/src/components/expense-categories/ExpenseCategorySelector.tsx
+++ b/src/components/expense-categories/ExpenseCategorySelector.tsx
@@ -20,6 +20,7 @@ export interface ExpenseCategorySelectorProps
   initiallyVisible?: boolean;
   setVisible?: Dispatch<SetStateAction<boolean>>;
   setSelectedIds?: Dispatch<SetStateAction<string[]>>;
+  staleTime?: number;
 }
 
 export function ExpenseCategorySelector(props: ExpenseCategorySelectorProps) {
@@ -33,11 +34,14 @@ export function ExpenseCategorySelector(props: ExpenseCategorySelectorProps) {
         visible={props.initiallyVisible || isModalOpen}
         setVisible={props.setVisible || setIsModalOpen}
         setSelectedIds={props.setSelectedIds}
+        onCreatedCategory={(category: ExpenseCategory) =>
+          props.onChange(category)
+        }
       />
 
       {!props.setSelectedIds && (
         <DebouncedCombobox
-          {...props}
+          inputLabel={props.inputLabel}
           value="id"
           endpoint="/api/v1/expense_categories"
           label="name"
@@ -45,8 +49,15 @@ export function ExpenseCategorySelector(props: ExpenseCategorySelectorProps) {
           onChange={(category: Record<ExpenseCategory>) =>
             category.resource && props.onChange(category.resource)
           }
+          disabled={props.readonly}
+          clearButton={props.clearButton}
+          onClearButtonClick={props.onClearButtonClick}
+          queryAdditional
+          initiallyVisible={props.initiallyVisible}
           actionLabel={t('new_expense_category')}
           onActionClick={() => setIsModalOpen(true)}
+          sortBy="name|asc"
+          staleTime={props.staleTime}
         />
       )}
     </>

--- a/src/pages/settings/expense-categories/components/CreateExpenseCategoryForm.tsx
+++ b/src/pages/settings/expense-categories/components/CreateExpenseCategoryForm.tsx
@@ -32,6 +32,7 @@ interface ExpenseCategoryInput {
 interface Props {
   setVisible?: Dispatch<SetStateAction<boolean>>;
   setSelectedIds?: Dispatch<SetStateAction<string[]>>;
+  onCreatedCategory?: (category: ExpenseCategory) => unknown;
 }
 
 export function CreateExpenseCategoryForm(props: Props) {
@@ -84,6 +85,10 @@ export function CreateExpenseCategoryForm(props: Props) {
 
           if (props.setSelectedIds) {
             props.setSelectedIds([response.data.data.id]);
+          }
+
+          if (props.onCreatedCategory) {
+            props.onCreatedCategory(response.data.data);
           }
 
           if (props.setVisible) {

--- a/src/pages/settings/expense-categories/components/CreateExpenseCategoryModal.tsx
+++ b/src/pages/settings/expense-categories/components/CreateExpenseCategoryModal.tsx
@@ -8,6 +8,7 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
+import { ExpenseCategory } from 'common/interfaces/expense-category';
 import { Modal } from 'components/Modal';
 import { Dispatch, SetStateAction } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -17,6 +18,7 @@ interface Props {
   visible: boolean;
   setVisible: Dispatch<SetStateAction<boolean>>;
   setSelectedIds?: Dispatch<SetStateAction<string[]>>;
+  onCreatedCategory: (category: ExpenseCategory) => unknown;
 }
 
 export function CreateExpenseCategoryModal(props: Props) {
@@ -31,6 +33,7 @@ export function CreateExpenseCategoryModal(props: Props) {
       <CreateExpenseCategoryForm
         setSelectedIds={props.setSelectedIds}
         setVisible={props.setVisible}
+        onCreatedCategory={props.onCreatedCategory}
       />
     </Modal>
   );


### PR DESCRIPTION
@turbo124 @beganovich The bug that was fixed on this PR was selecting the `Expense category` in the combobox after creating it via modal. Let me know your thoughts.