### PR TITLE
[Feature] show_email_footer email settings property

### DIFF
--- a/src/common/interfaces/company.interface.ts
+++ b/src/common/interfaces/company.interface.ts
@@ -61,6 +61,7 @@ export interface Settings {
   military_time: boolean;
   language_id: string;
   show_currency_code: boolean;
+  show_email_footer: boolean;
   company_gateway_ids: string;
   currency_id: string;
   custom_value1: string;

--- a/src/pages/settings/email-settings/EmailSettings.tsx
+++ b/src/pages/settings/email-settings/EmailSettings.tsx
@@ -44,6 +44,8 @@ export function EmailSettings() {
 
   const showPlanAlert = useShouldDisableAdvanceSettings();
 
+  console.log(company);
+
   return (
     <Settings
       title={t('email_settings')}
@@ -56,6 +58,15 @@ export function EmailSettings() {
       {showPlanAlert && <AdvancedSettingsPlanAlert />}
 
       <Card title={t('settings')}>
+        <Element leftSide={t('show_email_footer')}>
+          <Toggle
+            checked={company?.settings.show_email_footer}
+            onValueChange={(value) =>
+              handleChange('settings.show_email_footer', value)
+            }
+          />
+        </Element>
+
         <Element leftSide={t('attach_pdf')}>
           <Toggle
             checked={company?.settings.pdf_email_attachment}

--- a/src/pages/settings/email-settings/EmailSettings.tsx
+++ b/src/pages/settings/email-settings/EmailSettings.tsx
@@ -44,8 +44,6 @@ export function EmailSettings() {
 
   const showPlanAlert = useShouldDisableAdvanceSettings();
 
-  console.log(company);
-
   return (
     <Settings
       title={t('email_settings')}


### PR DESCRIPTION
Here is the screenshot of UI after implemented field for handling `show_email_footer` email settings property:

<img width="1262" alt="Screenshot 2023-02-19 at 12 48 59" src="https://user-images.githubusercontent.com/51542191/219946577-dd7c07f3-599b-4a27-902c-c56a7e10cf1d.png">

@beganovich @turbo124 Let me know your thoughts.