### PR TITLE
[Cleanup] Tooltips

### DIFF
--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -10,6 +10,7 @@
 
 import classNames from 'classnames';
 import { ReactElement, useEffect, useRef, useState } from 'react';
+import Tippy from '@tippyjs/react/headless';
 
 interface Props {
   children: ReactElement;
@@ -45,39 +46,45 @@ export function Tooltip(props: Props) {
 
   return (
     <div
-      className={classNames(`group ${props.className}`, {
+      className={classNames(`${props.className}`, {
         'max-w-sm': props.size === undefined || props.size === 'small',
         'max-w-md': props.size === 'regular',
         'max-w-xl': props.size === 'large',
       })}
     >
-      <div
-        ref={parentChildrenElement}
-        className={classNames('cursor-pointer', {
-          'truncate w-full': props.truncate,
-        })}
+      <Tippy
+        placement="top-start"
+        interactive={true}
+        render={() => (
+          <div className="flex flex-col items-center whitespace-normal">
+            <span
+              className={classNames(
+                'relative p-2 text-xs text-center text-white rounded-md bg-gray-500 break-all',
+                {
+                  'leading-1': includeLeading,
+                  'leading-none': !includeLeading,
+                }
+              )}
+              style={{ width: messageWidth }}
+            >
+              {props.message}
+            </span>
+
+            <div className="w-3 h-3 -mt-2 rotate-45 opacity-90 bg-gray-500"></div>
+          </div>
+        )}
       >
-        {props.children}
-      </div>
-
-      <div className="flex absolute z-50">
-        <div className="absolute bottom-0 flex-col items-center hidden mb-6 group-hover:flex">
-          <span
-            className={classNames(
-              'relative p-2 text-xs text-center text-white rounded-md bg-gray-500 whitespace-normal',
-              {
-                'leading-1': includeLeading,
-                'leading-none': !includeLeading,
-              }
-            )}
-            style={{ width: messageWidth }}
+        {
+          <div
+            ref={parentChildrenElement}
+            className={classNames('cursor-pointer', {
+              'truncate w-full': props.truncate,
+            })}
           >
-            {props.message}
-          </span>
-
-          <div className="w-3 h-3 -mt-2 rotate-45 opacity-90 bg-gray-500"></div>
-        </div>
-      </div>
+            {props.children}
+          </div>
+        }
+      </Tippy>
     </div>
   );
 }

--- a/src/pages/clients/common/hooks/useClientColumns.tsx
+++ b/src/pages/clients/common/hooks/useClientColumns.tsx
@@ -23,6 +23,7 @@ import { CopyToClipboard } from 'components/CopyToClipboard';
 import { customField } from 'components/CustomField';
 import { EntityStatus } from 'components/EntityStatus';
 import { Inline } from 'components/Inline';
+import { Tooltip } from 'components/Tooltip';
 import { DataTableColumnsExtended } from 'pages/invoices/common/hooks/useInvoiceColumns';
 import { useCallback } from 'react';
 import { ExternalLink } from 'react-feather';
@@ -291,13 +292,21 @@ export function useClientColumns() {
       column: 'private_notes',
       id: 'private_notes',
       label: t('private_notes'),
-      format: (value) => <span className="truncate">{value}</span>,
+      format: (value) => (
+        <Tooltip size="regular" truncate message={value as string}>
+          <span>{value}</span>
+        </Tooltip>
+      ),
     },
     {
       column: 'public_notes',
       id: 'public_notes',
       label: t('public_notes'),
-      format: (value) => <span className="truncate">{value}</span>,
+      format: (value) => (
+        <Tooltip size="regular" truncate message={value as string}>
+          <span>{value}</span>
+        </Tooltip>
+      ),
     },
     {
       column: 'state',

--- a/src/pages/credits/common/hooks.tsx
+++ b/src/pages/credits/common/hooks.tsx
@@ -71,6 +71,7 @@ import {
   MdPictureAsPdf,
   MdRestore,
 } from 'react-icons/md';
+import { Tooltip } from 'components/Tooltip';
 
 interface CreditUtilitiesProps {
   client?: Client;
@@ -482,7 +483,7 @@ export const creditColumns = [
   // 'vendor', @Todo: Need to fetch the relationship
 ] as const;
 
-type CreditColumns = (typeof creditColumns)[number];
+type CreditColumns = typeof creditColumns[number];
 
 export const defaultColumns: CreditColumns[] = [
   'status',
@@ -720,13 +721,21 @@ export function useCreditColumns() {
       column: 'private_notes',
       id: 'private_notes',
       label: t('private_notes'),
-      format: (value) => <span className="truncate">{value}</span>,
+      format: (value) => (
+        <Tooltip size="regular" truncate message={value as string}>
+          <span>{value}</span>
+        </Tooltip>
+      ),
     },
     {
       column: 'public_notes',
       id: 'public_notes',
       label: t('public_notes'),
-      format: (value) => <span className="truncate">{value}</span>,
+      format: (value) => (
+        <Tooltip size="regular" truncate message={value as string}>
+          <span>{value}</span>
+        </Tooltip>
+      ),
     },
     {
       column: 'tax_amount',

--- a/src/pages/expenses/common/hooks.tsx
+++ b/src/pages/expenses/common/hooks.tsx
@@ -26,6 +26,7 @@ import { EntityStatus } from 'components/EntityStatus';
 import { Icon } from 'components/icons/Icon';
 import { Action } from 'components/ResourceActions';
 import { StatusBadge } from 'components/StatusBadge';
+import { Tooltip } from 'components/Tooltip';
 import { useUpdateAtom } from 'jotai/utils';
 import { DataTableColumnsExtended } from 'pages/invoices/common/hooks/useInvoiceColumns';
 import { recurringExpenseAtom } from 'pages/recurring-expenses/common/atoms';
@@ -208,7 +209,11 @@ export function useExpenseColumns() {
       column: 'public_notes',
       id: 'public_notes',
       label: t('public_notes'),
-      format: (value) => <span className="truncate">{value}</span>,
+      format: (value) => (
+        <Tooltip size="regular" truncate message={value as string}>
+          <span>{value}</span>
+        </Tooltip>
+      ),
     },
     {
       column: 'entity_state',
@@ -306,7 +311,11 @@ export function useExpenseColumns() {
       column: 'private_notes',
       id: 'private_notes',
       label: t('private_notes'),
-      format: (value) => <span className="truncate">{value}</span>,
+      format: (value) => (
+        <Tooltip size="regular" truncate message={value as string}>
+          <span>{value}</span>
+        </Tooltip>
+      ),
     },
     {
       column: 'should_be_invoiced',

--- a/src/pages/invoices/common/hooks/useInvoiceColumns.tsx
+++ b/src/pages/invoices/common/hooks/useInvoiceColumns.tsx
@@ -23,6 +23,7 @@ import { CopyToClipboard } from 'components/CopyToClipboard';
 import { customField } from 'components/CustomField';
 import { DataTableColumns } from 'components/DataTable';
 import { EntityStatus } from 'components/EntityStatus';
+import { Tooltip } from 'components/Tooltip';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { InvoiceStatus } from '../components/InvoiceStatus';
@@ -357,13 +358,21 @@ export function useInvoiceColumns(): DataTableColumns<Invoice> {
       column: 'private_notes',
       id: 'private_notes',
       label: t('private_notes'),
-      format: (value) => <span className="truncate">{value}</span>,
+      format: (value) => (
+        <Tooltip size="regular" truncate message={value as string}>
+          <span>{value}</span>
+        </Tooltip>
+      ),
     },
     {
       column: 'public_notes',
       id: 'public_notes',
       label: t('public_notes'),
-      format: (value) => <span className="truncate">{value}</span>,
+      format: (value) => (
+        <Tooltip size="regular" truncate message={value as string}>
+          <span>{value}</span>
+        </Tooltip>
+      ),
     },
     {
       column: 'reminder1_sent',

--- a/src/pages/payments/common/hooks/usePaymentColumns.tsx
+++ b/src/pages/payments/common/hooks/usePaymentColumns.tsx
@@ -21,6 +21,7 @@ import { Payment } from 'common/interfaces/payment';
 import { customField } from 'components/CustomField';
 import { EntityStatus } from 'components/EntityStatus';
 import { StatusBadge } from 'components/StatusBadge';
+import { Tooltip } from 'components/Tooltip';
 import { DataTableColumnsExtended } from 'pages/invoices/common/hooks/useInvoiceColumns';
 import { useTranslation } from 'react-i18next';
 import { PaymentStatus } from '../components/PaymentStatus';
@@ -230,7 +231,11 @@ export function usePaymentColumns() {
       column: 'private_notes',
       id: 'private_notes',
       label: t('private_notes'),
-      format: (value) => <span className="truncate">{value}</span>,
+      format: (value) => (
+        <Tooltip size="regular" truncate message={value as string}>
+          <span>{value}</span>
+        </Tooltip>
+      ),
     },
     {
       column: 'refunded',

--- a/src/pages/projects/common/hooks.tsx
+++ b/src/pages/projects/common/hooks.tsx
@@ -22,6 +22,7 @@ import { customField } from 'components/CustomField';
 import { DropdownElement } from 'components/dropdown/DropdownElement';
 import { EntityStatus } from 'components/EntityStatus';
 import { Icon } from 'components/icons/Icon';
+import { Tooltip } from 'components/Tooltip';
 import { useUpdateAtom } from 'jotai/utils';
 import { DataTableColumnsExtended } from 'pages/invoices/common/hooks/useInvoiceColumns';
 import { useTranslation } from 'react-i18next';
@@ -112,13 +113,21 @@ export function useProjectColumns() {
       column: 'public_notes',
       id: 'public_notes',
       label: t('public_notes'),
-      format: (value) => <span className="truncate">{value}</span>,
+      format: (value) => (
+        <Tooltip size="regular" truncate message={value as string}>
+          <span>{value}</span>
+        </Tooltip>
+      ),
     },
     {
       column: 'private_notes',
       id: 'private_notes',
       label: t('private_notes'),
-      format: (value) => <span className="truncate">{value}</span>,
+      format: (value) => (
+        <Tooltip size="regular" truncate message={value as string}>
+          <span>{value}</span>
+        </Tooltip>
+      ),
     },
     {
       column: 'budgeted_hours',

--- a/src/pages/quotes/common/hooks.tsx
+++ b/src/pages/quotes/common/hooks.tsx
@@ -73,6 +73,7 @@ import {
 } from 'react-icons/md';
 import { SelectOption } from 'components/datatables/Actions';
 import { useAccentColor } from 'common/hooks/useAccentColor';
+import { Tooltip } from 'components/Tooltip';
 
 export type ChangeHandler = <T extends keyof Quote>(
   property: T,
@@ -744,13 +745,21 @@ export function useQuoteColumns() {
       column: 'private_notes',
       id: 'private_notes',
       label: t('private_notes'),
-      format: (value) => <span className="truncate">{value}</span>,
+      format: (value) => (
+        <Tooltip size="regular" truncate message={value as string}>
+          <span>{value}</span>
+        </Tooltip>
+      ),
     },
     {
       column: 'public_notes',
       id: 'public_notes',
       label: t('public_notes'),
-      format: (value) => <span className="truncate">{value}</span>,
+      format: (value) => (
+        <Tooltip size="regular" truncate message={value as string}>
+          <span>{value}</span>
+        </Tooltip>
+      ),
     },
     {
       column: 'tax_amount',

--- a/src/pages/recurring-expenses/common/hooks.tsx
+++ b/src/pages/recurring-expenses/common/hooks.tsx
@@ -45,6 +45,7 @@ import {
 } from 'react-icons/md';
 import { invalidationQueryAtom } from 'common/atoms/data-table';
 import { RecurringExpenseStatus as RecurringExpenseStatusBadge } from './components/RecurringExpenseStatus';
+import { Tooltip } from 'components/Tooltip';
 
 export const recurringExpenseColumns = [
   'status',
@@ -190,7 +191,11 @@ export function useRecurringExpenseColumns() {
       column: 'public_notes',
       id: 'public_notes',
       label: t('public_notes'),
-      format: (value) => <span className="truncate">{value}</span>,
+      format: (value) => (
+        <Tooltip size="regular" truncate message={value as string}>
+          <span>{value}</span>
+        </Tooltip>
+      ),
     },
     {
       column: 'entity_state',
@@ -289,7 +294,11 @@ export function useRecurringExpenseColumns() {
       column: 'private_notes',
       id: 'private_notes',
       label: t('private_notes'),
-      format: (value) => <span className="truncate">{value}</span>,
+      format: (value) => (
+        <Tooltip size="regular" truncate message={value as string}>
+          <span>{value}</span>
+        </Tooltip>
+      ),
     },
     {
       column: 'should_be_invoiced',

--- a/src/pages/recurring-invoices/common/hooks.tsx
+++ b/src/pages/recurring-invoices/common/hooks.tsx
@@ -58,6 +58,7 @@ import {
   MdStopCircle,
 } from 'react-icons/md';
 import { invalidationQueryAtom } from 'common/atoms/data-table';
+import { Tooltip } from 'components/Tooltip';
 
 interface RecurringInvoiceUtilitiesProps {
   client?: Client;
@@ -644,13 +645,21 @@ export function useRecurringInvoiceColumns() {
       column: 'public_notes',
       id: 'public_notes',
       label: t('public_notes'),
-      format: (value) => <span className="truncate">{value}</span>,
+      format: (value) => (
+        <Tooltip size="regular" truncate message={value as string}>
+          <span>{value}</span>
+        </Tooltip>
+      ),
     },
     {
       column: 'private_notes',
       id: 'private_notes',
       label: t('private_notes'),
-      format: (value) => <span className="truncate">{value}</span>,
+      format: (value) => (
+        <Tooltip size="regular" truncate message={value as string}>
+          <span>{value}</span>
+        </Tooltip>
+      ),
     },
     {
       column: 'updated_at',

--- a/src/pages/tasks/common/hooks.tsx
+++ b/src/pages/tasks/common/hooks.tsx
@@ -23,6 +23,7 @@ import { customField } from 'components/CustomField';
 import { SelectOption } from 'components/datatables/Actions';
 import { DropdownElement } from 'components/dropdown/DropdownElement';
 import { Icon } from 'components/icons/Icon';
+import { Tooltip } from 'components/Tooltip';
 import dayjs from 'dayjs';
 import { useUpdateAtom } from 'jotai/utils';
 import { DataTableColumnsExtended } from 'pages/invoices/common/hooks/useInvoiceColumns';
@@ -135,7 +136,11 @@ export function useTaskColumns() {
       column: 'description',
       id: 'description',
       label: t('description'),
-      format: (value) => <span className="truncate">{value}</span>,
+      format: (value) => (
+        <Tooltip size="regular" truncate message={value as string}>
+          <span>{value}</span>
+        </Tooltip>
+      ),
     },
     {
       column: 'duration',

--- a/src/pages/transactions/common/hooks/useTransactionColumns.tsx
+++ b/src/pages/transactions/common/hooks/useTransactionColumns.tsx
@@ -14,6 +14,7 @@ import { useFormatMoney } from 'common/hooks/money/useFormatMoney';
 import { useCurrentCompany } from 'common/hooks/useCurrentCompany';
 import { Transaction } from 'common/interfaces/transactions';
 import { DataTableColumns } from 'components/DataTable';
+import { Tooltip } from 'components/Tooltip';
 import { EntityStatus } from 'pages/transactions/components/EntityStatus';
 import { useTranslation } from 'react-i18next';
 
@@ -67,6 +68,11 @@ export function useTransactionColumns() {
     {
       id: 'description',
       label: t('description'),
+      format: (value) => (
+        <Tooltip size="regular" truncate message={value as string}>
+          <span>{value}</span>
+        </Tooltip>
+      ),
     },
     { id: 'invoices', label: t('invoices') },
     { id: 'expense', label: t('expense') },

--- a/src/pages/vendors/common/hooks.tsx
+++ b/src/pages/vendors/common/hooks.tsx
@@ -20,6 +20,7 @@ import { Vendor } from 'common/interfaces/vendor';
 import { CopyToClipboard } from 'components/CopyToClipboard';
 import { customField } from 'components/CustomField';
 import { EntityStatus } from 'components/EntityStatus';
+import { Tooltip } from 'components/Tooltip';
 import { DataTableColumnsExtended } from 'pages/invoices/common/hooks/useInvoiceColumns';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -218,7 +219,11 @@ export function useVendorColumns() {
       column: 'private_notes',
       id: 'private_notes',
       label: t('private_notes'),
-      format: (value) => <span className="truncate">{value}</span>,
+      format: (value) => (
+        <Tooltip size="regular" truncate message={value as string}>
+          <span>{value}</span>
+        </Tooltip>
+      ),
     },
     {
       column: 'updated_at',


### PR DESCRIPTION
The screenshot as example of implemented tooltip on one of tables and columns:

<img width="1211" alt="Screenshot 2023-03-01 at 15 46 56" src="https://user-images.githubusercontent.com/51542191/222174632-b46d0115-329f-499c-b15c-699675c9c51d.png">

@beganovich @turbo124 PR includes changing the plain text using the `Tooltip` component where we rule out possible overflow or bad UI. I think I have covered all the columns where possible. Let me know your thoughts.