### PR TITLE
[Cleanup] Taxes displaying refactor

### DIFF
--- a/src/pages/invoices/common/hooks/useResolveTotalVariable.tsx
+++ b/src/pages/invoices/common/hooks/useResolveTotalVariable.tsx
@@ -122,14 +122,13 @@ export function useResolveTotalVariable(props: Props) {
 
     if (variable == '$taxes' && invoiceSum) {
       return (
-        <Element leftSide={`${resolveTranslation(variable, '$')}:`}>
+        <>
           {invoiceSum?.getTaxMap().map((item, index) => (
-            <div key={index} className="flex space-x-6">
-              <span>{item.name}</span>
+            <Element key={index} leftSide={item.name}>
               <span>{formatMoney(item.total)}</span>
-            </div>
+            </Element>
           ))}
-        </Element>
+        </>
       );
     }
 


### PR DESCRIPTION
@beganovich @turbo124 PR includes changing the way taxes are displayed in the totals section. We had grouped taxes without separating the label and value, now we have the label on the left and the value on the right. Here's a screenshot:

![Screenshot 2023-03-20 at 00 10 30](https://user-images.githubusercontent.com/51542191/226215950-df517873-9688-45a5-b977-384e0b4a7618.png)

Let me know your thoughts.