### PR TITLE
[Feature] Payment status filters

### DIFF
--- a/src/pages/payments/common/hooks/usePaymentFilters.tsx
+++ b/src/pages/payments/common/hooks/usePaymentFilters.tsx
@@ -1,0 +1,69 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { SelectOption } from 'components/datatables/Actions';
+import { useTranslation } from 'react-i18next';
+
+export function usePaymentFilters() {
+  const [t] = useTranslation();
+
+  const filters: SelectOption[] = [
+    {
+      label: t('all'),
+      value: 'all',
+      color: 'black',
+      backgroundColor: '#e4e4e4',
+    },
+    {
+      label: t('pending'),
+      value: 'pending',
+      color: 'white',
+      backgroundColor: '#6B7280',
+    },
+    {
+      label: t('voided'),
+      value: 'voided',
+      color: 'white',
+      backgroundColor: '#93C5FD',
+    },
+    {
+      label: t('failed'),
+      value: 'failed',
+      color: 'white',
+      backgroundColor: '#DC2626',
+    },
+    {
+      label: t('completed'),
+      value: 'completed',
+      color: 'white',
+      backgroundColor: '#22C55E',
+    },
+    {
+      label: t('partially_refunded'),
+      value: 'partially_refunded',
+      color: 'white',
+      backgroundColor: '#1D4ED8',
+    },
+    {
+      label: t('refunded'),
+      value: 'refunded',
+      color: 'white',
+      backgroundColor: '#6B7280',
+    },
+    {
+      label: t('unapplied'),
+      value: 'unapplied',
+      color: 'white',
+      backgroundColor: '#6B7280',
+    },
+  ];
+
+  return filters;
+}

--- a/src/pages/payments/index/Payments.tsx
+++ b/src/pages/payments/index/Payments.tsx
@@ -20,6 +20,7 @@ import {
 } from '../common/hooks/usePaymentColumns';
 import { DataTableColumnsPicker } from 'components/DataTableColumnsPicker';
 import { useActions } from '../common/hooks/useActions';
+import { usePaymentFilters } from '../common/hooks/usePaymentFilters';
 
 export function Payments() {
   useTitle('payments');
@@ -31,6 +32,8 @@ export function Payments() {
   const columns = usePaymentColumns();
 
   const actions = useActions();
+
+  const filters = usePaymentFilters();
 
   return (
     <Default
@@ -47,6 +50,9 @@ export function Payments() {
         linkToEdit="/payments/:id/edit"
         withResourcefulActions
         customActions={actions}
+        customFilters={filters}
+        customFilterQueryKey="client_status"
+        customFilterPlaceholder="status"
         leftSideChevrons={
           <DataTableColumnsPicker
             columns={paymentColumns as unknown as string[]}


### PR DESCRIPTION
Here is the screenshot of implemented payment status filters:

<img width="1512" alt="Screenshot 2023-02-23 at 14 37 50" src="https://user-images.githubusercontent.com/51542191/220924596-c39eb3b5-6250-4f8a-9d57-7f00d2cfa562.png">

@beganovich @turbo124 I used all statuses that are specified in the table and their colors just to match UI properly:

- pending
- voided
- failed
- completed
- partially_refunded
- refunded
- unapplied

I noticed that we don't have a `voided` status in the Flutter app and we don't have this keyword in the translation files. I think that this status is specified as `cancelled` in the Flutter app. So please give me your advice on this status.

Let me know your thoughts.