### PR TITLE
[Feature] Postmark / Mailgun - Email providers

### DIFF
--- a/src/common/interfaces/company.interface.ts
+++ b/src/common/interfaces/company.interface.ts
@@ -109,6 +109,9 @@ export interface Settings {
   payment_number_counter: number;
   project_number_pattern: string;
   project_number_counter: number;
+  postmark_secret: string;
+  mailgun_secret: string;
+  mailgun_domain: string;
   purchase_order_number_pattern: string;
   purchase_order_number_counter: number;
   shared_invoice_quote_counter: boolean;

--- a/src/pages/settings/email-settings/EmailSettings.tsx
+++ b/src/pages/settings/email-settings/EmailSettings.tsx
@@ -104,10 +104,10 @@ export function EmailSettings() {
             <option defaultChecked value="default">
               {t('default')}
             </option>
-            <option value="gmail">{t('gmail')}</option>
-            <option value="microsoft">{t('microsoft')}</option>
-            <option value="client_postmark">{t('postmark')}</option>
-            <option value="client_mailgun">{t('mailgun')}</option>
+            <option value="gmail">Gmail</option>
+            <option value="microsoft">Microsoft</option>
+            <option value="client_postmark">Postmark</option>
+            <option value="client_mailgun">Mailgun</option>
           </SelectField>
         </Element>
 

--- a/src/pages/settings/email-settings/EmailSettings.tsx
+++ b/src/pages/settings/email-settings/EmailSettings.tsx
@@ -85,6 +85,56 @@ export function EmailSettings() {
 
         <Divider />
 
+        <Element leftSide={t('email_provider')}>
+          <SelectField
+            value={company?.settings.email_sending_method}
+            onValueChange={(value) =>
+              handleChange('settings.email_sending_method', value)
+            }
+          >
+            <option defaultChecked value="default">
+              {t('default')}
+            </option>
+            <option value="gmail">{t('gmail')}</option>
+            <option value="microsoft">{t('microsoft')}</option>
+            <option value="client_postmark">{t('postmark')}</option>
+            <option value="client_mailgun">{t('mailgun')}</option>
+          </SelectField>
+        </Element>
+
+        {company?.settings.email_sending_method === 'client_postmark' && (
+          <Element leftSide={t('secret')}>
+            <InputField
+              value={company?.settings.postmark_secret}
+              onValueChange={(value) =>
+                handleChange('settings.postmark_secret', value)
+              }
+            />
+          </Element>
+        )}
+
+        {company?.settings.email_sending_method === 'client_mailgun' && (
+          <>
+            <Element leftSide={t('secret')}>
+              <InputField
+                value={company?.settings.mailgun_secret}
+                onValueChange={(value) =>
+                  handleChange('settings.mailgun_secret', value)
+                }
+              />
+            </Element>
+
+            <Element leftSide={t('domain')}>
+              <InputField
+                value={company?.settings.mailgun_domain}
+                onValueChange={(value) =>
+                  handleChange('settings.mailgun_domain', value)
+                }
+              />
+            </Element>
+          </>
+        )}
+
         <Element leftSide={t('from_name')}>
           <InputField
             value={company?.settings.email_from_name}


### PR DESCRIPTION
Here is the screenshot of implemented solution for email providers (Postmark and Mailgun):

![Screenshot 2023-02-20 at 17 34 13](https://user-images.githubusercontent.com/51542191/220161128-29b138c0-618d-4613-977f-f80b331f2879.png)

@beganovich @turbo124 I just noticed one thing that we don't have `gmail` as a translated keyword, but `microsoft` was in the translation files. Should we have `gmail` and `microsoft` as translated keywords or can we put it as `plain text`. 

Also, David mentioned in the ticket that this should only be possible for Pro/Enterprise plans. The entire page (Email Settings) is available for saving only if the user has one of those plans. That covers that part.

Let me know your thoughts.