### PR TITLE
[Cleanup] Code refactoring - Split Submit Button Implementation

### DIFF
--- a/src/common/queries/expense-categories.ts
+++ b/src/common/queries/expense-categories.ts
@@ -70,3 +70,15 @@ export function bulk(
     ids: id,
   });
 }
+
+export function useBlankExpenseCategoryQuery() {
+  return useQuery<ExpenseCategory>(
+    '/api/v1/expense_categories/create',
+    () =>
+      request('GET', endpoint('/api/v1/expense_categories/create')).then(
+        (response: GenericSingleResourceResponse<ExpenseCategory>) =>
+          response.data.data
+      ),
+    { staleTime: Infinity }
+  );
+}

--- a/src/common/queries/payment-terms.ts
+++ b/src/common/queries/payment-terms.ts
@@ -15,6 +15,8 @@ import { useQuery } from 'react-query';
 import { route } from 'common/helpers/route';
 import { defaultHeaders } from './common/headers';
 import { Params } from './common/params.interface';
+import { PaymentTerm } from 'common/interfaces/payment-term';
+import { GenericSingleResourceResponse } from 'common/interfaces/generic-api-response';
 
 export function usePaymentTermsQuery(params: Params) {
   return useQuery(['/api/v1/payment_terms', params], () =>
@@ -51,4 +53,16 @@ export function bulk(
     action,
     ids: id,
   });
+}
+
+export function useBlankPaymentTermQuery() {
+  return useQuery<PaymentTerm>(
+    '/api/v1/payment_terms/create',
+    () =>
+      request('GET', endpoint('/api/v1/payment_terms/create')).then(
+        (response: GenericSingleResourceResponse<PaymentTerm>) =>
+          response.data.data
+      ),
+    { staleTime: Infinity }
+  );
 }

--- a/src/common/queries/tax-rates.ts
+++ b/src/common/queries/tax-rates.ts
@@ -14,6 +14,8 @@ import { request } from 'common/helpers/request';
 import { useQuery } from 'react-query';
 import { route } from 'common/helpers/route';
 import { Params } from './common/params.interface';
+import { GenericSingleResourceResponse } from 'common/interfaces/generic-api-response';
+import { TaxRate } from 'common/interfaces/tax-rate';
 
 export function useTaxRatesQuery(params: Params) {
   return useQuery(
@@ -50,4 +52,15 @@ export function bulk(
     action,
     ids: id,
   });
+}
+
+export function useBlankTaxRateQuery() {
+  return useQuery<TaxRate>(
+    '/api/v1/tax_rates/create',
+    () =>
+      request('GET', endpoint('/api/v1/tax_rates/create')).then(
+        (response: GenericSingleResourceResponse<TaxRate>) => response.data.data
+      ),
+    { staleTime: Infinity }
+  );
 }

--- a/src/pages/settings/expense-categories/Create.tsx
+++ b/src/pages/settings/expense-categories/Create.tsx
@@ -8,16 +8,43 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
-import { Card } from '@invoiceninja/cards';
+import { ButtonOption, Card } from '@invoiceninja/cards';
+import { AxiosError } from 'axios';
+import { endpoint } from 'common/helpers';
+import { request } from 'common/helpers/request';
+import { route } from 'common/helpers/route';
+import { toast } from 'common/helpers/toast/toast';
+import { useAccentColor } from 'common/hooks/useAccentColor';
 import { useTitle } from 'common/hooks/useTitle';
+import { ExpenseCategory } from 'common/interfaces/expense-category';
+import { GenericSingleResourceResponse } from 'common/interfaces/generic-api-response';
+import { ValidationBag } from 'common/interfaces/validation-bag';
+import { useBlankExpenseCategoryQuery } from 'common/queries/expense-categories';
+import { Icon } from 'components/icons/Icon';
 import { Settings } from 'components/layouts/Settings';
