### PR TITLE
[Bugfix] Remaining Cycles - Completed Recurring Expense Status

### DIFF
--- a/src/pages/recurring-expenses/common/components/RecurringExpenseStatus.tsx
+++ b/src/pages/recurring-expenses/common/components/RecurringExpenseStatus.tsx
@@ -21,13 +21,15 @@ interface Props {
 export function RecurringExpenseStatus(props: Props) {
   const [t] = useTranslation();
 
-  if (props.recurringExpense.remaining_cycles === 0)
+  const { recurringExpense } = props;
+
+  if (recurringExpense.remaining_cycles === 0)
     return <Badge variant="green">{t('completed')}</Badge>;
 
   return (
     <StatusBadge
       for={recurringExpenseStatus}
-      code={props.recurringExpense.status_id}
+      code={recurringExpense.status_id}
     />
   );
 }

--- a/src/pages/recurring-expenses/common/components/RecurringExpenseStatus.tsx
+++ b/src/pages/recurring-expenses/common/components/RecurringExpenseStatus.tsx
@@ -1,0 +1,33 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { Badge } from 'components/Badge';
+import { useTranslation } from 'react-i18next';
+import { StatusBadge } from 'components/StatusBadge';
+import recurringExpenseStatus from 'common/constants/recurring-expense';
+import { RecurringExpense } from 'common/interfaces/recurring-expense';
+
+interface Props {
+  recurringExpense: RecurringExpense;
+}
+
+export function RecurringExpenseStatus(props: Props) {
+  const [t] = useTranslation();
+
+  if (props.recurringExpense.remaining_cycles === 0)
+    return <Badge variant="green">{t('completed')}</Badge>;
+
+  return (
+    <StatusBadge
+      for={recurringExpenseStatus}
+      code={props.recurringExpense.status_id}
+    />
+  );
+}

--- a/src/pages/recurring-expenses/common/hooks.tsx
+++ b/src/pages/recurring-expenses/common/hooks.tsx
@@ -10,7 +10,6 @@
 
 import { Expense } from 'common/interfaces/expense';
 import { StatusBadge } from 'components/StatusBadge';
-import recurringExpenseStatus from 'common/constants/recurring-expense';
 import recurringExpensesFrequency from 'common/constants/recurring-expense-frequency';
 import { useTranslation } from 'react-i18next';
 import { date, endpoint } from 'common/helpers';
@@ -45,6 +44,7 @@ import {
   MdStopCircle,
 } from 'react-icons/md';
 import { invalidationQueryAtom } from 'common/atoms/data-table';
+import { RecurringExpenseStatus as RecurringExpenseStatusBadge } from './components/RecurringExpenseStatus';
 
 export const recurringExpenseColumns = [
   'status',
@@ -129,7 +129,7 @@ export function useRecurringExpenseColumns() {
             id: recurringExpense.id,
           })}
         >
-          <StatusBadge for={recurringExpenseStatus} code={value} />
+          <RecurringExpenseStatusBadge recurringExpense={recurringExpense} />
         </Link>
       ),
     },


### PR DESCRIPTION
Here is the screenshot of UI when `completed` status for recurring expense has been added:

![Screenshot 2023-02-20 at 18 52 51](https://user-images.githubusercontent.com/51542191/220173985-fd96f62e-6e92-47b4-ae3f-d1c336f7517c.png)

@beganovich @turbo124 So, when we have `remaining_cycles === 0` this status badge will be shown. Let me know your thoughts.