### PR TITLE
[Cleanup] Link To GitHub - Variables

### DIFF
--- a/src/pages/settings/generated-numbers/clients/Clients.tsx
+++ b/src/pages/settings/generated-numbers/clients/Clients.tsx
@@ -18,6 +18,8 @@ import { useDispatch } from 'react-redux';
 import { useCompanyChanges } from 'common/hooks/useCompanyChanges';
 import { ChangeEvent } from 'react';
 import { CopyToClipboard } from 'components/CopyToClipboard';
+import { Divider } from 'components/cards/Divider';
+import { LinkToVariables } from '../common/components/LinkToVariables';
 
 export function Clients() {
   const [t] = useTranslation();
@@ -68,16 +70,20 @@ export function Clients() {
         />
       </Element>
 
-      <Card>
-        {variables.map((item, index) => (
-          <ClickableElement
-            onClick={() => setPattern(pattern + item)}
-            key={index}
-          >
-            <CopyToClipboard text={item} />
-          </ClickableElement>
-        ))}
-      </Card>
+      <Divider />
+
+      {variables.map((item, index) => (
+        <ClickableElement
+          onClick={() => setPattern(pattern + item)}
+          key={index}
+        >
+          <CopyToClipboard text={item} />
+        </ClickableElement>
+      ))}
+
+      <Divider />
+
+      <LinkToVariables />
     </Card>
   );
 }

--- a/src/pages/settings/generated-numbers/common/components/LinkToVariables.tsx
+++ b/src/pages/settings/generated-numbers/common/components/LinkToVariables.tsx
@@ -1,0 +1,26 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { Link } from '@invoiceninja/forms';
+import { useTranslation } from 'react-i18next';
+
+export function LinkToVariables() {
+  const [t] = useTranslation();
+
+  return (
+    <Link
+      className="pl-6"
+      to="https://invoiceninja.github.io/docs/custom-fields/#custom-fields"
+      external
+    >
+      {t('click_to_variables')}
+    </Link>
+  );
+}

--- a/src/pages/settings/generated-numbers/credits/Credits.tsx
+++ b/src/pages/settings/generated-numbers/credits/Credits.tsx
@@ -18,6 +18,8 @@ import { useDispatch } from 'react-redux';
 import { useCompanyChanges } from 'common/hooks/useCompanyChanges';
 import { ChangeEvent } from 'react';
 import { CopyToClipboard } from 'components/CopyToClipboard';
+import { Divider } from 'components/cards/Divider';
+import { LinkToVariables } from '../common/components/LinkToVariables';
 
 export function Credits() {
   const [t] = useTranslation();
@@ -66,16 +68,20 @@ export function Credits() {
         />
       </Element>
 
-      <Card>
-        {variables.map((item, index) => (
-          <ClickableElement
-            onClick={() => setPattern(pattern + item)}
-            key={index}
-          >
-            <CopyToClipboard text={item} />
-          </ClickableElement>
-        ))}
-      </Card>
+      <Divider />
+
+      {variables.map((item, index) => (
+        <ClickableElement
+          onClick={() => setPattern(pattern + item)}
+          key={index}
+        >
+          <CopyToClipboard text={item} />
+        </ClickableElement>
+      ))}
+
+      <Divider />
+
+      <LinkToVariables />
     </Card>
   );
 }

--- a/src/pages/settings/generated-numbers/expenses/Expenses.tsx
+++ b/src/pages/settings/generated-numbers/expenses/Expenses.tsx
@@ -18,6 +18,8 @@ import { useDispatch } from 'react-redux';
 import { useCompanyChanges } from 'common/hooks/useCompanyChanges';
 import { ChangeEvent } from 'react';
 import { CopyToClipboard } from 'components/CopyToClipboard';
+import { Divider } from 'components/cards/Divider';
+import { LinkToVariables } from '../common/components/LinkToVariables';
 
 export function Expenses() {
   const [t] = useTranslation();
@@ -66,16 +68,20 @@ export function Expenses() {
         />
       </Element>
 
-      <Card>
-        {variables.map((item, index) => (
-          <ClickableElement
-            onClick={() => setPattern(pattern + item)}
-            key={index}
-          >
-            <CopyToClipboard text={item} />
-          </ClickableElement>
-        ))}
-      </Card>
+      <Divider />
+
+      {variables.map((item, index) => (
+        <ClickableElement
+          onClick={() => setPattern(pattern + item)}
+          key={index}
+        >
+          <CopyToClipboard text={item} />
+        </ClickableElement>
+      ))}
+
+      <Divider />
+
+      <LinkToVariables />
     </Card>
   );
 }

