### PR TITLE
[Cleanup] Contant mailto link changed to CopyToClipboard

### DIFF
--- a/src/pages/clients/show/components/Contacts.tsx
+++ b/src/pages/clients/show/components/Contacts.tsx
@@ -15,6 +15,7 @@ import { InfoCard } from 'components/InfoCard';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import React from 'react';
+import { CopyToClipboard } from 'components/CopyToClipboard';
 
 export function Contacts() {
   const [t] = useTranslation();
@@ -40,7 +41,7 @@ export function Contacts() {
                         {contact.first_name} {contact.last_name}
                       </p>
 
-                      <a href={`mailto:${contact.email}`}>{contact.email}</a>
+                      <CopyToClipboard text={contact.email} />
                     </div>
                   )
                 )}


### PR DESCRIPTION
@turbo124 @beganovich Tbh, the title of this ticket confused me a bit. I hope the point is to change mailto:[emailValue] to copy to the clipboard with email as the value. https://invoiceninja.atlassian.net/browse/RU-524 Let me know what you think.