### PR TITLE
[Feature] Time Log Description

### DIFF
--- a/src/common/interfaces/company.interface.ts
+++ b/src/common/interfaces/company.interface.ts
@@ -62,6 +62,7 @@ export interface Settings {
   military_time: boolean;
   language_id: string;
   show_currency_code: boolean;
+  show_task_item_description: boolean;
   show_email_footer: boolean;
   company_gateway_ids: string;
   currency_id: string;

--- a/src/pages/tasks/common/components/TaskTable.tsx
+++ b/src/pages/tasks/common/components/TaskTable.tsx
@@ -24,7 +24,7 @@ import {
   parseTime,
   parseTimeToDate,
 } from '../helpers';
-import { parseTimeLog } from '../helpers/calculate-time';
+import { parseTimeLog, TimeLogsType } from '../helpers/calculate-time';
 
 interface Props {
   task: Task;
@@ -34,6 +34,7 @@ interface Props {
 export enum LogPosition {
   Start = 0,
   End = 1,
+  Description = 2,
 }
 
 export function TaskTable(props: Props) {
@@ -55,13 +56,13 @@ export function TaskTable(props: Props) {
       startTime = last[1] + 1;
     }
 
-    logs.push([startTime, 0]);
+    logs.push([startTime, 0, '']);
 
     handleChange('time_log', JSON.stringify(logs));
   };
 
   const deleteTableRow = (index: number) => {
-    const logs: number[][] = parseTimeLog(task.time_log);
+    const logs: TimeLogsType = parseTimeLog(task.time_log);
 
     logs.splice(index, 1);
 
@@ -109,6 +110,18 @@ export function TaskTable(props: Props) {
     );
   };
 
+  const handleDescriptionChange = (
+    value: string,
+    index: number,
+    logPosition: number
+  ) => {
+    const logs = parseTimeLog(task.time_log);
+
+    logs[index][logPosition] = value;
+
+    handleChange('time_log', JSON.stringify(logs));
+  };
+
   useEffect(() => {
     if (typeof lastChangedIndex === 'number') {
       const parsedTimeLog = parseTimeLog(task.time_log);
@@ -133,12 +146,15 @@ export function TaskTable(props: Props) {
         <Th>{t('start_time')}</Th>
         {company?.show_task_end_date && <Th>{t('end_date')}</Th>}
         <Th>{t('end_time')}</Th>
+        {company?.settings.show_task_item_description && (
+          <Th>{t('description')}</Th>
+        )}
         <Th>{t('duration')}</Th>
       </Thead>
       <Tbody>
         {task.time_log &&
-          (JSON.parse(task.time_log) as number[][]).map(
-            ([start, stop], index) => (
+          (JSON.parse(task.time_log) as TimeLogsType).map(
+            ([start, stop, description], index) => (
               <Tr key={index}>
                 <Td>
                   <InputField
@@ -180,6 +196,20 @@ export function TaskTable(props: Props) {
                     step="1"
                   />
                 </Td>
+                {company?.settings.show_task_item_description && (
+                  <Td>
+                    <InputField
+                      value={description}
+                      onValueChange={(value) =>
+                        handleDescriptionChange(
+                          value,
+                          index,
+                          LogPosition.Description
+                        )
+                      }
+                    />
+                  </Td>
+                )}
                 <Td width="15%">
                   <div className="flex items-center space-x-4">
                     <InputField

--- a/src/pages/tasks/common/helpers/calculate-time.ts
+++ b/src/pages/tasks/common/helpers/calculate-time.ts
@@ -10,18 +10,19 @@
 
 import dayjs from 'dayjs';
 
+export type TimeLogType = [number, number, string];
+export type TimeLogsType = TimeLogType[];
+
 export function parseTimeLog(log: string) {
   if (log === '' || log === '[]') {
     return [];
   }
 
-  const numbers: number[][] = [];
-  const parsed: number[][] = JSON.parse(log);
+  const defaultRow: TimeLogsType = [[0, 0, '']];
+  const parsed: TimeLogsType = JSON.parse(log);
 
-  if (parsed.length === 0) {
-    numbers.push([0, 0]);
-
-    return numbers;
+  if (!parsed.length) {
+    return defaultRow;
   }
 
   return parsed;

--- a/src/pages/tasks/kanban/components/EditSlider.tsx
+++ b/src/pages/tasks/kanban/components/EditSlider.tsx
@@ -32,7 +32,10 @@ import {
   parseTime,
   parseTimeToDate,
 } from '$app/pages/tasks/common/helpers';
-import { parseTimeLog } from '$app/pages/tasks/common/helpers/calculate-time';
+import {
+  parseTimeLog,
+  TimeLogsType,
+} from '$app/pages/tasks/common/helpers/calculate-time';
 import { useSave } from '$app/pages/tasks/common/hooks';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -46,7 +49,7 @@ export function EditSlider() {
   const [isTimeModalVisible, setIsTimeModalVisible] = useState(false);
 
   const [timeLogIndex, setTimeLogIndex] = useState<number>();
-  const [timeLog, setTimeLog] = useState<number[][]>([]);
+  const [timeLog, setTimeLog] = useState<TimeLogsType>([]);
 
   const handleChange = (property: keyof Task, value: Task[typeof property]) => {
     setTask((current) => current && { ...current, [property]: value });


### PR DESCRIPTION
Here is the screenshot of updated UI when Description column is added:

![Screenshot 2023-03-24 at 19 37 14](https://user-images.githubusercontent.com/51542191/227613928-c6a84a91-e04c-40a4-9764-853deb886e0a.png)

@beganovich @turbo124 PR includes adding a `Description` column to the task time log table and managing the `Description` field. This column will be shown if `company.settings.show_task_item_description is true`, otherwise it will be hidden. I researched the `Task Settings` page and see that we don't have a Toggle implemented to handle this property. I didn't implement it in this PR because it wasn't mentioned in the ticket. But please let me know if I need to include adding a Toggle to manage the `show_task_item_description` property. Let me know your thoughts.