### PR TITLE
[Cleanup] Download PDF - File name

### DIFF
--- a/src/pages/invoices/common/hooks/useDownloadPdf.ts
+++ b/src/pages/invoices/common/hooks/useDownloadPdf.ts
@@ -37,9 +37,12 @@ export function useDownloadPdf(props: Props) {
             const blob = new Blob([response.data], { type: 'application/pdf' });
             const url = URL.createObjectURL(blob);
 
+            const [, filename] =
+              response.headers['content-disposition'].split('filename=');
+
             const link = document.createElement('a');
 
-            link.download = `${props.resource}.pdf`;
+            link.download = filename;
             link.href = url;
             link.target = '_blank';
 


### PR DESCRIPTION
@beganovich @turbo124 The file name for the downloaded PDF file has been changed to the file name we get through the headers instead of just using the entity name.