### PR TITLE
[Feature] Task Time Logs | Allow Billable

### DIFF
--- a/src/common/interfaces/company.interface.ts
+++ b/src/common/interfaces/company.interface.ts
@@ -63,6 +63,7 @@ export interface Settings {
   language_id: string;
   show_currency_code: boolean;
   show_task_item_description: boolean;
+  allow_billable_task_items: boolean;
   show_email_footer: boolean;
   company_gateway_ids: string;
   currency_id: string;

--- a/src/pages/settings/task-settings/TaskSettings.tsx
+++ b/src/pages/settings/task-settings/TaskSettings.tsx
@@ -115,6 +115,20 @@ export function TaskSettings() {
           />
         </Element>
 
+        <Element
+          leftSide={t('allow_billable_task_items')}
+          leftSideHelp={t('allow_billable_task_items_help')}
+        >
+          <Toggle
+            checked={
+              companyChanges?.settings.allow_billable_task_items || false
+            }
+            onChange={(value: boolean) =>
+              handleToggleChange('settings.allow_billable_task_items', value)
+            }
+          />
+        </Element>
+
         <Divider />
 
         <Element

--- a/src/pages/tasks/common/components/TaskTable.tsx
+++ b/src/pages/tasks/common/components/TaskTable.tsx
@@ -13,7 +13,7 @@ import { Table, Tbody, Td, Th, Thead, Tr } from '$app/components/tables';
 import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { Task } from '$app/common/interfaces/task';
 import dayjs from 'dayjs';
-import { ChangeEvent, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Plus, Trash2 } from 'react-feather';
 import { useTranslation } from 'react-i18next';
 import {
@@ -243,9 +243,9 @@ export function TaskTable(props: Props) {
                     <Td>
                       <Checkbox
                         checked={billable || false}
-                        onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                        onValueChange={(value, checked) =>
                           handleBillableChange(
-                            event.target.checked,
+                            checked || false,
                             index,
                             LogPosition.Billable
                           )

--- a/src/pages/tasks/common/components/TaskTable.tsx
+++ b/src/pages/tasks/common/components/TaskTable.tsx
@@ -8,12 +8,12 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
-import { InputField } from '$app/components/forms';
+import { Checkbox, InputField } from '$app/components/forms';
 import { Table, Tbody, Td, Th, Thead, Tr } from '$app/components/tables';
 import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { Task } from '$app/common/interfaces/task';
 import dayjs from 'dayjs';
-import { useEffect, useState } from 'react';
+import { ChangeEvent, useEffect, useState } from 'react';
 import { Plus, Trash2 } from 'react-feather';
 import { useTranslation } from 'react-i18next';
 import {
@@ -35,6 +35,7 @@ export enum LogPosition {
   Start = 0,
   End = 1,
   Description = 2,
+  Billable = 3,
 }
 
 export function TaskTable(props: Props) {
@@ -56,7 +57,7 @@ export function TaskTable(props: Props) {
       startTime = last[1] + 1;
     }
 
-    logs.push([startTime, 0, '']);
+    logs.push([startTime, 0, '', false]);
 
     handleChange('time_log', JSON.stringify(logs));
   };
@@ -122,6 +123,32 @@ export function TaskTable(props: Props) {
     handleChange('time_log', JSON.stringify(logs));
   };
 
+  const handleBillableChange = (
+    value: boolean,
+    index: number,
+    logPosition: number
+  ) => {
+    const logs = parseTimeLog(task.time_log);
+
+    logs[index][logPosition] = value;
+
+    handleChange('time_log', JSON.stringify(logs));
+  };
+
+  const getDescriptionColSpan = () => {
+    let colSpan = 4;
+
+    if (company?.show_task_end_date) {
+      colSpan += 1;
+    }
+
+    if (company?.settings.allow_billable_task_items) {
+      colSpan += 1;
+    }
+
+    return colSpan;
+  };
+
   useEffect(() => {
     if (typeof lastChangedIndex === 'number') {
       const parsedTimeLog = parseTimeLog(task.time_log);
@@ -147,12 +174,15 @@ export function TaskTable(props: Props) {
         {company?.show_task_end_date && <Th>{t('end_date')}</Th>}
         <Th>{t('end_time')}</Th>
         <Th>{t('duration')}</Th>
+        {company?.settings.allow_billable_task_items && (
+          <Th>{t('billable')}</Th>
+        )}
         <Th></Th>
       </Thead>
       <Tbody>
         {task.time_log &&
           (JSON.parse(task.time_log) as TimeLogsType).map(
-            ([start, stop, description], index) => (
+            ([start, stop, description, billable], index) => (
               <>
                 <Tr>
                   <Td>
@@ -209,6 +239,21 @@ export function TaskTable(props: Props) {
                     />
                   </Td>
 
+                  {company?.settings.allow_billable_task_items && (
+                    <Td>
+                      <Checkbox
+                        checked={billable || false}
+                        onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                          handleBillableChange(
+                            event.target.checked,
+                            index,
+                            LogPosition.Billable
+                          )
+                        }
+                      />
+                    </Td>
+                  )}
+
                   <Td
                     rowSpan={
                       company?.settings.show_task_item_description ? 2 : 1
@@ -225,7 +270,7 @@ export function TaskTable(props: Props) {
 
                 {company?.settings.show_task_item_description && (
                   <Tr>
-                    <Td colSpan={company?.show_task_end_date ? 5 : 4}>
+                    <Td colSpan={getDescriptionColSpan()}>
                       <InputField
                         element="textarea"
                         textareaRows={2}

--- a/src/pages/tasks/common/helpers/calculate-time.ts
+++ b/src/pages/tasks/common/helpers/calculate-time.ts
@@ -10,7 +10,7 @@
 
 import dayjs from 'dayjs';
 
-export type TimeLogType = [number, number, string];
+export type TimeLogType = [number, number, string, boolean];
 export type TimeLogsType = TimeLogType[];
 
 export function parseTimeLog(log: string) {
@@ -18,7 +18,7 @@ export function parseTimeLog(log: string) {
     return [];
   }
 
-  const defaultRow: TimeLogsType = [[0, 0, '']];
+  const defaultRow: TimeLogsType = [[0, 0, '', false]];
   const parsed: TimeLogsType = JSON.parse(log);
 
   if (!parsed.length) {


### PR DESCRIPTION
@beganovich @turbo124 PR includes adding a `Billable` column to the time logs table and a toggle field to handle the `allow_billable_task_items` property. Screenshots:

![Screenshot 2023-03-27 at 20 48 49](https://user-images.githubusercontent.com/51542191/228079286-db94104c-04ce-4a18-8aa1-d26863e2a2dc.png)

![Screenshot 2023-03-27 at 20 57 46](https://user-images.githubusercontent.com/51542191/228079314-4487d673-9cd7-44a7-852c-b9f5ac23e118.png)

![Screenshot 2023-03-27 at 20 58 52](https://user-images.githubusercontent.com/51542191/228079330-2ab891fc-6653-4e4f-8c8f-8c61f5d489e1.png)

I added two keywords that we don't have in the translation files yet to the toggle field, `allow_billable_task_items` and `allow_billable_task_items_help`. So if you agree with me, please just add them to the translation files.

Let me know your thoughts.