### PR TITLE
[Bugfix] Cloning Invoice - Line items

### DIFF
--- a/src/pages/invoices/common/components/ProductsTable.tsx
+++ b/src/pages/invoices/common/components/ProductsTable.tsx
@@ -93,17 +93,11 @@ export function ProductsTable(props: Props) {
                             key={columnIndex}
                           >
                             {length - 1 !== columnIndex &&
-                              resolveInputField(
-                                column,
-                                lineItem!._id as string
-                              )}
+                              resolveInputField(column, lineItemIndex)}
 
                             {length - 1 === columnIndex && (
                               <div className="flex justify-between items-center">
-                                {resolveInputField(
-                                  column,
-                                  lineItem!._id as string
-                                )}
+                                {resolveInputField(column, lineItemIndex)}
 
                                 {resource &&
                                   (lineItem.product_key || lineItemIndex > 0) &&

--- a/src/pages/invoices/common/hooks/useResolveInputField.tsx
+++ b/src/pages/invoices/common/hooks/useResolveInputField.tsx
@@ -87,9 +87,8 @@ export function useResolveInputField(props: Props) {
       getCurrency(resource[props.relationType], props.relationType);
   }, [resource?.[props.relationType]]);
 
-  return (key: string, _id: string) => {
+  return (key: string, index: number) => {
     const property = resolveProperty(key);
-    const index = resource.line_items.findIndex((item) => item._id === _id);
 
     if (property === 'product_key') {
       return (


### PR DESCRIPTION
@beganovich @turbo124 David noticed an bug in misplacing line items when cloning an invoice from a table. The reason for this is because we don't have an `_id` property for each line item in the table response. On the edit page in the response we have this property for each line item and we haven't had any bugs there. Looking deep into the code, the line item index is calculated using the `_id` property with this line of code:

`const index = resource.line_items.findIndex((item) => item._id === _id);`

Then I realized that we actually get the same result if we just pass the `lineItemIndex` from the line item table map. I've tested all the cases I know about this and I haven't seen any bad impact just this and also the code is formatted a bit (unnecessary code removed). Ben, if you know any part of the logic that this change will make an bug, please let us know. Otherwise, I think this is a solution for bug. Let me know your thoughts.