### PR TITLE
[Bugfix] Create Bank Account - Permission handling - Invoice Design Optional Chaining

### DIFF
--- a/src/pages/settings/bank-accounts/create/Create.tsx
+++ b/src/pages/settings/bank-accounts/create/Create.tsx
@@ -11,6 +11,7 @@
 import { Card, Element } from '@invoiceninja/cards';
 import { InputField } from '@invoiceninja/forms';
 import { enterprisePlan } from 'common/guards/guards/enterprise-plan';
+import { proPlan } from 'common/guards/guards/pro-plan';
 import { isHosted } from 'common/helpers';
 import { useTitle } from 'common/hooks/useTitle';
 import { BankAccount } from 'common/interfaces/bank-accounts';
@@ -67,7 +68,7 @@ export function Create() {
       title={t('new_bank_account')}
       breadcrumbs={pages}
       docsLink="docs/basic-settings/#create_bank_account"
-      disableSaveButton={!enterprisePlan() && isHosted()}
+      disableSaveButton={!enterprisePlan() && !proPlan() && isHosted()}
       onSaveClick={handleSave}
     >
       <Card onFormSubmit={handleSave} title={t('new_bank_account')}>

--- a/src/pages/settings/bank-accounts/create/Create.tsx
+++ b/src/pages/settings/bank-accounts/create/Create.tsx
@@ -10,6 +10,8 @@
 
 import { Card, Element } from '@invoiceninja/cards';
 import { InputField } from '@invoiceninja/forms';
+import { enterprisePlan } from 'common/guards/guards/enterprise-plan';
+import { isHosted } from 'common/helpers';
 import { useTitle } from 'common/hooks/useTitle';
 import { BankAccount } from 'common/interfaces/bank-accounts';
 import { ValidationBag } from 'common/interfaces/validation-bag';
@@ -65,6 +67,7 @@ export function Create() {
       title={t('new_bank_account')}
       breadcrumbs={pages}
       docsLink="docs/basic-settings/#create_bank_account"
+      disableSaveButton={!enterprisePlan() && isHosted()}
       onSaveClick={handleSave}
     >
       <Card onFormSubmit={handleSave} title={t('new_bank_account')}>

--- a/src/pages/settings/invoice-design/components/GeneralSettings.tsx
+++ b/src/pages/settings/invoice-design/components/GeneralSettings.tsx
@@ -987,7 +987,7 @@ export function GeneralSettings() {
           id="settings.page_numbering_alignment"
           onChange={handleChange}
           disabled={company?.settings?.page_numbering ? false : true}
-          value={company?.settings?.page_numbering_alignment.toString()}
+          value={company?.settings?.page_numbering_alignment?.toString()}
         >
           <option value="C">{t('center')}</option>
           <option value="R">{t('right')}</option>


### PR DESCRIPTION
@beganovich @turbo124 PR includes a bug fix on the invoice design page, just added optional chaining so they don't break the app if we don't have that property. The second part of the PR is to add a restriction to disable the create bank account button. So, if the user has a pro or enterprise plan, he will be able to create a bank account, otherwise the save button will be disabled.