### PR TITLE
[Bugfix] View In Portal Link | Checking Invitation Length

### DIFF
--- a/src/pages/invoices/common/components/ClientSelector.tsx
+++ b/src/pages/invoices/common/components/ClientSelector.tsx
@@ -106,7 +106,7 @@ export function ClientSelector(props: Props) {
             <div>
               <p className="text-sm text-gray-700">{contact.email}</p>
 
-              {resource.invitations.length && (
+              {resource.invitations.length >= 1 && (
                 <Link to={resource.invitations[0].link} external>
                   {t('view_in_portal')}
                 </Link>

--- a/src/pages/invoices/common/components/ClientSelector.tsx
+++ b/src/pages/invoices/common/components/ClientSelector.tsx
@@ -106,9 +106,11 @@ export function ClientSelector(props: Props) {
             <div>
               <p className="text-sm text-gray-700">{contact.email}</p>
 
-              <Link to={resource.invitations[0].link} external>
-                {t('view_in_portal')}
-              </Link>
+              {resource.invitations.length && (
+                <Link to={resource.invitations[0].link} external>
+                  {t('view_in_portal')}
+                </Link>
+              )}
             </div>
           </div>
         ))}


### PR DESCRIPTION
@beganovich @turbo124 While I was working on the `view_in_portal` action link on the `medium@example.com` account for testing last night, I didn't have a chance to find this bug when we need to check the length of the invitations. But after updating the seeder and working on the e2e tests task, I found that we need to check the contact invitations length so that we don't break the app. Everything is the same, I just added this security condition. A bug occurred in some cases when we selected a client when creating an invoice. Let me know your thoughts.