### PR TITLE
[Bugfix] Formatting money on cloning

### DIFF
--- a/src/common/helpers/number.ts
+++ b/src/common/helpers/number.ts
@@ -58,7 +58,7 @@ export class Number {
     } else if (swapSymbol) {
       return `${formatted} ${symbol.trim()}`;
     } else if (!options?.showCurrencyCode) {
-      return `${symbol}${formatted}`;
+      return `${symbol} ${formatted}`;
     }
 
     return this.formatValue(formatted, currency);

--- a/src/pages/invoices/common/hooks/useFormatMoney.ts
+++ b/src/pages/invoices/common/hooks/useFormatMoney.ts
@@ -37,6 +37,9 @@ export function useFormatMoney(props: Props) {
   const vendorResolver = useVendorResolver();
   const clientResolver = useClientResolver();
 
+  const [clientId, setClientId] = useState<string>('');
+  const [vendorId, setVendorId] = useState<string>('');
+
   const { resource, relationType } = props;
 
   const [country, setCountry] = useState<Country>();
@@ -45,18 +48,20 @@ export function useFormatMoney(props: Props) {
   const [relation, setRelation] = useState<Client | Vendor>();
 
   useEffect(() => {
-    if (resource?.[relationType] && relationType === 'client_id') {
-      clientResolver
-        .find(resource.client_id)
-        .then((client) => setRelation(client));
+    if (clientId && relationType === 'client_id') {
+      clientResolver.find(clientId).then((client) => setRelation(client));
     }
 
-    if (resource?.[relationType] && relationType === 'vendor_id') {
-      vendorResolver
-        .find(resource.vendor_id)
-        .then((vendor) => setRelation(vendor));
+    if (vendorId && relationType === 'vendor_id') {
+      vendorResolver.find(vendorId).then((vendor) => setRelation(vendor));
     }
-  }, [resource]);
+  }, [clientId, vendorId]);
+
+  useEffect(() => {
+    resource?.vendor_id && setVendorId(resource.vendor_id);
+
+    resource?.client_id && setClientId(resource.client_id);
+  }, [resource?.client_id, resource?.vendor_id]);
 
   useEffect(() => {
     if (relation && relationType === 'client_id') {


### PR DESCRIPTION
@beganovich @turbo124 We had a bug with incorrect formatting of money values ​​when cloning entities (invoice, quote, etc.). The actual bug was missing UI rerendering when we tried to clone entities with the same `client_id/vendor_id` twice in a row. On the second attempt, we will not have the proper UI displayed (with formatted values). The `atom` and `resolveClient` parts of the logic we actually use on creation pages (especially atom) have the biggest impact to resolve it like this. This change will resolve the bug in all entities where we had this bug. Let me know your thoughts.