--- a/src/pages/settings/generated-numbers/invoices/Invoices.tsx
+++ b/src/pages/settings/generated-numbers/invoices/Invoices.tsx
@@ -11,12 +11,14 @@
 import { useCompanyChanges } from 'common/hooks/useCompanyChanges';
 import { useInjectCompanyChanges } from 'common/hooks/useInjectCompanyChanges';
 import { updateChanges } from 'common/stores/slices/company-users';
+import { Divider } from 'components/cards/Divider';
 import { CopyToClipboard } from 'components/CopyToClipboard';
 import React, { ChangeEvent, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { Card, ClickableElement, Element } from '../../../../components/cards';
 import { InputField } from '../../../../components/forms';
+import { LinkToVariables } from '../common/components/LinkToVariables';
 
 export function Invoices() {
   const [t] = useTranslation();
@@ -66,16 +68,20 @@ export function Invoices() {
         />
       </Element>
 
-      <Card>
-        {variables.map((item, index) => (
-          <ClickableElement
-            onClick={() => setPattern(pattern + item)}
-            key={index}
-          >
-            <CopyToClipboard text={item} />
-          </ClickableElement>
-        ))}
-      </Card>
+      <Divider />
+
+      {variables.map((item, index) => (
+        <ClickableElement
+          onClick={() => setPattern(pattern + item)}
+          key={index}
+        >
+          <CopyToClipboard text={item} />
+        </ClickableElement>
+      ))}
+
+      <Divider />
+
+      <LinkToVariables />
     </Card>
   );
 }

--- a/src/pages/settings/generated-numbers/payments/Payments.tsx
+++ b/src/pages/settings/generated-numbers/payments/Payments.tsx
@@ -18,6 +18,8 @@ import { useDispatch } from 'react-redux';
 import { useCompanyChanges } from 'common/hooks/useCompanyChanges';
 import { ChangeEvent } from 'react';
 import { CopyToClipboard } from 'components/CopyToClipboard';
+import { Divider } from 'components/cards/Divider';
+import { LinkToVariables } from '../common/components/LinkToVariables';
 
 export function Payments() {
   const [t] = useTranslation();
@@ -67,16 +69,20 @@ export function Payments() {
         />
       </Element>
 
-      <Card>
-        {variables.map((item, index) => (
-          <ClickableElement
-            onClick={() => setPattern(pattern + item)}
-            key={index}
-          >
-            <CopyToClipboard text={item} />
-          </ClickableElement>
-        ))}
-      </Card>
+      <Divider />
+
+      {variables.map((item, index) => (
+        <ClickableElement
+          onClick={() => setPattern(pattern + item)}
+          key={index}
+        >
+          <CopyToClipboard text={item} />
+        </ClickableElement>
+      ))}
+
+      <Divider />
+
+      <LinkToVariables />
     </Card>
   );
 }

--- a/src/pages/settings/generated-numbers/projects/Projects.tsx
+++ b/src/pages/settings/generated-numbers/projects/Projects.tsx
@@ -18,6 +18,8 @@ import { useDispatch } from 'react-redux';
 import { useCompanyChanges } from 'common/hooks/useCompanyChanges';
 import { ChangeEvent } from 'react';
 import { CopyToClipboard } from 'components/CopyToClipboard';
+import { Divider } from 'components/cards/Divider';
+import { LinkToVariables } from '../common/components/LinkToVariables';
 
 export function Projects() {
   const [t] = useTranslation();
@@ -66,16 +68,20 @@ export function Projects() {
         />
       </Element>
 
-      <Card>
-        {variables.map((item, index) => (
-          <ClickableElement
-            onClick={() => setPattern(pattern + item)}
-            key={index}
-          >
-            <CopyToClipboard text={item} />
-          </ClickableElement>
-        ))}
-      </Card>
+      <Divider />
+
+      {variables.map((item, index) => (
+        <ClickableElement
+          onClick={() => setPattern(pattern + item)}
+          key={index}
+        >
+          <CopyToClipboard text={item} />
+        </ClickableElement>
+      ))}
+
+      <Divider />
+
+      <LinkToVariables />
     </Card>
   );
 }

--- a/src/pages/settings/generated-numbers/purchase-orders/PurchaseOrders.tsx
+++ b/src/pages/settings/generated-numbers/purchase-orders/PurchaseOrders.tsx
@@ -18,6 +18,8 @@ import { useDispatch } from 'react-redux';
 import { useCompanyChanges } from 'common/hooks/useCompanyChanges';
 import { ChangeEvent } from 'react';
 import { CopyToClipboard } from 'components/CopyToClipboard';
+import { Divider } from 'components/cards/Divider';
+import { LinkToVariables } from '../common/components/LinkToVariables';
 
 export function PurchaseOrders() {
   const [t] = useTranslation();
@@ -66,16 +68,20 @@ export function PurchaseOrders() {
         />
       </Element>
 
-      <Card>
-        {variables.map((item, index) => (
-          <ClickableElement
-            onClick={() => setPattern(pattern + item)}
-            key={index}
-          >
-            <CopyToClipboard text={item} />
-          </ClickableElement>
-        ))}
-      </Card>
+      <Divider />
+
+      {variables.map((item, index) => (
+        <ClickableElement
+          onClick={() => setPattern(pattern + item)}
+          key={index}
+        >
+          <CopyToClipboard text={item} />
+        </ClickableElement>
+      ))}
+
+      <Divider />
+
+      <LinkToVariables />
     </Card>
   );
 }

--- a/src/pages/settings/generated-numbers/quotes/Quotes.tsx
+++ b/src/pages/settings/generated-numbers/quotes/Quotes.tsx
@@ -18,6 +18,8 @@ import { useDispatch } from 'react-redux';
 import { useCompanyChanges } from 'common/hooks/useCompanyChanges';
 import { ChangeEvent } from 'react';
 import { CopyToClipboard } from 'components/CopyToClipboard';
+import { Divider } from 'components/cards/Divider';
+import { LinkToVariables } from '../common/components/LinkToVariables';
 
 export function Quotes() {
   const [t] = useTranslation();
@@ -66,16 +68,20 @@ export function Quotes() {
         />
       </Element>
 
-      <Card>
-        {variables.map((item, index) => (
-          <ClickableElement
-            onClick={() => setPattern(pattern + item)}
-            key={index}
-          >
-            <CopyToClipboard text={item} />
-          </ClickableElement>
-        ))}
-      </Card>
+      <Divider />
+
+      {variables.map((item, index) => (
+        <ClickableElement
+          onClick={() => setPattern(pattern + item)}
+          key={index}
+        >
+          <CopyToClipboard text={item} />
+        </ClickableElement>
+      ))}
+
+      <Divider />
+
+      <LinkToVariables />
     </Card>
   );
 }

--- a/src/pages/settings/generated-numbers/recurring-expenses/RecurringExpenses.tsx
+++ b/src/pages/settings/generated-numbers/recurring-expenses/RecurringExpenses.tsx
@@ -18,6 +18,8 @@ import { useDispatch } from 'react-redux';
 import { useCompanyChanges } from 'common/hooks/useCompanyChanges';
 import { ChangeEvent } from 'react';
 import { CopyToClipboard } from 'components/CopyToClipboard';
+import { Divider } from 'components/cards/Divider';
+import { LinkToVariables } from '../common/components/LinkToVariables';
 
 export function RecurringExpenses() {
   const [t] = useTranslation();
@@ -66,16 +68,20 @@ export function RecurringExpenses() {
         />
       </Element>
 
-      <Card>
-        {variables.map((item, index) => (
-          <ClickableElement
-            onClick={() => setPattern(pattern + item)}
-            key={index}
-          >
-            <CopyToClipboard text={item} />
-          </ClickableElement>
-        ))}
-      </Card>
+      <Divider />
+
+      {variables.map((item, index) => (
+        <ClickableElement
+          onClick={() => setPattern(pattern + item)}
+          key={index}
+        >
+          <CopyToClipboard text={item} />
+        </ClickableElement>
+      ))}
+
+      <Divider />
+
+      <LinkToVariables />
     </Card>
   );
 }

--- a/src/pages/settings/generated-numbers/recurring-invoices/RecurringInvoices.tsx
+++ b/src/pages/settings/generated-numbers/recurring-invoices/RecurringInvoices.tsx
@@ -18,6 +18,8 @@ import { useDispatch } from 'react-redux';
 import { useCompanyChanges } from 'common/hooks/useCompanyChanges';
 import { ChangeEvent } from 'react';
 import { CopyToClipboard } from 'components/CopyToClipboard';
+import { Divider } from 'components/cards/Divider';
+import { LinkToVariables } from '../common/components/LinkToVariables';
 
 export function RecurringInvoices() {
   const [t] = useTranslation();
@@ -67,16 +69,20 @@ export function RecurringInvoices() {
         />
       </Element>
 
-      <Card>
-        {variables.map((item, index) => (
-          <ClickableElement
-            onClick={() => setPattern(pattern + item)}
-            key={index}
-          >
-            <CopyToClipboard text={item} />
-          </ClickableElement>
-        ))}
-      </Card>
+      <Divider />
+
+      {variables.map((item, index) => (
+        <ClickableElement
+          onClick={() => setPattern(pattern + item)}
+          key={index}
+        >
+          <CopyToClipboard text={item} />
+        </ClickableElement>
+      ))}
+
+      <Divider />
+
+      <LinkToVariables />
     </Card>
   );
 }

--- a/src/pages/settings/generated-numbers/tasks/Tasks.tsx
+++ b/src/pages/settings/generated-numbers/tasks/Tasks.tsx
@@ -18,6 +18,8 @@ import { useDispatch } from 'react-redux';
 import { useCompanyChanges } from 'common/hooks/useCompanyChanges';
 import { ChangeEvent } from 'react';
 import { CopyToClipboard } from 'components/CopyToClipboard';
+import { Divider } from 'components/cards/Divider';
+import { LinkToVariables } from '../common/components/LinkToVariables';
 
 export function Tasks() {
   const [t] = useTranslation();
@@ -66,16 +68,20 @@ export function Tasks() {
         />
       </Element>
 
-      <Card>
-        {variables.map((item, index) => (
-          <ClickableElement
-            onClick={() => setPattern(pattern + item)}
-            key={index}
-          >
-            <CopyToClipboard text={item} />
-          </ClickableElement>
-        ))}
-      </Card>
+      <Divider />
+
+      {variables.map((item, index) => (
+        <ClickableElement
+          onClick={() => setPattern(pattern + item)}
+          key={index}
+        >
+          <CopyToClipboard text={item} />
+        </ClickableElement>
+      ))}
+
+      <Divider />
+
+      <LinkToVariables />
     </Card>
   );
 }

--- a/src/pages/settings/generated-numbers/vendors/Vendors.tsx
+++ b/src/pages/settings/generated-numbers/vendors/Vendors.tsx
@@ -18,6 +18,8 @@ import { useDispatch } from 'react-redux';
 import { useCompanyChanges } from 'common/hooks/useCompanyChanges';
 import { ChangeEvent } from 'react';
 import { CopyToClipboard } from 'components/CopyToClipboard';
+import { Divider } from 'components/cards/Divider';
+import { LinkToVariables } from '../common/components/LinkToVariables';
 
 export function Vendors() {
   const [t] = useTranslation();
@@ -66,16 +68,20 @@ export function Vendors() {
         />
       </Element>
 
-      <Card>
-        {variables.map((item, index) => (
-          <ClickableElement
-            onClick={() => setPattern(pattern + item)}
-            key={index}
-          >
-            <CopyToClipboard text={item} />
-          </ClickableElement>
-        ))}
-      </Card>
+      <Divider />
+
+      {variables.map((item, index) => (
+        <ClickableElement
+          onClick={() => setPattern(pattern + item)}
+          key={index}
+        >
+          <CopyToClipboard text={item} />
+        </ClickableElement>
+      ))}
+
+      <Divider />
+
+      <LinkToVariables />
     </Card>
   );
 }


### PR DESCRIPTION
Here's a screenshot of the current UI for the Generated Numbers tabs:

<img width="1262" alt="Screenshot 2023-02-17 at 15 35 42" src="https://user-images.githubusercontent.com/51542191/219692663-40369813-6528-48af-95a2-c61ba0862f4f.png">

@turbo124 The plain text on the screenshot has been replaced with `click_to_variables` translation keyword. If you agree with me, please just add it to translation files.

@beganovich Just to mention, we had one unnecessary card component nested on all the cards. IMO it made the bottom of each card look a little weird. So, I removed them and set Dividers. IMO, it looks better now.

Let me your thoughts.