### PR TITLE
[Bugfix] More Actions Dropdown | Payment Edit Page

### DIFF
--- a/src/pages/payments/Payment.tsx
+++ b/src/pages/payments/Payment.tsx
@@ -11,12 +11,13 @@
 import { route } from '$app/common/helpers/route';
 import { Payment as PaymentEntity } from '$app/common/interfaces/payment';
 import { ValidationBag } from '$app/common/interfaces/validation-bag';
+import { usePaymentQuery } from '$app/common/queries/payments';
 import { Page } from '$app/components/Breadcrumbs';
 import { Container } from '$app/components/Container';
 import { Default } from '$app/components/layouts/Default';
 import { ResourceActions } from '$app/components/ResourceActions';
 import { Tab, Tabs } from '$app/components/Tabs';
-import { FormEvent, useState } from 'react';
+import { FormEvent, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Outlet, useParams } from 'react-router-dom';
 import { useActions } from './common/hooks/useActions';
@@ -26,6 +27,8 @@ export function Payment() {
   const [t] = useTranslation();
 
   const { id } = useParams();
+
+  const { data } = usePaymentQuery({ id });
 
   const [paymentValue, setPaymentValue] = useState<PaymentEntity>();
 
@@ -57,6 +60,19 @@ export function Payment() {
   const onSave = useSave(setErrors);
 
   const actions = useActions();
+
+  useEffect(() => {
+    if (data) {
+      const paymentResponse: PaymentEntity = {
+        ...data.data.data,
+        invoices: [],
+        credits: [],
+      };
+      delete paymentResponse.documents;
+
+      setPaymentValue(paymentResponse);
+    }
+  }, [data]);
 
   return (
     <Default

--- a/src/pages/payments/common/hooks/useActions.tsx
+++ b/src/pages/payments/common/hooks/useActions.tsx
@@ -26,13 +26,15 @@ import {
   MdSend,
   MdSettingsBackupRestore,
 } from 'react-icons/md';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 
 export function useActions() {
+  const { id } = useParams();
+
   const [t] = useTranslation();
   const location = useLocation();
 
-  const isEditPage = location.pathname.endsWith('/edit');
+  const isEditPage = location.pathname.includes(id!);
 
   const bulk = useBulk();
 
@@ -65,7 +67,11 @@ export function useActions() {
         {t('email_payment')}
       </DropdownElement>
     ),
-    () => isEditPage && <Divider withoutPadding />,
+    (payment: Payment) =>
+      isEditPage &&
+      getEntityState(payment) !== EntityState.Deleted && (
+        <Divider withoutPadding />
+      ),
     (payment: Payment) =>
       getEntityState(payment) === EntityState.Active &&
       isEditPage && (
@@ -77,8 +83,8 @@ export function useActions() {
         </DropdownElement>
       ),
     (payment: Payment) =>
-      (getEntityState(payment) === EntityState.Archived ||
-        getEntityState(payment) === EntityState.Deleted) &&
+      getEntityState(payment) === EntityState.Archived &&
+      getEntityState(payment) !== EntityState.Deleted &&
       isEditPage && (
         <DropdownElement
           onClick={() => bulk(payment.id, 'restore')}

--- a/src/pages/payments/edit/Edit.tsx
+++ b/src/pages/payments/edit/Edit.tsx
@@ -14,14 +14,13 @@ import paymentType from '$app/common/constants/payment-type';
 import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { useTitle } from '$app/common/hooks/useTitle';
 import { Payment } from '$app/common/interfaces/payment';
-import { usePaymentQuery } from '$app/common/queries/payments';
 import { Divider } from '$app/components/cards/Divider';
 import { ConvertCurrency } from '$app/components/ConvertCurrency';
 import { CustomField } from '$app/components/CustomField';
 import Toggle from '$app/components/forms/Toggle';
-import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import { Dispatch, SetStateAction, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useOutletContext, useParams } from 'react-router-dom';
+import { useOutletContext } from 'react-router-dom';
 import { PaymentOverview } from './PaymentOverview';
 import { ClientCard } from '$app/pages/clients/show/components/ClientCard';
 import { ValidationBag } from '$app/common/interfaces/validation-bag';
@@ -37,25 +36,13 @@ export function Edit() {
   const { documentTitle } = useTitle('edit_payment');
   const [t] = useTranslation();
 
-  const context: Context = useOutletContext();
+  const context = useOutletContext<Context>();
 
   const { setPayment, payment, errors } = context;
 
   const [convertCurrency, setConvertCurrency] = useState(false);
 
-  const { id } = useParams();
-  const { data } = usePaymentQuery({ id });
-
   const company = useCurrentCompany();
-
-  useEffect(() => {
-    if (data?.data.data) {
-      const payment: Payment = { ...data.data.data, invoices: [], credits: [] };
-      delete payment.documents;
-
-      setPayment(payment);
-    }
-  }, [data]);
 
   const handleChange = <
     TField extends keyof Payment,
@@ -70,7 +57,7 @@ export function Edit() {
   return (
     <Card title={documentTitle}>
       {payment?.client && <ClientCard client={payment.client} />}
-      {payment && <PaymentOverview payment={data?.data.data} />}
+      {payment && <PaymentOverview payment={payment} />}
 
       <Divider />
 

--- a/src/pages/payments/routes.tsx
+++ b/src/pages/payments/routes.tsx
@@ -60,27 +60,11 @@ export const paymentRoutes = (
         />
       }
     >
+      <Route path="edit" element={<Edit />} />
       <Route path="documents" element={<Documents />} />
       <Route path="payment_fields" element={<PaymentFields />} />
       <Route path="apply" element={<Apply />} />
       <Route path="refund" element={<Refund />} />
-    </Route>
-    <Route path=":id/edit" element={<Payment />}>
-      <Route
-        path=""
-        element={
-          <Guard
-            guards={[
-              or(
-                permission('edit_payment'),
-                permission('view_payment'),
-                assigned('/api/v1/payments/:id')
-              ),
-            ]}
-            component={<Edit />}
-          />
-        }
-      />
     </Route>
   </Route>
 );


### PR DESCRIPTION
@beganovich @turbo124 We had a bug with hidden `More Actions` dropdown if we change the tab from `Edit` to `Documents/Custom Fields`. I fixed it and improved the UX for bulk actions here. For this entity, if we delete it, we will not be able to get it back. So now, if the user deletes a payment from the edit page, there is no bulk action under the dropdown that will be available to call. The same behavior will be implemented on the table, but on a different PR. Let me know your thoughts.