### PR TITLE
[Bugfix] Title - Edit Expense Page

### DIFF
--- a/src/pages/expenses/edit/Edit.tsx
+++ b/src/pages/expenses/edit/Edit.tsx
@@ -30,7 +30,7 @@ import { useSave } from './hooks/useSave';
 export function Edit() {
   const [t] = useTranslation();
 
-  const { documentTitle } = useTitle('expense');
+  const { documentTitle } = useTitle('edit_expense');
 
   const { id } = useParams();
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes just changing title on edit expense page. We had title `Expense` but it should be `Edit Expense`. Let me know your thoughts.