### PR TITLE
[Feature] mark_paid_payment_email company settings property

### DIFF
--- a/src/pages/settings/company/components/Defaults.tsx
+++ b/src/pages/settings/company/components/Defaults.tsx
@@ -120,6 +120,26 @@ export function Defaults() {
           </Element>
 
           <Element
+            leftSide={t('mark_paid_payment_email')}
+            leftSideHelp={t('mark_paid_payment_email_help')}
+          >
+            <Toggle
+              checked={
+                companyChanges?.settings?.mark_paid_payment_email || false
+              }
+              onChange={(value: boolean) =>
+                dispatch(
+                  updateChanges({
+                    object: 'company',
+                    property: 'settings.mark_paid_payment_email',
+                    value,
+                  })
+                )
+              }
+            />
+          </Element>
+
+          <Element
             leftSide={t('use_quote_terms')}
             leftSideHelp={t('use_quote_terms_help')}
           >


### PR DESCRIPTION
Here is the screenshot of UI with added field for handling `mark_paid_payment_email` property:

<img width="1261" alt="Screenshot 2023-02-19 at 12 38 54" src="https://user-images.githubusercontent.com/51542191/219945702-83fe819c-bc61-4bd5-8011-e8b0185af62a.png">

@beganovich @turbo124 Let me know your thoughts.