### PR TITLE
[CleanUp] Transaction slider bugfix && Vendor/Expense category pre-selection

### DIFF
--- a/src/common/queries/transaction-rules.ts
+++ b/src/common/queries/transaction-rules.ts
@@ -27,7 +27,12 @@ export function useBlankTransactionRuleQuery() {
   );
 }
 
-export function useTransactionRuleQuery(params: { id: string | undefined }) {
+interface Params {
+  id: string | undefined;
+  enabled?: boolean;
+}
+
+export function useTransactionRuleQuery(params: Params) {
   return useQuery<TransactionRule>(
     route('/api/v1/bank_transaction_rules/:id', { id: params.id }),
     () =>
@@ -38,6 +43,6 @@ export function useTransactionRuleQuery(params: { id: string | undefined }) {
         (response: GenericSingleResourceResponse<TransactionRule>) =>
           response.data.data
       ),
-    { staleTime: Infinity }
+    { enabled: params.enabled ?? true, staleTime: Infinity }
   );
 }

--- a/src/pages/transactions/components/Details.tsx
+++ b/src/pages/transactions/components/Details.tsx
@@ -31,11 +31,11 @@ import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useTransactionQuery } from '../common/queries';
 import { TransactionMatchDetails } from './TransactionMatchDetails';
+import { useTransactionRuleQuery } from '$app/common/queries/transaction-rules';
 
 interface Props {
   transactionId: string;
   setTransactionId: Dispatch<SetStateAction<string>>;
-  setSliderVisible?: Dispatch<SetStateAction<boolean>>;
 }
 
 export function Details(props: Props) {
@@ -47,12 +47,19 @@ export function Details(props: Props) {
 
   const { data: transaction } = useTransactionQuery({
     id: props.transactionId,
-    enabled: !!props.transactionId,
+    enabled: Boolean(props.transactionId),
   });
 
   const { data: bankAccountResponse } = useBankAccountQuery({
     id: transaction?.bank_integration_id || '',
-    enabled: !!transaction,
+    enabled: Boolean(transaction),
+  });
+
+  const isMatched = TransactionStatus.Matched === transaction?.status_id;
+
+  const { data: bankTransactionRuleResponse } = useTransactionRuleQuery({
+    id: transaction?.bank_transaction_rule_id || '',
+    enabled: Boolean(transaction) && isMatched,
   });
 
   const [matchedInvoices, setMatchedInvoices] = useState<Invoice[]>();
@@ -232,6 +239,7 @@ export function Details(props: Props) {
             status_id: transaction?.status_id || '',
           }}
           isCreditTransactionType={isCreditTransactionType}
+          transactionRule={bankTransactionRuleResponse}
         />
       )}
     </div>

--- a/src/pages/transactions/components/TransactionMatchDetails.tsx
+++ b/src/pages/transactions/components/TransactionMatchDetails.tsx
@@ -42,6 +42,8 @@ export function TransactionMatchDetails(props: Props) {
 
   const queryClient = useQueryClient();
 
+  const { transactionRule } = props;
+
   const [isFormBusy, setIsFormBusy] = useState<boolean>(false);
 
   const [isTransactionConverted, setIsTransactionConverted] =
@@ -247,16 +249,18 @@ export function TransactionMatchDetails(props: Props) {
   }, []);
 
   useEffect(() => {
-    if (props.transactionRule) {
-      if (props.transactionRule.category_id) {
-        setExpenseCategoryIds([props.transactionRule.category_id]);
+    if (transactionRule) {
+      const { category_id, vendor_id } = transactionRule;
+
+      if (category_id) {
+        setExpenseCategoryIds([category_id]);
       }
 
-      if (props.transactionRule.vendor_id) {
-        setVendorIds([props.transactionRule.vendor_id]);
+      if (vendor_id) {
+        setVendorIds([vendor_id]);
       }
     }
-  }, [props.transactionRule]);
+  }, [transactionRule]);
 
   return (
     <div className="flex flex-col flex-1">

--- a/src/pages/transactions/components/TransactionMatchDetails.tsx
+++ b/src/pages/transactions/components/TransactionMatchDetails.tsx
@@ -23,6 +23,7 @@ import { MdContentCopy, MdLink } from 'react-icons/md';
 import { useTranslation } from 'react-i18next';
 import { TabGroup } from '$app/components/TabGroup';
 import { Transaction } from '$app/common/interfaces/transactions';
+import { TransactionRule } from '$app/common/interfaces/transaction-rules';
 
 export interface TransactionDetails {
   base_type: string;
@@ -33,6 +34,7 @@ export interface TransactionDetails {
 interface Props {
   transactionDetails: TransactionDetails;
   isCreditTransactionType: boolean;
+  transactionRule: TransactionRule | undefined;
 }
 
 export function TransactionMatchDetails(props: Props) {
@@ -243,6 +245,18 @@ export function TransactionMatchDetails(props: Props) {
       setIsTransactionConverted(true);
     };
   }, []);
+
+  useEffect(() => {
+    if (props.transactionRule) {
+      if (props.transactionRule.category_id) {
+        setExpenseCategoryIds([props.transactionRule.category_id]);
+      }
+
+      if (props.transactionRule.vendor_id) {
+        setVendorIds([props.transactionRule.vendor_id]);
+      }
+    }
+  }, [props.transactionRule]);
 
   return (
     <div className="flex flex-col flex-1">

--- a/src/pages/transactions/index/Transactions.tsx
+++ b/src/pages/transactions/index/Transactions.tsx
@@ -14,7 +14,7 @@ import { Default } from '$app/components/layouts/Default';
 import { useTranslation } from 'react-i18next';
 import { useTransactionColumns } from '../common/hooks/useTransactionColumns';
 import { ImportButton } from '$app/components/import/ImportButton';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Details } from '../components/Details';
 import { Slider } from '$app/components/cards/Slider';
 import { Transaction } from '$app/common/interfaces/transactions';
@@ -35,11 +35,9 @@ export function Transactions() {
 
   const [sliderTitle, setSliderTitle] = useState<string>();
 
-  const [isTransactionSliderVisible, setIsTransactionSliderVisible] =
-    useState<boolean>(false);
-
   const getSelectedTransaction = (transaction: Transaction) => {
     setTransactionId(transaction.id);
+
     if (transaction.description) {
       let cutDescription = transaction.description;
       if (transaction.description.length > 35) {
@@ -51,29 +49,17 @@ export function Transactions() {
     }
   };
 
-  useEffect(() => {
-    if (transactionId) {
-      setIsTransactionSliderVisible(true);
-    }
-  }, [transactionId]);
-
-  const handleSliderClose = () => {
-    setTransactionId('');
-    setIsTransactionSliderVisible(false);
-  };
-
   return (
     <>
       <Slider
         title={sliderTitle}
-        visible={isTransactionSliderVisible}
-        onClose={handleSliderClose}
+        visible={Boolean(transactionId)}
+        onClose={() => setTransactionId('')}
         size="large"
       >
         <Details
           transactionId={transactionId}
           setTransactionId={setTransactionId}
-          setSliderVisible={setIsTransactionSliderVisible}
         />
       </Slider>
 


### PR DESCRIPTION
@beganovich @turbo124 PR includes a bug fix for opening and closing transaction matching sliders. Additionally, I did pre-selection the vendor or expense category if the transaction has the `matched` status. Let me know your thoughts.