+import { FormEvent, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { BiPlusCircle } from 'react-icons/bi';
+import { useQueryClient } from 'react-query';
+import { useNavigate } from 'react-router-dom';
 import { CreateExpenseCategoryForm } from './components/CreateExpenseCategoryForm';
 
 export function Create() {
   useTitle('new_expense_category');
 
   const [t] = useTranslation();
+
+  const navigate = useNavigate();
+  const accentColor: string = useAccentColor();
+  const queryClient = useQueryClient();
+
+  const { data: blankExpenseCategory } = useBlankExpenseCategoryQuery();
+
+  const [errors, setErrors] = useState<ValidationBag>();
+
+  const [isFormBusy, setIsFormBusy] = useState<boolean>(false);
+
+  const [expenseCategory, setExpenseCategory] = useState<ExpenseCategory>();
 
   const pages = [
     { name: t('settings'), href: '/settings' },
@@ -28,10 +55,81 @@ export function Create() {
     },
   ];
 
+  const handleSave = (
+    event: FormEvent<HTMLFormElement>,
+    actionType: string
+  ) => {
+    event.preventDefault();
+
+    if (!isFormBusy) {
+      setIsFormBusy(true);
+
+      toast.processing();
+
+      request('POST', endpoint('/api/v1/expense_categories'), expenseCategory)
+        .then((response: GenericSingleResourceResponse<ExpenseCategory>) => {
+          toast.success('created_expense_category');
+
+          queryClient.invalidateQueries('/api/v1/expense_categories');
+
+          if (actionType === 'save') {
+            navigate(
+              route('/settings/expense_categories/:id/edit', {
+                id: response.data.data.id,
+              })
+            );
+          } else {
+            if (blankExpenseCategory) {
+              setExpenseCategory({
+                ...blankExpenseCategory,
+                color: accentColor,
+              });
+            }
+          }
+        })
+        .catch((error: AxiosError<ValidationBag>) => {
+          if (error.response?.status === 422) {
+            toast.dismiss();
+            setErrors(error.response.data);
+          } else {
+            console.error(error);
+            toast.error();
+          }
+        })
+        .finally(() => setIsFormBusy(false));
+    }
+  };
+
+  const saveOptions: ButtonOption[] = [
+    {
+      onClick: (event: FormEvent<HTMLFormElement>) =>
+        handleSave(event, 'create'),
+      text: `${t('save')} / ${t('create')}`,
+      icon: <Icon element={BiPlusCircle} />,
+    },
+  ];
+
+  useEffect(() => {
+    if (blankExpenseCategory) {
+      setExpenseCategory({ ...blankExpenseCategory, color: accentColor });
+    }
+  }, [blankExpenseCategory]);
+
   return (
     <Settings title={t('expense_categories')} breadcrumbs={pages}>
-      <Card title={t('create_expense_category')}>
-        <CreateExpenseCategoryForm />
+      <Card
+        title={t('create_expense_category')}
+        withSaveButton
+        disableSubmitButton={isFormBusy}
+        onSaveClick={(event) => handleSave(event, 'save')}
+        additionalSaveOptions={saveOptions}
+      >
+        <CreateExpenseCategoryForm
+          expenseCategory={expenseCategory}
+          setExpenseCategory={setExpenseCategory}
+          errors={errors}
+          setErrors={setErrors}
+        />
       </Card>
     </Settings>
   );

--- a/src/pages/settings/expense-categories/components/CreateExpenseCategoryForm.tsx
+++ b/src/pages/settings/expense-categories/components/CreateExpenseCategoryForm.tsx
@@ -9,126 +9,56 @@
  */
 
 import { CardContainer } from '@invoiceninja/cards';
-import { Button, InputField, InputLabel } from '@invoiceninja/forms';
-import { AxiosError } from 'axios';
-import { endpoint } from 'common/helpers';
-import { request } from 'common/helpers/request';
-import { route } from 'common/helpers/route';
-import { toast } from 'common/helpers/toast/toast';
+import { InputField, InputLabel } from '@invoiceninja/forms';
 import { ExpenseCategory } from 'common/interfaces/expense-category';
-import { GenericSingleResourceResponse } from 'common/interfaces/generic-api-response';
 import { ValidationBag } from 'common/interfaces/validation-bag';
 import { ColorPicker } from 'components/forms/ColorPicker';
-import { Dispatch, FormEvent, SetStateAction, useState } from 'react';
+import { Dispatch, SetStateAction } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useQueryClient } from 'react-query';
-import { useNavigate } from 'react-router-dom';
-
-interface ExpenseCategoryInput {
-  name: string;
-  color: string;
-}
 
 interface Props {
-  setVisible?: Dispatch<SetStateAction<boolean>>;
-  setSelectedIds?: Dispatch<SetStateAction<string[]>>;
-  onCreatedCategory?: (category: ExpenseCategory) => unknown;
+  errors: ValidationBag | undefined;
+  setErrors: Dispatch<SetStateAction<ValidationBag | undefined>>;
+  setExpenseCategory: Dispatch<SetStateAction<ExpenseCategory | undefined>>;
+  expenseCategory: ExpenseCategory | undefined;
 }
 
 export function CreateExpenseCategoryForm(props: Props) {
   const [t] = useTranslation();
 
-  const navigate = useNavigate();
-
-  const queryClient = useQueryClient();
-
-  const [errors, setErrors] = useState<ValidationBag>();
-
-  const [isFormBusy, setIsFormBusy] = useState<boolean>(false);
-
-  const [expenseCategory, setExpenseCategory] = useState<ExpenseCategoryInput>({
-    name: '',
-    color: '',
-  });
+  const { errors, setErrors, setExpenseCategory, expenseCategory } = props;
 
   const handleChange = (
     property: keyof ExpenseCategory,
     value: ExpenseCategory[keyof ExpenseCategory]
   ) => {
-    setExpenseCategory((prevState) => ({
-      ...prevState,
-      [property]: value,
-    }));
-  };
+    setErrors(undefined);
 
-  const handleSave = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-
-    if (!isFormBusy) {
-      setIsFormBusy(true);
-
-      toast.processing();
-
-      request('POST', endpoint('/api/v1/expense_categories'), expenseCategory)
-        .then((response: GenericSingleResourceResponse<ExpenseCategory>) => {
-          toast.success('created_expense_category');
-
-          queryClient.invalidateQueries('/api/v1/expense_categories');
-
-          window.dispatchEvent(
-            new CustomEvent('invalidate.combobox.queries', {
-              detail: {
-                url: endpoint('/api/v1/expense_categories'),
-              },
-            })
-          );
-
-          if (props.setSelectedIds) {
-            props.setSelectedIds([response.data.data.id]);
-          }
-
-          if (props.onCreatedCategory) {
-            props.onCreatedCategory(response.data.data);
-          }
-
-          if (props.setVisible) {
-            props.setVisible(false);
-          } else {
-            navigate(
-              route('/settings/expense_categories/:id/edit', {
-                id: response.data.data.id,
-              })
-            );
-          }
-        })
-        .catch((error: AxiosError<ValidationBag>) => {
-          if (error.response?.status === 422) {
-            setErrors(error.response.data);
-            toast.dismiss();
-          } else {
-            toast.error();
-          }
-        })
-        .finally(() => setIsFormBusy(false));
-    }
+    setExpenseCategory(
+      (prevState) =>
+        prevState && {
+          ...prevState,
+          [property]: value,
+        }
+    );
   };
 
   return (
     <CardContainer>
       <InputField
+        required
         label={t('name')}
+        value={expenseCategory?.name}
         onValueChange={(value) => handleChange('name', value)}
         errorMessage={errors?.errors.name}
-        required
       />
 
       <InputLabel>{t('color')}</InputLabel>
 
-      <ColorPicker onValueChange={(value) => handleChange('color', value)} />
-
-      <div className="flex justify-end space-x-4 mt-5">
-        <Button onClick={handleSave}>{t('save')}</Button>
-      </div>
+      <ColorPicker
+        value={expenseCategory?.color}
+        onValueChange={(value) => handleChange('color', value)}
+      />
     </CardContainer>
   );
 }

