### PR TITLE
[Bugfix] Subject property - Disabling - Emailing Invoice

### DIFF
--- a/src/pages/invoices/email/components/Mailer.tsx
+++ b/src/pages/invoices/email/components/Mailer.tsx
@@ -14,6 +14,7 @@ import MDEditor from '@uiw/react-md-editor';
 import { enterprisePlan } from 'common/guards/guards/enterprise-plan';
 import { freePlan } from 'common/guards/guards/free-plan';
 import { proPlan } from 'common/guards/guards/pro-plan';
+import { isSelfHosted } from 'common/helpers';
 import { generateEmailPreview } from 'common/helpers/emails/generate-email-preview';
 import { useHandleSend } from 'common/hooks/emails/useHandleSend';
 import { useResolveTemplate } from 'common/hooks/emails/useResolveTemplate';
@@ -146,7 +147,7 @@ export const Mailer = forwardRef<MailerComponent, Props>((props, ref) => {
             label={t('subject')}
             value={subject || template?.raw_subject}
             onValueChange={(value) => setSubject(value)}
-            disabled={freePlan()}
+            disabled={freePlan() && !isSelfHosted()}
           />
 
           {(proPlan() || enterprisePlan()) && (

--- a/src/pages/invoices/email/components/Mailer.tsx
+++ b/src/pages/invoices/email/components/Mailer.tsx
@@ -14,7 +14,7 @@ import MDEditor from '@uiw/react-md-editor';
 import { enterprisePlan } from 'common/guards/guards/enterprise-plan';
 import { freePlan } from 'common/guards/guards/free-plan';
 import { proPlan } from 'common/guards/guards/pro-plan';
-import { isSelfHosted } from 'common/helpers';
+import { isHosted } from 'common/helpers';
 import { generateEmailPreview } from 'common/helpers/emails/generate-email-preview';
 import { useHandleSend } from 'common/hooks/emails/useHandleSend';
 import { useResolveTemplate } from 'common/hooks/emails/useResolveTemplate';
@@ -147,7 +147,7 @@ export const Mailer = forwardRef<MailerComponent, Props>((props, ref) => {
             label={t('subject')}
             value={subject || template?.raw_subject}
             onValueChange={(value) => setSubject(value)}
-            disabled={freePlan() && !isSelfHosted()}
+            disabled={freePlan() && isHosted()}
           />
 
           {(proPlan() || enterprisePlan()) && (


### PR DESCRIPTION
@beganovich @turbo124 PR includes changes to the condition of disabling the `subject` property on the emailing invoice page. So far we've disabled it if the user only has `freePlan()`, but we haven't covered that this field should be enabled for `SELF-HOSTED` users. So I just added that part of the condition. Let me know your thoughts.