### PR TITLE
[Feature] Lock Invoiced Tasks - Field Implementation

### DIFF
--- a/src/pages/settings/task-settings/TaskSettings.tsx
+++ b/src/pages/settings/task-settings/TaskSettings.tsx
@@ -47,7 +47,7 @@ export function TaskSettings() {
       })
     );
 
-  const handleToggleChange = (id: string, value: boolean) =>
+  const handleToggleChange = (id: string, value: boolean | string) =>
     dispatch(
       updateChanges({
         object: 'company',
@@ -139,6 +139,23 @@ export function TaskSettings() {
         </Element>
 
         <Element
+          leftSide={t('lock_invoiced_tasks')}
+          leftSideHelp={t('lock_invoiced_tasks_help')}
+        >
+          <Toggle
+            checked={
+              companyChanges?.settings?.lock_invoices === 'off' ? false : true
+            }
+            onChange={(value: boolean) =>
+              handleToggleChange(
+                'settings.lock_invoices',
+                value === false ? 'off' : 'on'
+              )
+            }
+          />
+        </Element>
+
+        <Element
           leftSide={t('add_documents_to_invoice')}
           leftSideHelp={t('add_documents_to_invoice_help')}
         >
@@ -160,6 +177,7 @@ export function TaskSettings() {
             }
           />
         </Element>
+
         <Element leftSide={t('tasks_shown_in_portal')}>
           <SelectField
             id="settings.show_all_tasks_client_portal"


### PR DESCRIPTION
Here's a screenshot of the Lock Invoiced Tasks implementation implemented under task settings:

<img width="1261" alt="Screenshot 2023-01-28 at 01 39 45" src="https://user-images.githubusercontent.com/51542191/215231206-26410eda-31e4-40ff-90ff-08e94edaee74.png">

@turbo124 This field is based on the `off/on` string. Handling this field like this requires additional adjusting on the front end. I guess we don't have any special states of this field, so if that's correct, I suggest you cast this to a boolean value. Also, the only property I found in the company settings based on the lock keyword is `lock_invoices`, I'm not 100% sure I'm on the right track, so please let me know if I'm wrong. Also, tell me what you think.