--- a/src/pages/settings/expense-categories/components/CreateExpenseCategoryModal.tsx
+++ b/src/pages/settings/expense-categories/components/CreateExpenseCategoryModal.tsx
@@ -8,10 +8,26 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
+import { Button } from '@invoiceninja/forms';
+import { AxiosError } from 'axios';
+import { endpoint } from 'common/helpers';
+import { request } from 'common/helpers/request';
+import { toast } from 'common/helpers/toast/toast';
+import { useAccentColor } from 'common/hooks/useAccentColor';
 import { ExpenseCategory } from 'common/interfaces/expense-category';
+import { GenericSingleResourceResponse } from 'common/interfaces/generic-api-response';
+import { ValidationBag } from 'common/interfaces/validation-bag';
+import { useBlankExpenseCategoryQuery } from 'common/queries/expense-categories';
 import { Modal } from 'components/Modal';
-import { Dispatch, SetStateAction } from 'react';
+import {
+  Dispatch,
+  FormEvent,
+  SetStateAction,
+  useEffect,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
+import { useQueryClient } from 'react-query';
 import { CreateExpenseCategoryForm } from './CreateExpenseCategoryForm';
 
 interface Props {
@@ -24,6 +40,64 @@ interface Props {
 export function CreateExpenseCategoryModal(props: Props) {
   const [t] = useTranslation();
 
+  const queryClient = useQueryClient();
+  const accentColor: string = useAccentColor();
+
+  const { data: blankExpenseCategory } = useBlankExpenseCategoryQuery();
+
+  const [errors, setErrors] = useState<ValidationBag>();
+  const [isFormBusy, setIsFormBusy] = useState<boolean>(false);
+  const [expenseCategory, setExpenseCategory] = useState<ExpenseCategory>();
+
+  const handleSave = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!isFormBusy) {
+      toast.processing();
+      setIsFormBusy(true);
+
+      request('POST', endpoint('/api/v1/expense_categories'), expenseCategory)
+        .then((response: GenericSingleResourceResponse<ExpenseCategory>) => {
+          toast.success('created_expense_category');
+
+          queryClient.invalidateQueries('/api/v1/expense_categories');
+
+          window.dispatchEvent(
+            new CustomEvent('invalidate.combobox.queries', {
+              detail: {
+                url: endpoint('/api/v1/expense_categories'),
+              },
+            })
+          );
+
+          if (props.setSelectedIds) {
+            props.setSelectedIds([response.data.data.id]);
+          }
+
+          if (props.onCreatedCategory) {
+            props.onCreatedCategory(response.data.data);
+          }
+
+          props.setVisible(false);
+        })
+        .catch((error: AxiosError<ValidationBag>) => {
+          if (error.response?.status === 422) {
+            setErrors(error.response.data);
+            toast.dismiss();
+          } else {
+            toast.error();
+          }
+        })
+        .finally(() => setIsFormBusy(false));
+    }
+  };
+
+  useEffect(() => {
+    if (blankExpenseCategory) {
+      setExpenseCategory({ ...blankExpenseCategory, color: accentColor });
+    }
+  }, [blankExpenseCategory]);
+
   return (
     <Modal
       title={t('create_expense_category')}
@@ -31,10 +105,15 @@ export function CreateExpenseCategoryModal(props: Props) {
       onClose={() => props.setVisible(false)}
     >
       <CreateExpenseCategoryForm
-        setSelectedIds={props.setSelectedIds}
-        setVisible={props.setVisible}
-        onCreatedCategory={props.onCreatedCategory}
+        expenseCategory={expenseCategory}
+        setExpenseCategory={setExpenseCategory}
+        errors={errors}
+        setErrors={setErrors}
       />
+
+      <div className="flex justify-end space-x-4 mt-5">
+        <Button onClick={handleSave}>{t('save')}</Button>
+      </div>
     </Modal>
   );
 }

--- a/src/pages/settings/payment-terms/Create.tsx
+++ b/src/pages/settings/payment-terms/Create.tsx
@@ -8,24 +8,36 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
-import { Card, CardContainer } from '@invoiceninja/cards';
+import { ButtonOption, Card, CardContainer } from '@invoiceninja/cards';
 import { InputField } from '@invoiceninja/forms';
 import { AxiosError, AxiosResponse } from 'axios';
 import { endpoint } from 'common/helpers';
 import { request } from 'common/helpers/request';
 import { route } from 'common/helpers/route';
+import { toast } from 'common/helpers/toast/toast';
+import { useTitle } from 'common/hooks/useTitle';
 import { PaymentTerm } from 'common/interfaces/payment-term';
+import { ValidationBag } from 'common/interfaces/validation-bag';
+import { useBlankPaymentTermQuery } from 'common/queries/payment-terms';
 import { Breadcrumbs } from 'components/Breadcrumbs';
 import { Container } from 'components/Container';
+import { Icon } from 'components/icons/Icon';
 import { Settings } from 'components/layouts/Settings';
-import { useFormik } from 'formik';
-import { useEffect } from 'react';
-import toast from 'react-hot-toast';
+import { FormEvent, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { BiPlusCircle } from 'react-icons/bi';
+import { useQueryClient } from 'react-query';
 import { useNavigate } from 'react-router-dom';
+import { useHandleChange } from './common/hooks/useHandleChange';
 
 export function Create() {
+  const { documentTitle } = useTitle('create_payment_term');
+
   const [t] = useTranslation();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const { data: blankPaymentTerm } = useBlankPaymentTermQuery();
 
   const pages = [
     { name: t('settings'), href: '/settings' },
@@ -34,37 +46,67 @@ export function Create() {
     { name: t('create_payment_term'), href: '/settings/payment_terms/create' },
   ];
 
-  const navigate = useNavigate();
+  const [errors, setErrors] = useState<ValidationBag>();
+  const [isFormBusy, setIsFormBusy] = useState<boolean>(false);
+  const [paymentTerm, setPaymentTerm] = useState<PaymentTerm>();
+
+  const handleChange = useHandleChange({ setErrors, setPaymentTerm });
+
+  const handleSave = (
+    event: FormEvent<HTMLFormElement>,
+    actionType: string
+  ) => {
+    event.preventDefault();
+
+    if (!isFormBusy) {
+      toast.processing();
+      setIsFormBusy(true);
+
+      request('POST', endpoint('/api/v1/payment_terms'), paymentTerm)
+        .then((response: AxiosResponse) => {
+          toast.success('created_payment_term');
+
+          queryClient.invalidateQueries('/api/v1/payment_terms');
+
+          if (actionType === 'save') {
+            navigate(
+              route('/settings/payment_terms/:id/edit', {
+                id: response.data.data.id,
+              })
+            );
+          } else {
+            if (blankPaymentTerm) {
+              setPaymentTerm(blankPaymentTerm);
+            }
+          }
+        })
+        .catch((error: AxiosError<ValidationBag>) => {
+          if (error.response?.status === 422) {
+            toast.dismiss();
+            setErrors(error.response.data);
+          } else {
+            console.error(error);
+            toast.error();
+          }
+        })
+        .finally(() => setIsFormBusy(false));
+    }
+  };
+
+  const saveOptions: ButtonOption[] = [
+    {
+      onClick: (event: FormEvent<HTMLFormElement>) =>
+        handleSave(event, 'create'),
+      text: `${t('save')} / ${t('create')}`,
+      icon: <Icon element={BiPlusCircle} />,
+    },
+  ];
 
   useEffect(() => {
-    document.title = `${import.meta.env.VITE_APP_TITLE}: ${t(
-      'create_payment_term'
-    )}`;
-  });
-
-  const formik = useFormik({
-    enableReinitialize: true,
-    initialValues: {
-      num_days: 0,
-    },
-    onSubmit: (values: Partial<PaymentTerm>) => {
-      toast.loading(t('processing'));
-
-      request('POST', endpoint('/api/v1/payment_terms'), values)
-        .then((response: AxiosResponse) => {
-          toast.dismiss();
-          toast.success(t('created_payment_term'));
-
-          navigate(
-            route('/settings/payment_terms/:id/edit', {
-              id: response.data.data.id,
-            })
-          );
-        })
-        .catch((error: AxiosError) => console.error(error))
-        .finally(() => formik.setSubmitting(false));
-    },
-  });
+    if (blankPaymentTerm) {
+      setPaymentTerm(blankPaymentTerm);
+    }
+  }, [blankPaymentTerm]);
 
   return (
     <Settings title={t('payment_terms')}>
@@ -72,18 +114,21 @@ export function Create() {
         <Breadcrumbs pages={pages} />
 
         <Card
+          title={documentTitle}
           withSaveButton
-          disableSubmitButton={formik.isSubmitting}
-          onFormSubmit={formik.handleSubmit}
-          title={t('create_payment_term')}
+          disableSubmitButton={isFormBusy}
+          onFormSubmit={(event) => handleSave(event, 'save')}
+          onSaveClick={(event) => handleSave(event, 'save')}
+          additionalSaveOptions={saveOptions}
         >
           <CardContainer>
             <InputField
-              value={formik.values.num_days}
+              required
+              value={paymentTerm?.num_days}
               type="number"
-              id="num_days"
               label={t('number_of_days')}
-              onChange={formik.handleChange}
+              onValueChange={(value) => handleChange('num_days', Number(value))}
+              errorMessage={errors?.errors.num_days}
             />
           </CardContainer>
         </Card>

--- a/src/pages/settings/payment-terms/common/hooks/useHandleChange.tsx
+++ b/src/pages/settings/payment-terms/common/hooks/useHandleChange.tsx
@@ -1,0 +1,34 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { PaymentTerm } from 'common/interfaces/payment-term';
+import { ValidationBag } from 'common/interfaces/validation-bag';
+import { Dispatch, SetStateAction } from 'react';
+
+interface Params {
+  setPaymentTerm: Dispatch<SetStateAction<PaymentTerm | undefined>>;
+  setErrors: Dispatch<SetStateAction<ValidationBag | undefined>>;
+}
+
+export function useHandleChange(params: Params) {
+  const { setPaymentTerm, setErrors } = params;
+
+  return <T extends keyof PaymentTerm>(
+    property: T,
+    value: PaymentTerm[typeof property]
+  ) => {
+    setErrors(undefined);
+
+    setPaymentTerm(
+      (currentPaymentTerm) =>
+        currentPaymentTerm && { ...currentPaymentTerm, [property]: value }
+    );
+  };
+}

--- a/src/pages/settings/tax-rates/Create.tsx
+++ b/src/pages/settings/tax-rates/Create.tsx
@@ -8,25 +8,36 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
-import { Card, CardContainer } from '@invoiceninja/cards';
+import { ButtonOption, Card, CardContainer } from '@invoiceninja/cards';
 import { InputField } from '@invoiceninja/forms';
 import { AxiosError } from 'axios';
 import { endpoint } from 'common/helpers';
 import { request } from 'common/helpers/request';
 import { route } from 'common/helpers/route';
+import { toast } from 'common/helpers/toast/toast';
+import { useTitle } from 'common/hooks/useTitle';
+import { TaxRate } from 'common/interfaces/tax-rate';
 import { ValidationBag } from 'common/interfaces/validation-bag';
+import { useBlankTaxRateQuery } from 'common/queries/tax-rates';
 import { Breadcrumbs } from 'components/Breadcrumbs';
 import { Container } from 'components/Container';
+import { Icon } from 'components/icons/Icon';
 import { Settings } from 'components/layouts/Settings';
-import { useFormik } from 'formik';
-import { useEffect, useState } from 'react';
-import toast from 'react-hot-toast';
+import { FormEvent, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { BiPlusCircle } from 'react-icons/bi';
 import { useQueryClient } from 'react-query';
 import { useNavigate } from 'react-router-dom';
+import { useHandleChange } from './common/hooks/useHandleChange';
 
 export function Create() {
+  const { documentTitle } = useTitle('create_tax_rate');
+
   const [t] = useTranslation();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const { data: blankTaxRate } = useBlankTaxRateQuery();
 
   const pages = [
     { name: t('settings'), href: '/settings' },
@@ -34,46 +45,67 @@ export function Create() {
     { name: t('create_tax_rate'), href: '/settings/tax_rates/create' },
   ];
 
-  const [errors, setErrors] = useState<Record<string, any>>({});
-  const navigate = useNavigate();
-  const queryClient = useQueryClient();
+  const [errors, setErrors] = useState<ValidationBag>();
+  const [taxRate, setTaxRate] = useState<TaxRate>();
+  const [isFormBusy, setIsFormBusy] = useState<boolean>(false);
 
-  useEffect(() => {
-    document.title = `${import.meta.env.VITE_APP_TITLE}: ${t(
-      'create_tax_rate'
-    )}`;
-  });
+  const handleChange = useHandleChange({ setErrors, setTaxRate });
 
-  const formik = useFormik({
-    initialValues: {
-      name: '',
-      rate: '',
-    },
-    onSubmit: (values) => {
-      setErrors({});
+  const handleSave = (
+    event: FormEvent<HTMLFormElement>,
+    actionType: string
+  ) => {
+    event.preventDefault();
 
-      request('POST', endpoint('/api/v1/tax_rates'), values)
+    if (!isFormBusy) {
+      toast.processing();
+      setIsFormBusy(true);
+
+      request('POST', endpoint('/api/v1/tax_rates'), taxRate)
         .then((response) => {
-          toast.success(t('created_tax_rate'));
+          toast.success('created_tax_rate');
 
-          queryClient.invalidateQueries('/api/v1/payment_terms');
+          queryClient.invalidateQueries('/api/v1/tax_rates');
 
-          navigate(
-            route('/settings/tax_rates/:id/edit', {
-              id: response.data.data.id,
-            })
-          );
+          if (actionType === 'save') {
+            navigate(
+              route('/settings/tax_rates/:id/edit', {
+                id: response.data.data.id,
+              })
+            );
+          } else {
+            if (blankTaxRate) {
+              setTaxRate(blankTaxRate);
+            }
+          }
         })
         .catch((error: AxiosError<ValidationBag>) => {
-          console.error(error);
-
-          error.response?.status === 422
-            ? setErrors(error.response.data)
-            : toast.error(t('error_title'));
+          if (error.response?.status === 422) {
+            toast.dismiss();
+            setErrors(error.response.data);
+          } else {
+            console.error(error);
+            toast.error();
+          }
         })
-        .finally(() => formik.setSubmitting(false));
+        .finally(() => setIsFormBusy(false));
+    }
+  };
+
+  const saveOptions: ButtonOption[] = [
+    {
+      onClick: (event: FormEvent<HTMLFormElement>) =>
+        handleSave(event, 'create'),
+      text: `${t('save')} / ${t('create')}`,
+      icon: <Icon element={BiPlusCircle} />,
     },
-  });
+  ];
+
+  useEffect(() => {
+    if (blankTaxRate) {
+      setTaxRate(blankTaxRate);
+    }
+  }, [blankTaxRate]);
 
   return (
     <Settings title={t('tax_rates')}>
@@ -81,28 +113,30 @@ export function Create() {
         <Breadcrumbs pages={pages} />
 
         <Card
+          title={documentTitle}
           withSaveButton
-          disableSubmitButton={formik.isSubmitting}
-          onFormSubmit={formik.handleSubmit}
-          title={t('create_tax_rate')}
+          disableSubmitButton={isFormBusy}
+          onFormSubmit={(event) => handleSave(event, 'save')}
+          onSaveClick={(event) => handleSave(event, 'save')}
+          additionalSaveOptions={saveOptions}
         >
           <CardContainer>
             <InputField
-              type="text"
-              id="name"
-              label={t('name')}
-              errorMessage={errors?.errors?.name}
-              onChange={formik.handleChange}
               required
+              type="text"
+              label={t('name')}
+              value={taxRate?.name}
+              onValueChange={(value) => handleChange('name', value)}
+              errorMessage={errors?.errors.name}
             />
 
             <InputField
-              type="text"
-              id="rate"
-              label={t('rate')}
-              errorMessage={errors?.errors?.rate}
-              onChange={formik.handleChange}
               required
+              type="text"
+              label={t('rate')}
+              value={taxRate?.rate}
+              onValueChange={(value) => handleChange('rate', Number(value))}
+              errorMessage={errors?.errors.rate}
             />
           </CardContainer>
         </Card>

--- a/src/pages/settings/tax-rates/common/hooks/useHandleChange.tsx
+++ b/src/pages/settings/tax-rates/common/hooks/useHandleChange.tsx
@@ -1,0 +1,34 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { TaxRate } from 'common/interfaces/tax-rate';
+import { ValidationBag } from 'common/interfaces/validation-bag';
+import { Dispatch, SetStateAction } from 'react';
+
+interface Params {
+  setTaxRate: Dispatch<SetStateAction<TaxRate | undefined>>;
+  setErrors: Dispatch<SetStateAction<ValidationBag | undefined>>;
+}
+
+export function useHandleChange(params: Params) {
+  const { setTaxRate, setErrors } = params;
+
+  return <T extends keyof TaxRate>(
+    property: T,
+    value: TaxRate[typeof property]
+  ) => {
+    setErrors(undefined);
+
+    setTaxRate(
+      (currentTaxRate) =>
+        currentTaxRate && { ...currentTaxRate, [property]: value }
+    );
+  };
+}


### PR DESCRIPTION
Here are screenshots of an implemented split submit button solution on the `Create Pages` page for Expense Categories, Tax Rates, and Payment Terms:

![Screenshot 2023-02-12 at 23 19 05](https://user-images.githubusercontent.com/51542191/218341096-069981ba-15b1-4738-ae1b-42ac52687275.png)

![Screenshot 2023-02-12 at 23 19 20](https://user-images.githubusercontent.com/51542191/218341107-d4933734-ec8b-4385-aec7-dbc20a11b85b.png)

![Screenshot 2023-02-12 at 23 19 34](https://user-images.githubusercontent.com/51542191/218341119-efcaf8b2-7491-4ffb-b604-6a4b73b3dedd.png)

@beganovich @turbo124 Besides the functionality of implementing this additional action button, here is the refactoring of the code to be consistent with the rest of the project and easier handling of the additional features in future.