### PR TITLE
[Cleanup] Payment Settings - Defaults - Pages - Refactoring

### DIFF
--- a/src/pages/settings/company/components/Defaults.tsx
+++ b/src/pages/settings/company/components/Defaults.tsx
@@ -10,7 +10,7 @@
 
 import { useTranslation } from 'react-i18next';
 import { Card, Element } from '../../../../components/cards';
-import { Link, SelectField } from '../../../../components/forms';
+import { SelectField } from '../../../../components/forms';
 import Toggle from '../../../../components/forms/Toggle';
 import { useDispatch, useSelector } from 'react-redux';
 import { useStaticsQuery } from 'common/queries/statics';
@@ -49,20 +49,6 @@ export function Defaults() {
     <>
       {companyChanges?.settings && (
         <Card title={t('defaults')}>
-          <Element leftSide={t('auto_bill')}>
-            <SelectField
-              value={companyChanges?.settings?.auto_bill}
-              onChange={handleChange}
-              id="settings.auto_bill"
-            >
-              <option defaultChecked></option>
-              <option value="always">{t('enabled')}</option>
-              <option value="optout">{t('optout')}</option>
-              <option value="optin">{t('optin')}</option>
-              <option value="off">{t('disabled')}</option>
-            </SelectField>
-          </Element>
-
           <Element leftSide={t('payment_type')}>
             <SelectField
               value={companyChanges?.settings?.payment_type_id}
@@ -79,27 +65,6 @@ export function Defaults() {
               )}
             </SelectField>
           </Element>
-
-          {terms && (
-            <Element leftSide={t('payment_terms')}>
-              <SelectField
-                value={companyChanges?.settings?.payment_terms}
-                id="settings.payment_terms"
-                onChange={handleChange}
-              >
-                <option value=""></option>
-                {terms.data.data.map((type: PaymentTerm) => (
-                  <option key={type.id} value={type.num_days}>
-                    {type.name}
-                  </option>
-                ))}
-              </SelectField>
-
-              <Link to="/settings/payment_terms" className="block mt-2">
-                {t('configure_payment_terms')}
-              </Link>
-            </Element>
-          )}
 
           {terms && (
             <Element leftSide={t('quote_valid_until')}>


### PR DESCRIPTION
@turbo124 @beganovich As David mentioned in this list https://invoiceninja.atlassian.net/browse/RU-533, we need to move two fields from the `Defaults` page to the `Payment Settings` page. Let me know if there's anything else I need to change.

Here are screenshots of updated UI for those pages:

![Screenshot 2023-01-25 at 16 03 38](https://user-images.githubusercontent.com/51542191/214598924-8ce1481c-1a00-40ac-bc1b-50fb68ff58c0.png)

![Screenshot 2023-01-25 at 16 03 57](https://user-images.githubusercontent.com/51542191/214598960-5dd09e0b-d787-4295-95e5-3716ee2a78d8.png)