### PR TITLE
[Cleanup] Send time helper text

### DIFF
--- a/src/pages/settings/email-settings/EmailSettings.tsx
+++ b/src/pages/settings/email-settings/EmailSettings.tsx
@@ -122,10 +122,7 @@ export function EmailSettings() {
           />
         </Element>
 
-        <Element
-          leftSide={t('send_time')}
-          leftSideHelp={t('comma_sparated_list')}
-        >
+        <Element leftSide={t('send_time')}>
           <SelectField
             value={company?.settings.entity_send_time}
             onValueChange={(value) =>


### PR DESCRIPTION
@turbo124 @beganovich Here is the screenshot of UI with removed helper text for `send_time` field:

![Screenshot 2023-02-04 at 00 31 17](https://user-images.githubusercontent.com/51542191/216729985-473a03fe-b026-43a0-8c27-cbcd5af8808d.png)
