### PR TITLE
[Cleanup] Currency registration field and fixing bug on registration card

### DIFF
--- a/src/pages/settings/client-portal/components/Registration.tsx
+++ b/src/pages/settings/client-portal/components/Registration.tsx
@@ -40,6 +40,7 @@ export function Registration() {
     { field: 'state', label: t('state') },
     { field: 'postal_code', label: t('postal_code') },
     { field: 'country_id', label: t('country') },
+    { field: 'currency_id', label: t('currency') },
     { field: 'custom_value1', label: t('custom1') },
     { field: 'custom_value2', label: t('custom2') },
     { field: 'custom_value3', label: t('custom3') },
@@ -53,21 +54,36 @@ export function Registration() {
       company?.client_registration_fields || []
     );
 
-    return fields.find((field) => field.key === property)?.required;
+    return Boolean(fields.find((field) => field.key === property)?.required);
   };
 
   const handleRegistrationToggle = (property: string, value: boolean) => {
-    const fields: Field[] = cloneDeep(
+    let existingFields: Field[] = cloneDeep(
       company?.client_registration_fields || []
     );
 
-    const index = fields.findIndex((field) => field.key === property);
+    const alreadyAdded = existingFields.some((field) => field.key === property);
+    const index = fields.findIndex((field) => field.field === property);
 
     if (index >= 0) {
-      fields[index].required = value;
-    }
+      if (alreadyAdded) {
+        const updatedFields = existingFields.map((field) => ({
+          ...field,
+          required: field.key === property ? value : field.required,
+        }));
 
-    handleChange('client_registration_fields', [...fields]);
+        handleChange('client_registration_fields', updatedFields);
+      } else {
+        const foundField = fields[index];
+
+        existingFields = [
+          ...existingFields,
+          { key: foundField.field, required: value },
+        ];
+
+        handleChange('client_registration_fields', existingFields);
+      }
+    }
   };
 
   return (


### PR DESCRIPTION
Here is the screenshot of UI with added `currency` field:

![Screenshot 2023-02-03 at 18 41 15](https://user-images.githubusercontent.com/51542191/216671769-ac4e1c7a-1453-45ee-a0dd-8104c8998ff5.png)

@beganovich @turbo124 Besides just adding this field, I noticed that updating the company field `client_registration_fields` doesn't work. So this PR includes that part as well, I think it works correctly now and the API will get an array with objects that include the `field key` and the `required (boolean)`. Let me know your thoughts.