### PR TITLE
[Bugfix] UX - Edit User Page - Closing Password Confirmation Modal

### DIFF
--- a/src/components/PasswordConfirmation.tsx
+++ b/src/components/PasswordConfirmation.tsx
@@ -9,6 +9,7 @@
  */
 import { ChangeEvent, FormEvent, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
 import { Button, InputField } from './forms';
 import { Modal } from './Modal';
 
@@ -20,6 +21,7 @@ interface Props {
 
 export function PasswordConfirmation(props: Props) {
   const [t] = useTranslation();
+  const navigate = useNavigate();
 
   const [isModalOpen, setIsModalOpen] = useState(props.show ?? false);
   const [currentPassword, setCurrentPassword] = useState('');
@@ -40,9 +42,7 @@ export function PasswordConfirmation(props: Props) {
 
   return (
     <Modal
-      onClose={() => {
-        props.onClose(false);
-      }}
+      onClose={() => navigate('/settings/users')}
       visible={isModalOpen}
       title={t('confirmation')}
       text={t('please_enter_your_password')}


### PR DESCRIPTION
@beganovich @turbo124 PR includes improving the UX when closing the password confirmation modal on the `Edit User` page. Previously, when we close the password confirmation modal, we got this weird UI where we don't have any tab because the user didn't enter the correct password and from this page the user can't open the modal again. Screenshot:

![Screenshot 2023-03-26 at 03 19 20](https://user-images.githubusercontent.com/51542191/227750472-0c05b466-403c-4b87-9215-12fd98ce5576.png)

Now, instead of just hiding the modal when the user just closes the password confirmation modal, we navigate the user to the `/settings/users` page where he is available again to open the same `Edit User` page and enter the correct password. IMO, this behavior improves the UX for this case. But, let me know your thoughts.