### PR TITLE
[Cleanup] Overdue invoice status badge

### DIFF
--- a/src/pages/invoices/common/components/InvoiceStatus.tsx
+++ b/src/pages/invoices/common/components/InvoiceStatus.tsx
@@ -25,6 +25,9 @@ export function InvoiceStatus(props: Props) {
   if (props.entity.archived_at)
     return <Badge variant="orange">{t('archived')}</Badge>;
 
+  if (props.entity.due_date && new Date(props.entity.due_date) < new Date())
+    return <Badge variant="yellow">{t('overdue')}</Badge>;
+
   switch (props.entity.status_id) {
     case '1':
       return <Badge variant="generic">{t('draft')}</Badge>;
@@ -41,8 +44,5 @@ export function InvoiceStatus(props: Props) {
 
     default:
       return <Badge variant="light-blue">{t('reversed')}</Badge>;
-      break;
   }
-
-  return <></>;
 }

--- a/src/pages/invoices/common/hooks/useInvoiceFilters.ts
+++ b/src/pages/invoices/common/hooks/useInvoiceFilters.ts
@@ -37,7 +37,7 @@ export function useInvoiceFilters() {
       label: t('overdue'),
       value: 'overdue',
       color: 'white',
-      backgroundColor: '#93C5FD',
+      backgroundColor: '#CA8A04',
     },
   ];
 


### PR DESCRIPTION
Here is the screenshot with added overdue status badge added to invoice entity:

![Screenshot 2023-02-14 at 16 45 30](https://user-images.githubusercontent.com/51542191/218788335-ae4d5d9d-c117-445c-8c3b-675278abbfa2.png)

@turbo124 If you look at the screenshot, you can notice that even if I selected the `overdue` status, it included one invoice for me that has a date less than the current date. The conditiion looks like this:

`if (props.entity.due_date && new Date(props.entity.due_date) < new Date())`

Please let know if I missed anything in this condition, maybe I have to take a look into date value?

Let me know your thoughts.