### PR TITLE
[Bugfix] Translating custom label keyword

### DIFF
--- a/src/pages/settings/localization/components/CustomLabels.tsx
+++ b/src/pages/settings/localization/components/CustomLabels.tsx
@@ -97,7 +97,7 @@ export function CustomLabels() {
       (label) => label.property === property
     );
 
-    return possibleDefault ? possibleDefault.translation : property;
+    return possibleDefault ? possibleDefault.translation : t(property);
   };
 
   const handleSelectChange = (property: string): void => {


### PR DESCRIPTION
Here is the screenshot of updated UI for Localization page:

![Screenshot 2023-02-14 at 02 03 07](https://user-images.githubusercontent.com/51542191/218611339-3f65755b-28b9-4da3-87f0-fa1cd8fc6e29.png)

@turbo124 @beganovich Now, the left side (keyword for custom field) will be translated instead of just showing keyword on the UI.