### PR TITLE
[Bugfix] Password Confirmation Navigation/Closing

### DIFF
--- a/src/components/PasswordConfirmation.tsx
+++ b/src/components/PasswordConfirmation.tsx
@@ -9,7 +9,7 @@
  */
 import { ChangeEvent, FormEvent, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { Button, InputField } from './forms';
 import { Modal } from './Modal';
 
@@ -22,6 +22,7 @@ interface Props {
 export function PasswordConfirmation(props: Props) {
   const [t] = useTranslation();
   const navigate = useNavigate();
+  const location = useLocation();
 
   const [isModalOpen, setIsModalOpen] = useState(props.show ?? false);
   const [currentPassword, setCurrentPassword] = useState('');
@@ -42,7 +43,11 @@ export function PasswordConfirmation(props: Props) {
 
   return (
     <Modal
-      onClose={() => navigate('/settings/users')}
+      onClose={() =>
+        location.pathname.startsWith('/settings/users')
+          ? navigate('/settings/users')
+          : props.onClose(false)
+      }
       visible={isModalOpen}
       title={t('confirmation')}
       text={t('please_enter_your_password')}


### PR DESCRIPTION
@beganovich @turbo124 The last time when I was working on improving the behavior of the `/settings/users/:id/edit` page when the user closes the `Password Confirmation` modal, I didn't notice that we were using the same component in the rest of the app. So when the user clicks the `X` on any Password Confirmation modal, the user will be navigated to the `/settings/users` page, even though it's a completely different page.

So I fixed that and just added a condition to navigate the user to the `/settings/users` page only if the user closes the modal from the `/settings/users/:id/edit` page. 

Note: Sorry for this little mistake on the last PR.

Let me know your thoughts.