### PR TITLE
[Bugfix] Bulk Routes

### DIFF
--- a/src/pages/clients/index/Clients.tsx
+++ b/src/pages/clients/index/Clients.tsx
@@ -58,6 +58,7 @@ export function Clients() {
       <DataTable
         resource="client"
         endpoint="/api/v1/clients?sort=id|desc"
+        bulkRoute="/api/v1/clients/bulk"
         columns={columns}
         linkToCreate="/clients/create"
         linkToEdit="/clients/:id/edit"

--- a/src/pages/projects/index/Projects.tsx
+++ b/src/pages/projects/index/Projects.tsx
@@ -42,6 +42,7 @@ export function Projects() {
       <DataTable
         resource="project"
         endpoint="/api/v1/projects?sort=id|desc"
+        bulkRoute="/api/v1/projects/bulk"
         columns={columns}
         customActions={actions}
         linkToCreate="/projects/create"

--- a/src/pages/settings/bank-accounts/components/transaction-rules/TransactionRules.tsx
+++ b/src/pages/settings/bank-accounts/components/transaction-rules/TransactionRules.tsx
@@ -40,6 +40,7 @@ export function TransactionRules() {
         resource="transaction_rule"
         columns={columns}
         endpoint="/api/v1/bank_transaction_rules?include=vendor,expense_category&sort=id|desc"
+        bulkRoute="/api/v1/bank_transaction_rules/bulk"
         linkToCreate="/settings/bank_accounts/transaction_rules/create"
         linkToEdit="/settings/bank_accounts/transaction_rules/:id/edit"
         withResourcefulActions

--- a/src/pages/settings/bank-accounts/index/BankAccounts.tsx
+++ b/src/pages/settings/bank-accounts/index/BankAccounts.tsx
@@ -66,6 +66,7 @@ export function BankAccounts() {
         resource="bank_account"
         columns={columns}
         endpoint="/api/v1/bank_integrations?sort=id|desc"
+        bulkRoute="/api/v1/bank_integrations/bulk"
         linkToCreate="/settings/bank_accounts/create"
         linkToEdit="/settings/bank_accounts/:id/edit"
         withResourcefulActions

--- a/src/pages/settings/expense-categories/ExpenseCategories.tsx
+++ b/src/pages/settings/expense-categories/ExpenseCategories.tsx
@@ -43,6 +43,7 @@ export function ExpenseCategories() {
   return (
     <DataTable
       endpoint="/api/v1/expense_categories?sort=id|desc"
+      bulkRoute="/api/v1/expense_categories/bulk"
       resource="expense_category"
       columns={columns}
       linkToCreate="/settings/expense_categories/create"

--- a/src/pages/settings/gateways/index/Gateways.tsx
+++ b/src/pages/settings/gateways/index/Gateways.tsx
@@ -40,6 +40,7 @@ export function Gateways() {
       columns={columns}
       resource="company_gateway"
       endpoint="/api/v1/company_gateways?sort=id|desc"
+      bulkRoute="/api/v1/company_gateways/bulk"
       linkToCreate="/settings/gateways/create"
       linkToEdit="/settings/gateways/:id/edit"
       withResourcefulActions

--- a/src/pages/settings/integrations/api-tokens/ApiTokens.tsx
+++ b/src/pages/settings/integrations/api-tokens/ApiTokens.tsx
@@ -61,6 +61,7 @@ export function ApiTokens() {
         resource="token"
         columns={columns}
         endpoint="/api/v1/tokens?sort=id|desc"
+        bulkRoute="/api/v1/tokens/bulk"
         linkToCreate="/settings/integrations/api_tokens/create"
         linkToEdit="/settings/integrations/api_tokens/:id/edit"
         withResourcefulActions

--- a/src/pages/settings/integrations/api-webhooks/ApiWebhooks.tsx
+++ b/src/pages/settings/integrations/api-webhooks/ApiWebhooks.tsx
@@ -53,6 +53,7 @@ export function ApiWebhooks() {
         resource="webhook"
         columns={columns}
         endpoint="/api/v1/webhooks?sort=id|desc"
+        bulkRoute="/api/v1/webhooks/bulk"
         linkToCreate="/settings/integrations/api_webhooks/create"
         linkToEdit="/settings/integrations/api_webhooks/:id/edit"
         withResourcefulActions

--- a/src/pages/settings/schedules/index/Schedules.tsx
+++ b/src/pages/settings/schedules/index/Schedules.tsx
@@ -35,6 +35,7 @@ export function Schedules() {
       <DataTable
         resource="schedule"
         endpoint="/api/v1/task_schedulers?sort=id|desc"
+        bulkRoute="/api/v1/task_schedulers/bulk"
         columns={columns}
         linkToCreate="/settings/schedules/create"
         linkToEdit="/settings/schedules/:id/edit"

--- a/src/pages/settings/subscriptions/index/Subscriptions.tsx
+++ b/src/pages/settings/subscriptions/index/Subscriptions.tsx
@@ -35,6 +35,7 @@ export function Subscriptions() {
       <DataTable
         resource="subscription"
         endpoint="/api/v1/subscriptions?sort=id|desc"
+        bulkRoute="/api/v1/subscriptions/bulk"
         columns={columns}
         linkToCreate="/settings/subscriptions/create"
         linkToEdit="/settings/subscriptions/:id/edit"

--- a/src/pages/settings/task-statuses/TaskStatuses.tsx
+++ b/src/pages/settings/task-statuses/TaskStatuses.tsx
@@ -48,6 +48,7 @@ export function TaskStatuses() {
       resource="task_status"
       columns={columns}
       endpoint="/api/v1/task_statuses?sort=id|desc"
+      bulkRoute="/api/v1/task_statuses/bulk"
       linkToCreate="/settings/task_statuses/create"
       linkToEdit="/settings/task_statuses/:id/edit"
       withResourcefulActions

--- a/src/pages/settings/tax-rates/TaxRates.tsx
+++ b/src/pages/settings/tax-rates/TaxRates.tsx
@@ -18,6 +18,7 @@ export function TaxRates() {
     <DataTable
       resource="tax_rate"
       endpoint="/api/v1/tax_rates?sort=id|desc"
+      bulkRoute="/api/v1/tax_rates/bulk"
       columns={columns}
       linkToCreate="/settings/tax_rates/create"
       linkToEdit="/settings/tax_rates/:id/edit"

--- a/src/pages/transactions/components/BankAccountSelector.tsx
+++ b/src/pages/transactions/components/BankAccountSelector.tsx
@@ -46,7 +46,6 @@ export function BankAccountSelector(props: BankAccountSelectorProps) {
         disabled={props.readonly}
         clearButton={props.clearButton}
         onClearButtonClick={props.onClearButtonClick}
-        errorMessage={props.errorMessage}
         queryAdditional
         actionLabel={t('new_bank_account')}
         onActionClick={() => setIsModalOpen(true)}

--- a/src/pages/transactions/components/BankAccountSelector.tsx
+++ b/src/pages/transactions/components/BankAccountSelector.tsx
@@ -46,6 +46,7 @@ export function BankAccountSelector(props: BankAccountSelectorProps) {
         disabled={props.readonly}
         clearButton={props.clearButton}
         onClearButtonClick={props.onClearButtonClick}
+        errorMessage={props.errorMessage}
         queryAdditional
         actionLabel={t('new_bank_account')}
         onActionClick={() => setIsModalOpen(true)}

--- a/src/pages/transactions/index/Transactions.tsx
+++ b/src/pages/transactions/index/Transactions.tsx
@@ -71,6 +71,7 @@ export function Transactions() {
         <DataTable
           resource="transaction"
           endpoint="/api/v1/bank_transactions?sort=id|desc"
+          bulkRoute="/api/v1/bank_transactions/bulk"
           columns={columns}
           linkToCreate="/transactions/create"
           linkToEdit="/transactions/:id/edit"

--- a/src/pages/vendors/index/Vendors.tsx
+++ b/src/pages/vendors/index/Vendors.tsx
@@ -38,6 +38,7 @@ export function Vendors() {
         resource="vendor"
         columns={columns}
         endpoint="/api/v1/vendors?sort=id|desc"
+        bulkRoute="/api/v1/vendors/bulk"
         linkToCreate="/vendors/create"
         linkToEdit="/vendors/:id/edit"
         withResourcefulActions


### PR DESCRIPTION
@beganovich @turbo124 We had a bug with bulk route for some entities. The reason for this is that we didn't specify `bulkRoute` before, so after adding `?sort=id|desc` the route was broken. Now that's fixed. Let me know your thoughts.