### PR TITLE
[Bugfix] Displaying bulk actions | Product Edit Page

### DIFF
--- a/src/pages/products/common/hooks.tsx
+++ b/src/pages/products/common/hooks.tsx
@@ -31,7 +31,7 @@ import {
   MdDelete,
   MdRestore,
 } from 'react-icons/md';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { productAtom } from './atoms';
 import { bulk } from '$app/common/queries/products';
 import { useQueryClient } from 'react-query';
@@ -236,17 +236,17 @@ export function useProductColumns() {
 }
 
 export function useActions() {
+  const { id } = useParams();
+
   const [t] = useTranslation();
 
   const navigate = useNavigate();
-
   const location = useLocation();
-
   const queryClient = useQueryClient();
 
   const setProduct = useSetAtom(productAtom);
 
-  const isEditPage = !location.pathname.endsWith('/products');
+  const isEditPage = location.pathname.includes(id!);
 
   const cloneToProduct = (product: Product) => {
     setProduct({ ...product, id: '', documents: [] });

--- a/src/pages/products/common/hooks.tsx
+++ b/src/pages/products/common/hooks.tsx
@@ -246,7 +246,7 @@ export function useActions() {
 
   const setProduct = useSetAtom(productAtom);
 
-  const isEditPage = location.pathname.endsWith('/edit');
+  const isEditPage = !location.pathname.endsWith('/products');
 
   const cloneToProduct = (product: Product) => {
     setProduct({ ...product, id: '', documents: [] });


### PR DESCRIPTION
@beganovich @turbo124 We had a bug with displaying bulk actions when switching to the `Documents/Product Fields` tabs. It's resolved now and looks good from my end. Here's a screenshot:

![Screenshot 2023-03-20 at 00 40 06](https://user-images.githubusercontent.com/51542191/226217458-e94eb492-5311-4d4d-81d1-2fdd071a514c.png)

Let me know your thoughts.