### PR TITLE
[Cleanup] Users endpoint - without query parameter

### DIFF
--- a/src/pages/settings/users/index/Users.tsx
+++ b/src/pages/settings/users/index/Users.tsx
@@ -15,9 +15,12 @@ import { DataTable, DataTableColumns } from 'components/DataTable';
 import { Settings } from 'components/layouts/Settings';
 import { useTranslation } from 'react-i18next';
 import { route } from 'common/helpers/route';
+import { useCurrentUser } from 'common/hooks/useCurrentUser';
 
 export function Users() {
   useTitle('user_management');
+
+  const currentUser = useCurrentUser();
 
   const [t] = useTranslation();
 
@@ -48,7 +51,9 @@ export function Users() {
       <DataTable
         resource="user"
         columns={columns}
-        endpoint="/api/v1/users"
+        endpoint={route('/api/v1/users?without=:userId', {
+          userId: currentUser?.id,
+        })}
         linkToCreate="/settings/users/create"
       />
     </Settings>


### PR DESCRIPTION
Here is the screenshot of UI when after including without query parameters to users endpoint:

<img width="1261" alt="Screenshot 2023-02-24 at 11 19 02" src="https://user-images.githubusercontent.com/51542191/221352424-2b62657d-4c68-4c8d-895d-315dfdf0855d.png">

@turbo124 @beganovich As you know, after logging into the account, we must have at least one user to display in this table. But, after including this query parameter, the currently logged in user will not be listed. Let me know your thoughts.