### PR TITLE
[Cleanup] Empty columns - Helper text

### DIFF
--- a/src/pages/settings/invoice-design/components/GeneralSettings.tsx
+++ b/src/pages/settings/invoice-design/components/GeneralSettings.tsx
@@ -20,7 +20,7 @@ import { ChangeEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { Card, ClickableElement, Element } from '../../../../components/cards';
-import { SelectField } from '../../../../components/forms';
+import { Radio, SelectField } from '../../../../components/forms';
 import Toggle from '../../../../components/forms/Toggle';
 
 export function GeneralSettings() {
@@ -963,21 +963,20 @@ export function GeneralSettings() {
       <Divider />
 
       <Element leftSide={t('empty_columns')}>
-        <div className="flex items-center space-x-4">
-          <Toggle
-            checked={company?.settings?.hide_empty_columns_on_pdf}
-            id="settings.hide_empty_columns_on_pdf"
-            onChange={(value: boolean) =>
-              handleToggleChange('settings.hide_empty_columns_on_pdf', value)
-            }
-          />
-
-          <span>
-            {company?.settings.hide_empty_columns_on_pdf
-              ? t('hide')
-              : t('show')}
-          </span>
-        </div>
+        <Radio
+          name="empty_columns"
+          options={[
+            { id: 'hide', title: t('hide'), value: 'true' },
+            { id: 'show', title: t('show'), value: 'false' },
+          ]}
+          onValueChange={(value) =>
+            handleToggleChange(
+              'settings.hide_empty_columns_on_pdf',
+              value === 'true' ? true : false
+            )
+          }
+          defaultSelected={company?.settings?.hide_empty_columns_on_pdf?.toString()}
+        />
       </Element>
 
       <Element leftSide={t('page_numbering')}>

--- a/src/pages/settings/invoice-design/components/GeneralSettings.tsx
+++ b/src/pages/settings/invoice-design/components/GeneralSettings.tsx
@@ -963,13 +963,21 @@ export function GeneralSettings() {
       <Divider />
 
       <Element leftSide={t('empty_columns')}>
-        <Toggle
-          checked={company?.settings?.hide_empty_columns_on_pdf}
-          id="settings.hide_empty_columns_on_pdf"
-          onChange={(value: boolean) =>
-            handleToggleChange('settings.hide_empty_columns_on_pdf', value)
-          }
-        />
+        <div className="flex items-center space-x-4">
+          <Toggle
+            checked={company?.settings?.hide_empty_columns_on_pdf}
+            id="settings.hide_empty_columns_on_pdf"
+            onChange={(value: boolean) =>
+              handleToggleChange('settings.hide_empty_columns_on_pdf', value)
+            }
+          />
+
+          <span>
+            {company?.settings.hide_empty_columns_on_pdf
+              ? t('hide')
+              : t('show')}
+          </span>
+        </div>
       </Element>
 
       <Element leftSide={t('page_numbering')}>


### PR DESCRIPTION
Here is the screenshot with added helper text for `hide_empty_columns_on_pdf` company settings property:

![Screenshot 2023-02-14 at 00 59 32](https://user-images.githubusercontent.com/51542191/218602239-bbc1410d-9356-4dcb-948b-750aabad6c96.png)

@beganovich @turbo124 When property has set to true text should be Hide but when it is set to false, text should be Show. Let me know your thoughts.