### PR TITLE
[Cleanup] Commented Decimal Comma Option - Localization

### DIFF
--- a/src/pages/settings/localization/components/Settings.tsx
+++ b/src/pages/settings/localization/components/Settings.tsx
@@ -60,7 +60,7 @@ export function Settings() {
           </SelectField>
         </Element>
 
-        <Element leftSide={t('decimal_comma')}>
+        {/* <Element leftSide={t('decimal_comma')}>
           <Toggle
             checked={company?.settings.use_comma_as_decimal_place}
             onChange={(value: boolean) =>
@@ -73,7 +73,7 @@ export function Settings() {
               )
             }
           />
-        </Element>
+        </Element> */}
 
         <Element leftSide={t('currency_format')}>
           <Radio


### PR DESCRIPTION
@turbo124 @beganovich As David mentioned in the Jira ticket, I had to remove the `decimal_comma` on the localization settings page. That's why I just commented out this part of the code, so that if we decide to bring it back, we can just uncomment it.