### PR TITLE
[Feature] Auto start task

### DIFF
--- a/src/common/interfaces/company.interface.ts
+++ b/src/common/interfaces/company.interface.ts
@@ -25,6 +25,7 @@ export interface Company {
   enable_product_cost: boolean;
   enable_product_quantity: boolean;
   show_task_end_date: boolean;
+  auto_start_tasks: boolean;
   use_quote_terms_on_conversion: boolean;
   is_disabled: boolean;
   enable_applying_payments: boolean;

--- a/src/pages/tasks/common/hooks/useStart.ts
+++ b/src/pages/tasks/common/hooks/useStart.ts
@@ -14,9 +14,11 @@ import { toast } from 'common/helpers/toast/toast';
 import { Task } from 'common/interfaces/task';
 import { useQueryClient } from 'react-query';
 import { route } from 'common/helpers/route';
+import { useLocation } from 'react-router-dom';
 
 export function useStart() {
   const queryClient = useQueryClient();
+  const location = useLocation();
 
   return (task: Task) => {
     toast.processing();
@@ -27,7 +29,9 @@ export function useStart() {
       task
     )
       .then(() => {
-        toast.success('started_task');
+        !location.pathname.endsWith('/create')
+          ? toast.success('started_task')
+          : toast.dismiss();
 
         queryClient.invalidateQueries('/api/v1/tasks');
 

--- a/src/pages/tasks/create/Create.tsx
+++ b/src/pages/tasks/create/Create.tsx
@@ -13,6 +13,7 @@ import { endpoint, isProduction } from 'common/helpers';
 import { request } from 'common/helpers/request';
 import { route } from 'common/helpers/route';
 import { toast } from 'common/helpers/toast/toast';
+import { useCurrentCompany } from 'common/hooks/useCurrentCompany';
 import { useTitle } from 'common/hooks/useTitle';
 import { Task } from 'common/interfaces/task';
 import { ValidationBag } from 'common/interfaces/validation-bag';
@@ -27,6 +28,7 @@ import { taskAtom } from '../common/atoms';
 import { TaskDetails } from '../common/components/TaskDetails';
 import { TaskTable } from '../common/components/TaskTable';
 import { isOverlapping } from '../common/helpers/is-overlapping';
+import { useStart } from '../common/hooks/useStart';
 
 export function Create() {
   const [t] = useTranslation();
@@ -36,6 +38,9 @@ export function Create() {
   const [searchParams] = useSearchParams();
 
   const { data } = useBlankTaskQuery();
+  const company = useCurrentCompany();
+
+  const start = useStart();
 
   const { data: taskStatuses } = useTaskStatusesQuery();
 
@@ -97,6 +102,8 @@ export function Create() {
 
     request('POST', endpoint('/api/v1/tasks'), task)
       .then((response) => {
+        company?.auto_start_tasks && start(response.data.data);
+
         toast.success('created_task');
 
         navigate(route('/tasks/:id/edit', { id: response.data.data.id }));


### PR DESCRIPTION
@turbo124 As we know we already have `auto_start_tasks` field under `Task settings` but we didn't have that feature. So, I implemented it here. If this setting is on, after creating a task we will call the API to run this task and after that the user will be navigated to the edit page of that created task. With this setting the task will be created without running. Let me know your thoughts.