### PR TITLE
[Cleanup] Upgrade CTA Label - Self Hosted

### DIFF
--- a/src/components/layouts/Default.tsx
+++ b/src/components/layouts/Default.tsx
@@ -403,7 +403,7 @@ export function Default(props: Props) {
                   >
                     <span>
                       {isSelfHosted() && isOwner
-                        ? t('upgrade')
+                        ? t('purchase_white_label')
                         : t('unlock_pro')}
                     </span>
                   </button>


### PR DESCRIPTION
@beganovich @turbo124 PR includes changing the label in the upgrade CTA in the top navigation bar to translate the `purchase_white_label` keyword. Here's a screenshot:

<img width="1175" alt="Screenshot 2023-03-19 at 16 17 12" src="https://user-images.githubusercontent.com/51542191/226186395-4c02c896-4ba7-484b-8d36-8d20d5a7d8b3.png">

We do not have this keyword in the translation files, so if it is okay from your end also, please just add it. Let me know your thoughts.