### PR TITLE
[Bugfix] View In Portal Link | Invoice Edit Page

### DIFF
--- a/src/pages/invoices/common/components/ClientSelector.tsx
+++ b/src/pages/invoices/common/components/ClientSelector.tsx
@@ -106,7 +106,7 @@ export function ClientSelector(props: Props) {
             <div>
               <p className="text-sm text-gray-700">{contact.email}</p>
 
-              <Link to={contact.link} external>
+              <Link to={resource.invitations[0].link} external>
                 {t('view_in_portal')}
               </Link>
             </div>


### PR DESCRIPTION
@beganovich @turbo124 PR includes changing `view_in_portal` link for `Invoice|Recurring Invoice` Edit page. Now, navigation will go to `invoice.invitations.link/recurringInvoice.invitations.link` link. Let me know your thoughts.