### PR TITLE
[Feature] Convert To Inovice - Quote Functionality

### DIFF
--- a/src/pages/quotes/common/hooks.tsx
+++ b/src/pages/quotes/common/hooks.tsx
@@ -68,6 +68,7 @@ import {
   MdPictureAsPdf,
   MdRestore,
   MdSend,
+  MdSwitchRight,
 } from 'react-icons/md';
 import { SelectOption } from 'components/datatables/Actions';
 
@@ -352,6 +353,15 @@ export function useActions() {
           icon={<Icon element={MdDone} />}
         >
           {t('approve')}
+        </DropdownElement>
+      ),
+    (quote) =>
+      quote.status_id !== QuoteStatus.Converted && (
+        <DropdownElement
+          onClick={() => bulk(quote.id, 'convert_to_invoice')}
+          icon={<Icon element={MdSwitchRight} />}
+        >
+          {t('convert_to_invoice')}
         </DropdownElement>
       ),
     () => <Divider withoutPadding />,

--- a/src/pages/quotes/common/hooks.tsx
+++ b/src/pages/quotes/common/hooks.tsx
@@ -69,8 +69,10 @@ import {
   MdRestore,
   MdSend,
   MdSwitchRight,
+  MdTextSnippet,
 } from 'react-icons/md';
 import { SelectOption } from 'components/datatables/Actions';
+import { useAccentColor } from 'common/hooks/useAccentColor';
 
 export type ChangeHandler = <T extends keyof Quote>(
   property: T,
@@ -495,6 +497,9 @@ export function useQuoteColumns() {
   const { t } = useTranslation();
   const { dateFormat } = useCurrentCompanyDateFormats();
 
+  const accentColor = useAccentColor();
+  const navigate = useNavigate();
+
   const currentUser = useCurrentUser();
   const company = useCurrentCompany();
   const formatMoney = useFormatMoney();
@@ -517,7 +522,22 @@ export function useQuoteColumns() {
       column: 'status',
       id: 'status_id',
       label: t('status'),
-      format: (value, quote) => <QuoteStatusBadge entity={quote} />,
+      format: (value, quote) => (
+        <div className="flex items-center space-x-2">
+          <QuoteStatusBadge entity={quote} />
+
+          {quote.status_id === QuoteStatus.Converted && (
+            <MdTextSnippet
+              className="cursor-pointer"
+              fontSize={19}
+              color={accentColor}
+              onClick={() =>
+                navigate(route('/invoices/:id/edit', { id: quote.invoice_id }))
+              }
+            />
+          )}
+        </div>
+      ),
     },
     {
       column: 'number',

--- a/src/pages/quotes/common/hooks/useBulkAction.ts
+++ b/src/pages/quotes/common/hooks/useBulkAction.ts
@@ -18,14 +18,21 @@ import { route } from 'common/helpers/route';
 export function useBulkAction() {
   const queryClient = useQueryClient();
 
-  return (id: string, action: 'archive' | 'restore' | 'delete') => {
+  return (
+    id: string,
+    action: 'archive' | 'restore' | 'delete' | 'convert_to_invoice'
+  ) => {
     toast.processing();
 
     request('POST', endpoint('/api/v1/quotes/bulk'), {
       action,
       ids: [id],
     })
-      .then(() => toast.success(`${action}d_quote`))
+      .then(() => {
+        action === 'convert_to_invoice'
+          ? toast.success('converted_quote')
+          : toast.success(`${action}d_quote`);
+      })
       .catch((error: AxiosError) => {
         console.error(error);
 

--- a/src/pages/settings/company/components/Defaults.tsx
+++ b/src/pages/settings/company/components/Defaults.tsx
@@ -119,7 +119,10 @@ export function Defaults() {
             />
           </Element>
 
-          <Element leftSide={t('use_quote_terms')}>
+          <Element
+            leftSide={t('use_quote_terms')}
+            leftSideHelp={t('use_quote_terms_help')}
+          >
             <Toggle
               checked={companyChanges?.use_quote_terms_on_conversion}
               onChange={(value: boolean) =>


### PR DESCRIPTION
Here is the screenshot of added action to more-actions dropdown menu:

![Screenshot 2023-02-01 at 07 45 50](https://user-images.githubusercontent.com/51542191/215971393-e6210f6c-1a6d-40d3-8d03-61a45177e9ab.png)

@turbo124 As we discussed in Slack, we already have the option to `use quote terms` in Defaults settings page, but we missed the `Convert To Invoice` Quote functionality for this property. It is now added and works perfectly on my end. Let me know your thoughts.