### PR TITLE
[Bugfix] Total Fields Reordering | Invoice Design Tabs Reordering

### DIFF
--- a/src/pages/invoices/common/components/InvoiceTotals.tsx
+++ b/src/pages/invoices/common/components/InvoiceTotals.tsx
@@ -48,44 +48,13 @@ export function InvoiceTotals(props: Props) {
 
   return (
     <Card className="col-span-12 xl:col-span-4 h-max">
-      {variables.map((variable, index) => (
-        <Fragment key={index}>{resolveVariable(variable)}</Fragment>
-      ))}
-
-      {company && company?.custom_fields?.surcharge1 && (
-        <CustomSurchargeField
-          field="surcharge1"
-          defaultValue={resource?.custom_surcharge1}
-          value={resource?.custom_surcharge1.toString() || ''}
-          onValueChange={(value) => handleChange('custom_surcharge1', value)}
-        />
-      )}
-
-      {company && company?.custom_fields?.surcharge2 && (
-        <CustomSurchargeField
-          field="surcharge2"
-          defaultValue={resource?.custom_surcharge2}
-          value={resource?.custom_surcharge2.toString() || ''}
-          onValueChange={(value) => handleChange('custom_surcharge2', value)}
-        />
-      )}
-
-      {company && company?.custom_fields?.surcharge3 && (
-        <CustomSurchargeField
-          field="surcharge3"
-          defaultValue={resource?.custom_surcharge3}
-          value={resource?.custom_surcharge3.toString() || ''}
-          onValueChange={(value) => handleChange('custom_surcharge3', value)}
-        />
-      )}
-
-      {company && company?.custom_fields?.surcharge4 && (
-        <CustomSurchargeField
-          field="surcharge4"
-          defaultValue={resource?.custom_surcharge4}
-          value={resource?.custom_surcharge4.toString() || ''}
-          onValueChange={(value) => handleChange('custom_surcharge4', value)}
-        />
+      {variables.map(
+        (variable, index) =>
+          (variable === '$subtotal' ||
+            variable === '$paid_to_date' ||
+            variable === '$taxes') && (
+            <Fragment key={index}>{resolveVariable(variable)}</Fragment>
+          )
       )}
 
       {company && company.enabled_tax_rates > 0 && (
@@ -173,6 +142,51 @@ export function InvoiceTotals(props: Props) {
             onInputFocus={() => setCurrentTaxRateInput(3)}
           />
         </Element>
+      )}
+
+      {variables.map(
+        (variable, index) =>
+          variable !== '$subtotal' &&
+          variable !== '$paid_to_date' &&
+          variable !== '$taxes' && (
+            <Fragment key={index}>{resolveVariable(variable)}</Fragment>
+          )
+      )}
+
+      {company && company?.custom_fields?.surcharge1 && (
+        <CustomSurchargeField
+          field="surcharge1"
+          defaultValue={resource?.custom_surcharge1}
+          value={resource?.custom_surcharge1.toString() || ''}
+          onValueChange={(value) => handleChange('custom_surcharge1', value)}
+        />
+      )}
+
+      {company && company?.custom_fields?.surcharge2 && (
+        <CustomSurchargeField
+          field="surcharge2"
+          defaultValue={resource?.custom_surcharge2}
+          value={resource?.custom_surcharge2.toString() || ''}
+          onValueChange={(value) => handleChange('custom_surcharge2', value)}
+        />
+      )}
+
+      {company && company?.custom_fields?.surcharge3 && (
+        <CustomSurchargeField
+          field="surcharge3"
+          defaultValue={resource?.custom_surcharge3}
+          value={resource?.custom_surcharge3.toString() || ''}
+          onValueChange={(value) => handleChange('custom_surcharge3', value)}
+        />
+      )}
+
+      {company && company?.custom_fields?.surcharge4 && (
+        <CustomSurchargeField
+          field="surcharge4"
+          defaultValue={resource?.custom_surcharge4}
+          value={resource?.custom_surcharge4.toString() || ''}
+          onValueChange={(value) => handleChange('custom_surcharge4', value)}
+        />
       )}
     </Card>
   );

--- a/src/pages/invoices/common/hooks/useResolveTotalVariable.tsx
+++ b/src/pages/invoices/common/hooks/useResolveTotalVariable.tsx
@@ -112,7 +112,7 @@ export function useResolveTotalVariable(props: Props) {
       );
     }
 
-    if (variable == '$balance' && invoiceSum) {
+    if (variable == '$balance_due' && invoiceSum) {
       return (
         <Element leftSide={resolveTranslation(variable, '$')}>
           {formatMoney(invoiceSum.invoice.balance)}

--- a/src/pages/invoices/common/hooks/useTotalVariables.ts
+++ b/src/pages/invoices/common/hooks/useTotalVariables.ts
@@ -18,7 +18,7 @@ export function useTotalVariables() {
   useEffect(() => {
     // We need to clone the product columns to local object,
     // because by default it's frozen.
-    let variables: string[] = ['$net_subtotal'];
+    let variables: string[] = ['$subtotal'];
     // clone(company?.settings.pdf_variables.total_columns) || [];
 
     // In case we have `$line_taxes` or `$total_taxes` we want to remove them
@@ -57,7 +57,7 @@ export function useTotalVariables() {
 
     variables.push('$total');
     variables.push('$paid_to_date');
-    variables.push('$balance');
+    variables.push('$balance_due');
     variables.push('$taxes');
 
     setColumns(variables);

--- a/src/pages/settings/invoice-design/common/hooks.tsx
+++ b/src/pages/settings/invoice-design/common/hooks.tsx
@@ -21,6 +21,10 @@ export function useInvoiceDesignTabs() {
       href: route('/settings/invoice_design'),
     },
     {
+      name: t('total_fields'),
+      href: route('/settings/invoice_design/total_fields'),
+    },
+    {
       name: t('client_details'),
       href: route('/settings/invoice_design/client_details'),
     },
@@ -59,10 +63,6 @@ export function useInvoiceDesignTabs() {
     {
       name: t('task_columns'),
       href: route('/settings/invoice_design/task_columns'),
-    },
-    {
-      name: t('total_fields'),
-      href: route('/settings/invoice_design/total_fields'),
     },
   ];
 


### PR DESCRIPTION
@beganovich @turbo124 PR includes reordering for total variables and invoice design tabs. Screenshots:

![Screenshot 2023-03-31 at 03 22 17](https://user-images.githubusercontent.com/51542191/229001035-72422734-2b34-4c13-8a07-43cf195820f0.png)

![Screenshot 2023-03-31 at 03 29 38](https://user-images.githubusercontent.com/51542191/229001049-8a7e9071-38be-4151-9115-73df5cd64432.png)

Note: The `Total Fields` tab has just been moved from the last place to the second place.

Let me know your thoughts.