### PR TITLE
[Cleanup] Project pages 422 errors / Selector components error message

### DIFF
--- a/src/components/clients/ClientSelector.tsx
+++ b/src/components/clients/ClientSelector.tsx
@@ -54,6 +54,7 @@ export function ClientSelector(props: ClientSelectorProps) {
         exclude={props.exclude}
         staleTime={props.staleTime || 500}
         disableWithSpinner={props.disableWithSpinner}
+        errorMessage={props.errorMessage}
       />
     </>
   );

--- a/src/components/expense-categories/ExpenseCategorySelector.tsx
+++ b/src/components/expense-categories/ExpenseCategorySelector.tsx
@@ -58,6 +58,7 @@ export function ExpenseCategorySelector(props: ExpenseCategorySelectorProps) {
           onActionClick={() => setIsModalOpen(true)}
           sortBy="name|asc"
           staleTime={props.staleTime}
+          errorMessage={props.errorMessage}
         />
       )}
     </>

--- a/src/components/products/ProductSelector.tsx
+++ b/src/components/products/ProductSelector.tsx
@@ -22,6 +22,7 @@ interface Props {
   onClearButtonClick?: () => unknown;
   onProductCreated?: (product: Product) => unknown;
   onInputFocus?: () => unknown;
+  errorMessage?: string | string[];
 }
 
 export function ProductSelector(props: Props) {
@@ -45,6 +46,7 @@ export function ProductSelector(props: Props) {
         onInputFocus={props.onInputFocus}
         sortBy="product_key|asc"
         withShadowRecord
+        errorMessage={props.errorMessage}
       />
 
       <ProductCreate

--- a/src/components/projects/ProjectSelector.tsx
+++ b/src/components/projects/ProjectSelector.tsx
@@ -41,6 +41,7 @@ export function ProjectSelector(props: GenericSelectorProps<Project>) {
         queryAdditional
         actionLabel={t('new_project')}
         onActionClick={() => setIsModalOpen(true)}
+        errorMessage={props.errorMessage}
       />
     </>
   );

--- a/src/components/users/UserSelector.tsx
+++ b/src/components/users/UserSelector.tsx
@@ -34,6 +34,7 @@ export function UserSelector(props: GenericSelectorProps<User>) {
       queryAdditional
       actionLabel={t('new_user')}
       onActionClick={() => navigate('/settings/users')}
+      errorMessage={props.errorMessage}
     />
   );
 }

--- a/src/components/vendors/VendorSelector.tsx
+++ b/src/components/vendors/VendorSelector.tsx
@@ -55,6 +55,7 @@ export function VendorSelector(props: VendorSelectorProps) {
           onActionClick={() => setIsModalOpen(true)}
           sortBy="name|asc"
           staleTime={props.staleTime}
+          errorMessage={props.errorMessage}
         />
       )}
     </>


### PR DESCRIPTION
Here is the screenshot of updated UI for project pages when error message is correctly mapped:

<img width="1261" alt="Screenshot 2023-02-20 at 20 08 16" src="https://user-images.githubusercontent.com/51542191/220183221-2facb7bd-21e6-4cc5-81f3-dac0c59589ba.png">

@turbo124 @beganovich Actually, we have correctly added the error messages to the components, but only some custom selector components do not have error message prop mapped. I just fixed it and it works as it should. In one of the previous tickets, I made sure that all components add error message props. Let me know your thoughts.