### PR TITLE
[Cleanup] Bank account selector

### DIFF
--- a/src/common/interfaces/bank-accounts.ts
+++ b/src/common/interfaces/bank-accounts.ts
@@ -10,30 +10,20 @@
 
 export interface BankAccount {
   id: string;
-  bank_account_name: string;
-  bank_account_type: string;
-  balance: number;
-}
-
-export interface BankAccountInput {
-  bank_account_name: string;
-}
-
-export interface BankAccountDetails {
-  id: string;
   archived_at: number;
   auto_sync: boolean;
-  bank_account_name: string;
-  bank_account_type: string;
   balance: number;
   bank_account_id: number;
+  bank_account_name: string;
+  bank_account_number: string;
   bank_account_status: string;
+  bank_account_type: string;
   created_at: number;
   currency: string;
   disabled_upstream: boolean;
   from_date: string;
   is_deleted: boolean;
-  nickname: string;
+  nickname?: string;
   provider_id: number;
   provider_name: string;
   updated_at: number;

--- a/src/common/interfaces/bank-accounts.ts
+++ b/src/common/interfaces/bank-accounts.ts
@@ -23,7 +23,7 @@ export interface BankAccount {
   disabled_upstream: boolean;
   from_date: string;
   is_deleted: boolean;
-  nickname?: string;
+  nickname: string;
   provider_id: number;
   provider_name: string;
   updated_at: number;

--- a/src/pages/settings/bank-accounts/common/queries.ts
+++ b/src/pages/settings/bank-accounts/common/queries.ts
@@ -12,10 +12,7 @@ import { endpoint } from 'common/helpers';
 import { request } from 'common/helpers/request';
 import { useQuery } from 'react-query';
 import { GenericSingleResourceResponse } from 'common/interfaces/generic-api-response';
-import {
-  BankAccount,
-  BankAccountDetails,
-} from 'common/interfaces/bank-accounts';
+import { BankAccount } from 'common/interfaces/bank-accounts';
 import { route } from 'common/helpers/route';
 
 interface BankAccountParams {
@@ -24,14 +21,14 @@ interface BankAccountParams {
 }
 
 export function useBankAccountQuery(params: BankAccountParams) {
-  return useQuery<BankAccountDetails>(
+  return useQuery<BankAccount>(
     route('/api/v1/bank_integrations/:id', { id: params.id }),
     () =>
       request(
         'GET',
         endpoint('/api/v1/bank_integrations/:id', { id: params.id })
       ).then(
-        (response: GenericSingleResourceResponse<BankAccountDetails>) =>
+        (response: GenericSingleResourceResponse<BankAccount>) =>
           response.data.data
       ),
     { enabled: params.enabled ?? true, staleTime: Infinity }
@@ -44,6 +41,18 @@ export function useBankAccountsQuery() {
     () =>
       request('GET', endpoint('/api/v1/bank_integrations')).then(
         (response: GenericSingleResourceResponse<BankAccount[]>) =>
+          response.data.data
+      ),
+    { staleTime: Infinity }
+  );
+}
+
+export function useBlankBankAccountQuery() {
+  return useQuery<BankAccount>(
+    '/api/v1/bank_integrations/create',
+    () =>
+      request('GET', endpoint('/api/v1/bank_integrations/create')).then(
+        (response: GenericSingleResourceResponse<BankAccount>) =>
           response.data.data
       ),
     { staleTime: Infinity }

--- a/src/pages/settings/bank-accounts/components/Details.tsx
+++ b/src/pages/settings/bank-accounts/components/Details.tsx
@@ -10,12 +10,12 @@
 
 import { useFormatMoney } from 'common/hooks/money/useFormatMoney';
 import { useCurrentCompany } from 'common/hooks/useCurrentCompany';
-import { BankAccountDetails } from 'common/interfaces/bank-accounts';
+import { BankAccount } from 'common/interfaces/bank-accounts';
 import { useTranslation } from 'react-i18next';
 import { Card, Element } from '../../../../components/cards';
 
 interface Props {
-  accountDetails?: BankAccountDetails;
+  accountDetails?: BankAccount;
 }
 
 export function Details(props: Props) {

--- a/src/pages/settings/bank-accounts/create/Create.tsx
+++ b/src/pages/settings/bank-accounts/create/Create.tsx
@@ -11,12 +11,12 @@
 import { Card, Element } from '@invoiceninja/cards';
 import { InputField } from '@invoiceninja/forms';
 import { useTitle } from 'common/hooks/useTitle';
-import { BankAccountInput } from 'common/interfaces/bank-accounts';
+import { BankAccount } from 'common/interfaces/bank-accounts';
 import { ValidationBag } from 'common/interfaces/validation-bag';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
 import { Settings } from '../../../../components/layouts/Settings';
+import { useBlankBankAccountQuery } from '../common/queries';
 import { useHandleCreate } from './hooks/useHandleCreate';
 
 export function Create() {
@@ -24,7 +24,7 @@ export function Create() {
 
   useTitle('new_bank_account');
 
-  const navigate = useNavigate();
+  const { data } = useBlankBankAccountQuery();
 
   const pages = [
     { name: t('settings'), href: '/settings' },
@@ -36,7 +36,7 @@ export function Create() {
 
   const [errors, setErrors] = useState<ValidationBag>();
 
-  const [bankAccount, setBankAccount] = useState<BankAccountInput>();
+  const [bankAccount, setBankAccount] = useState<BankAccount>();
 
   const handleSave = useHandleCreate(
     bankAccount,
@@ -46,24 +46,25 @@ export function Create() {
   );
 
   const handleChange = (
-    property: keyof BankAccountInput,
-    value: BankAccountInput[keyof BankAccountInput]
+    property: keyof BankAccount,
+    value: BankAccount[keyof BankAccount]
   ) => {
-    setBankAccount((prevState) => ({ ...prevState, [property]: value }));
+    setBankAccount(
+      (prevState) => prevState && { ...prevState, [property]: value }
+    );
   };
 
-  const handleCancel = () => {
-    if (!isFormBusy) {
-      navigate('/settings/bank_accounts');
+  useEffect(() => {
+    if (data) {
+      setBankAccount(data);
     }
-  };
+  }, [data]);
 
   return (
     <Settings
-      title={t('create_bank_account')}
+      title={t('new_bank_account')}
       breadcrumbs={pages}
       docsLink="docs/basic-settings/#create_bank_account"
-      onCancelClick={handleCancel}
       onSaveClick={handleSave}
     >
       <Card onFormSubmit={handleSave} title={t('new_bank_account')}>

--- a/src/pages/settings/bank-accounts/create/hooks/useHandleCreate.ts
+++ b/src/pages/settings/bank-accounts/create/hooks/useHandleCreate.ts
@@ -37,8 +37,6 @@ export function useHandleCreate(
       setErrors(undefined);
       setIsFormBusy(true);
 
-      delete bankAccount['nickname'];
-
       request('POST', endpoint('/api/v1/bank_integrations'), bankAccount)
         .then((response: GenericSingleResourceResponse<BankAccount>) => {
           toast.success('created_bank_account');

--- a/src/pages/settings/bank-accounts/show/BankAccount.tsx
+++ b/src/pages/settings/bank-accounts/show/BankAccount.tsx
@@ -10,7 +10,7 @@
 
 import { route } from 'common/helpers/route';
 import { useTitle } from 'common/hooks/useTitle';
-import { BankAccountDetails } from 'common/interfaces/bank-accounts';
+import { BankAccount as BankAccountEntity } from 'common/interfaces/bank-accounts';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
@@ -36,7 +36,7 @@ export function BankAccount() {
 
   const { data: response } = useBankAccountQuery({ id });
 
-  const [accountDetails, setAccountDetails] = useState<BankAccountDetails>();
+  const [accountDetails, setAccountDetails] = useState<BankAccountEntity>();
 
   useEffect(() => {
     setAccountDetails(response);

--- a/src/pages/transactions/components/BankAccountSelector.tsx
+++ b/src/pages/transactions/components/BankAccountSelector.tsx
@@ -15,7 +15,12 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CreateBankAccountModal } from './CreateBankAccountModal';
 
-export function BankAccountSelector(props: GenericSelectorProps<BankAccount>) {
+export interface BankAccountSelectorProps
+  extends GenericSelectorProps<BankAccount> {
+  staleTime?: number;
+}
+
+export function BankAccountSelector(props: BankAccountSelectorProps) {
   const [t] = useTranslation();
   const [isModalOpen, setIsModalOpen] = useState(false);
 
@@ -24,18 +29,25 @@ export function BankAccountSelector(props: GenericSelectorProps<BankAccount>) {
       <CreateBankAccountModal
         isModalOpen={isModalOpen}
         setIsModalOpen={setIsModalOpen}
+        onCreatedBankAccount={(bankAccount) => props.onChange(bankAccount)}
       />
 
       <DebouncedCombobox
-        {...props}
+        inputLabel={props.inputLabel}
         endpoint="/api/v1/bank_integrations"
         label="bank_account_name"
+        defaultValue={props.value}
         onChange={(value: Record<BankAccount>) =>
           value.resource && props.onChange(value.resource)
         }
+        disabled={props.readonly}
+        clearButton={props.clearButton}
+        onClearButtonClick={props.onClearButtonClick}
+        queryAdditional
         actionLabel={t('new_bank_account')}
         onActionClick={() => setIsModalOpen(true)}
-        clearButton
+        sortBy="bank_account_name|desc"
+        staleTime={props.staleTime}
       />
     </>
   );

--- a/src/pages/transactions/components/CreateBankAccountModal.tsx
+++ b/src/pages/transactions/components/CreateBankAccountModal.tsx
@@ -9,41 +9,48 @@
  */
 
 import { Modal } from 'components/Modal';
-import { Dispatch, SetStateAction } from 'react';
+import { Dispatch, SetStateAction, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, InputField } from '@invoiceninja/forms';
-import { BankAccountInput } from 'common/interfaces/bank-accounts';
+import { BankAccount } from 'common/interfaces/bank-accounts';
 import { useState } from 'react';
 import { ValidationBag } from 'common/interfaces/validation-bag';
 import { useHandleCreate } from 'pages/settings/bank-accounts/create/hooks/useHandleCreate';
+import { useBlankBankAccountQuery } from 'pages/settings/bank-accounts/common/queries';
 
 interface Props {
   isModalOpen: boolean;
   setIsModalOpen: Dispatch<SetStateAction<boolean>>;
+  onCreatedBankAccount?: (account: BankAccount) => unknown;
 }
 
 export function CreateBankAccountModal(props: Props) {
   const [t] = useTranslation();
 
+  const { data } = useBlankBankAccountQuery();
+
   const [isFormBusy, setIsFormBusy] = useState<boolean>(false);
 
   const [errors, setErrors] = useState<ValidationBag>();
 
-  const [bankAccount, setBankAccount] = useState<BankAccountInput>();
+  const [bankAccount, setBankAccount] = useState<BankAccount>();
 
   const handleSave = useHandleCreate(
     bankAccount,
     setErrors,
     setIsFormBusy,
     isFormBusy,
-    props.setIsModalOpen
+    props.setIsModalOpen,
+    props.onCreatedBankAccount
   );
 
   const handleChange = (
-    property: keyof BankAccountInput,
-    value: BankAccountInput[keyof BankAccountInput]
+    property: keyof BankAccount,
+    value: BankAccount[keyof BankAccount]
   ) => {
-    setBankAccount((prevState) => ({ ...prevState, [property]: value }));
+    setBankAccount(
+      (prevState) => prevState && { ...prevState, [property]: value }
+    );
   };
 
   const handleCancel = () => {
@@ -51,6 +58,12 @@ export function CreateBankAccountModal(props: Props) {
       props.setIsModalOpen(false);
     }
   };
+
+  useEffect(() => {
+    if (data) {
+      setBankAccount(data);
+    }
+  }, [data]);
 
   return (
     <Modal

--- a/src/pages/transactions/components/TransactionForm.tsx
+++ b/src/pages/transactions/components/TransactionForm.tsx
@@ -102,7 +102,7 @@ export function TransactionForm(props: Props) {
 
       <Element required leftSide={t('bank_account')}>
         <BankAccountSelector
-          defaultValue={props.transaction.bank_integration_id}
+          value={props.transaction.bank_integration_id}
           onChange={(account) =>
             props.handleChange('bank_integration_id', account.id)
           }
@@ -110,7 +110,7 @@ export function TransactionForm(props: Props) {
             props.handleChange('bank_integration_id', '')
           }
           errorMessage={props.errors?.errors.bank_integration_id}
-          clearButton
+          clearButton={Boolean(props.transaction.bank_integration_id)}
         />
       </Element>
 


### PR DESCRIPTION
@turbo124 The bank account selector has been improved and now, after creation via the modal, the newly created bank account will be immediately selected in the selector. 

One important thing to mention. I refactored the code a bit and used `bank_integrations/create` end point for the first time. When we try to create a bank account (POST method `bank_integrations`) we get an error because of the `nickname` property in this object. If I remove it everything works perfectly. So to make everything work I removed this property before saving the new bank account. But is there any way to fix this on the API side and make it work with the `nickname` property, same as for the PUT method?

@beganovich I've included a few more files in this PR, not just the two main files. The reason for this is the slightly unconventional interface of `BankAccount`. To make it conventional with the rest of the app, I decided to make changes to this PR. I think this is a specific case because if we want to split it into two PRs, we need to wait for the first one to merge. I hope you agree with me.

Let me know your thoughts. 