### PR TITLE
[Cleanup] Products Create/Edit page - Quantity label

### DIFF
--- a/src/pages/products/common/components/ProductForm.tsx
+++ b/src/pages/products/common/components/ProductForm.tsx
@@ -81,7 +81,7 @@ export function ProductForm(props: Props) {
       )}
 
       {company?.enable_product_quantity && (
-        <Element leftSide={t('quantity')}>
+        <Element leftSide={t('default_quantity')}>
           <InputField
             value={product.quantity}
             onValueChange={(value) => handleChange('quantity', value)}


### PR DESCRIPTION
Here is the screenshot of changed quantity label to default_quantity for Product pages:

<img width="1258" alt="Screenshot 2023-01-23 at 14 43 25" src="https://user-images.githubusercontent.com/51542191/214054931-35d821ba-6fdc-4fcd-b58e-ed9bd99e10f1.png">