### PR TITLE
[Cleanup] Default checking | Purchase Order Vendor Contacts

### DIFF
--- a/src/pages/purchase-orders/edit/components/VendorSelector.tsx
+++ b/src/pages/purchase-orders/edit/components/VendorSelector.tsx
@@ -45,7 +45,9 @@ export function VendorSelector(props: Props) {
       (i) => i.vendor_contact_id === id
     );
 
-    return Boolean(potential);
+    const contact = vendor?.contacts.find((contact) => contact.id === id);
+
+    return Boolean(potential) || Boolean(contact?.send_email);
   };
 
   return (


### PR DESCRIPTION
@beganovich @turbo124 PR includes adding condition for default checking vendor contacts on purchase order creation. So, if `send_email` property is `true` on specific contact, that contact will be checked by default. Let me know your thoughts.