### PR TITLE
[Bugifix] Invoice client name - Transaction match slider

### DIFF
--- a/src/pages/transactions/components/ListBox.tsx
+++ b/src/pages/transactions/components/ListBox.tsx
@@ -131,11 +131,7 @@ export function ListBox(props: Props) {
   };
 
   const getClientName = (clientId: string) => {
-    const foundClient = clients?.find(({ id }) => id === clientId);
-
-    const { name, display_name } = foundClient || {};
-
-    return name || display_name;
+    return clients?.find(({ id }) => id === clientId)?.display_name;
   };
 
   const getFormattedResourceList = (resourceList: any) => {

--- a/src/pages/transactions/components/ListBox.tsx
+++ b/src/pages/transactions/components/ListBox.tsx
@@ -131,7 +131,11 @@ export function ListBox(props: Props) {
   };
 
   const getClientName = (clientId: string) => {
-    return clients?.find(({ id }) => id === clientId)?.name;
+    const foundClient = clients?.find(({ id }) => id === clientId);
+
+    const { name, display_name } = foundClient || {};
+
+    return name || display_name;
   };
 
   const getFormattedResourceList = (resourceList: any) => {


### PR DESCRIPTION
@beganovich @turbo124 The PR fixes a bug showing `display_name` instead of the classic `Client name`. The `display_name` property will display the name of some of the contacts assigned to the `Client` if there is no entered classic `name` property. Let me know your thoughts.