### PR TITLE
[Bugfix] created_by column | Expenses

### DIFF
--- a/src/pages/expenses/common/hooks.tsx
+++ b/src/pages/expenses/common/hooks.tsx
@@ -112,7 +112,7 @@ export function useAllExpenseColumns() {
     //   'assigned_to', @Todo: Need to resolve relationship
     //   'category', @Todo: Need to resolve relationship
     'created_at',
-    'created_by',
+    //'created_by', @Todo: Need to resolve relationship
     firstCustom,
     secondCustom,
     thirdCustom,


### PR DESCRIPTION
@beganovich @turbo124 While working on the columns task, I saw that we have the `column_by` column on Expenses page active and available for use. This is not the case for other entities, that part of the code is commented out on every other entity with the message that we need to resolve the relationship. I just wanted to remove this column from the dropdown list until we resolve the relationship so that it is available to use this column properly. Screenshot:

![Screenshot 2023-03-24 at 20 27 10](https://user-images.githubusercontent.com/51542191/227664627-cbedd826-e9f2-4cb8-aefc-5425386c087d.png)

Of course, let me know if we already have this relationship resolved. Let me know your thoughts.