### PR TITLE
[Cleanup] Additional Save Options | Recurring Invoice

### DIFF
--- a/src/components/layouts/Default.tsx
+++ b/src/components/layouts/Default.tsx
@@ -8,7 +8,7 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
-import { ReactNode, useState } from 'react';
+import { FormEvent, ReactElement, ReactNode, useState } from 'react';
 import {
   Home,
   Menu as MenuIcon,
@@ -48,6 +48,14 @@ import { useUnlockButtonForHosted } from '$app/common/hooks/useUnlockButtonForHo
 import { useUnlockButtonForSelfHosted } from '$app/common/hooks/useUnlockButtonForSelfHosted';
 import { useCurrentCompanyUser } from '$app/common/hooks/useCurrentCompanyUser';
 import { useEnabled } from '$app/common/guards/guards/enabled';
+import { Dropdown } from '$app/components/dropdown/Dropdown';
+import { DropdownElement } from '$app/components/dropdown/DropdownElement';
+
+export interface SaveOption {
+  label: string;
+  onClick: (event: FormEvent<HTMLFormElement>) => unknown;
+  icon?: ReactElement;
+}
 
 interface Props extends CommonProps {
   title?: string | null;
@@ -61,6 +69,7 @@ interface Props extends CommonProps {
   backButtonLabel?: string;
   disableSaveButton?: boolean;
   withoutBackButton?: boolean;
+  additionalSaveOptions?: SaveOption[];
 }
 
 export function Default(props: Props) {
@@ -423,13 +432,47 @@ export function Default(props: Props) {
                 )}
 
                 {props.onSaveClick && (
-                  <Button
-                    disabled={props.disableSaveButton}
-                    disableWithoutIcon
-                    onClick={props.onSaveClick}
-                  >
-                    {props.saveButtonLabel ?? t('save')}
-                  </Button>
+                  <div>
+                    {props.onSaveClick && !props.additionalSaveOptions && (
+                      <Button
+                        onClick={props.onSaveClick}
+                        disabled={props.disableSaveButton}
+                        disableWithoutIcon
+                      >
+                        {props.saveButtonLabel ?? t('save')}
+                      </Button>
+                    )}
+
+                    {props.onSaveClick && props.additionalSaveOptions && (
+                      <div className="flex">
+                        <Button
+                          className="rounded-br-none rounded-tr-none px-3"
+                          onClick={props.onSaveClick}
+                          disabled={props.disableSaveButton}
+                          disableWithoutIcon
+                        >
+                          {props.saveButtonLabel ?? t('save')}
+                        </Button>
+
+                        <Dropdown
+                          className="rounded-bl-none rounded-tl-none h-full px-1 border-gray-200 border-l-1 border-y-0 border-r-0"
+                          cardActions
+                          disabled={props.disableSaveButton}
+                        >
+                          {props.additionalSaveOptions.map((option, index) => (
+                            <DropdownElement
+                              key={index}
+                              icon={option.icon}
+                              disabled={props.disableSaveButton}
+                              onClick={option.onClick}
+                            >
+                              {option.label}
+                            </DropdownElement>
+                          ))}
+                        </Dropdown>
+                      </div>
+                    )}
+                  </div>
                 )}
 
                 <div className="space-x-3 items-center hidden lg:flex">

--- a/src/pages/invoices/common/components/ClientSelector.tsx
+++ b/src/pages/invoices/common/components/ClientSelector.tsx
@@ -106,7 +106,7 @@ export function ClientSelector(props: Props) {
             <div>
               <p className="text-sm text-gray-700">{contact.email}</p>
 
-              <Link to={resource.invitations[0]?.link} external>
+              <Link to={resource.invitations[0].link} external>
                 {t('view_in_portal')}
               </Link>
             </div>

--- a/src/pages/invoices/common/components/ClientSelector.tsx
+++ b/src/pages/invoices/common/components/ClientSelector.tsx
@@ -106,7 +106,7 @@ export function ClientSelector(props: Props) {
             <div>
               <p className="text-sm text-gray-700">{contact.email}</p>
 
-              <Link to={resource.invitations[0].link} external>
+              <Link to={resource.invitations[0]?.link} external>
                 {t('view_in_portal')}
               </Link>
             </div>

--- a/src/pages/recurring-invoices/common/hooks.tsx
+++ b/src/pages/recurring-invoices/common/hooks.tsx
@@ -200,7 +200,10 @@ export function useSave(props: RecurringInvoiceSaveProps) {
   const { setErrors } = props;
   const queryClient = useQueryClient();
 
-  return (recurringInvoice: RecurringInvoice, queryAction?: 'send_now') => {
+  return (
+    recurringInvoice: RecurringInvoice,
+    queryAction?: 'send_now' | 'start'
+  ) => {
     toast.processing();
     setErrors(undefined);
 

--- a/src/pages/recurring-invoices/common/hooks.tsx
+++ b/src/pages/recurring-invoices/common/hooks.tsx
@@ -207,11 +207,9 @@ export function useSave(props: RecurringInvoiceSaveProps) {
     toast.processing();
     setErrors(undefined);
 
-    let endpointUrl = '/api/v1/recurring_invoices/:id';
-
-    if (queryAction) {
-      endpointUrl = `/api/v1/recurring_invoices/:id?${queryAction}=true`;
-    }
+    const endpointUrl = queryAction
+      ? `/api/v1/recurring_invoices/:id?${queryAction}=true`
+      : '/api/v1/recurring_invoices/:id';
 
     request(
       'PUT',
@@ -459,11 +457,9 @@ export function useCreate({ setErrors }: RecurringInvoiceSaveProps) {
     setErrors(undefined);
     toast.processing();
 
-    let endpointUrl = '/api/v1/recurring_invoices';
-
-    if (queryAction) {
-      endpointUrl = `/api/v1/recurring_invoices?${queryAction}=true`;
-    }
+    const endpointUrl = queryAction
+      ? `/api/v1/recurring_invoices?${queryAction}=true`
+      : '/api/v1/recurring_invoices';
 
     request('POST', endpoint(endpointUrl), recurringInvoice)
       .then((response: GenericSingleResourceResponse<RecurringInvoice>) => {

--- a/src/pages/recurring-invoices/common/hooks.tsx
+++ b/src/pages/recurring-invoices/common/hooks.tsx
@@ -200,13 +200,19 @@ export function useSave(props: RecurringInvoiceSaveProps) {
   const { setErrors } = props;
   const queryClient = useQueryClient();
 
-  return (recurringInvoice: RecurringInvoice) => {
+  return (recurringInvoice: RecurringInvoice, queryAction?: 'send_now') => {
     toast.processing();
     setErrors(undefined);
 
+    let endpointUrl = '/api/v1/recurring_invoices/:id';
+
+    if (queryAction) {
+      endpointUrl = '/api/v1/recurring_invoices/:id?' + queryAction + '=true';
+    }
+
     request(
       'PUT',
-      endpoint('/api/v1/recurring_invoices/:id', { id: recurringInvoice.id }),
+      endpoint(endpointUrl, { id: recurringInvoice.id }),
       recurringInvoice
     )
       .then(() => {
@@ -443,11 +449,20 @@ export function useActions() {
 export function useCreate({ setErrors }: RecurringInvoiceSaveProps) {
   const navigate = useNavigate();
 
-  return (recurringInvoice: RecurringInvoice) => {
+  return (
+    recurringInvoice: RecurringInvoice,
+    queryAction?: 'start' | 'send_now'
+  ) => {
     setErrors(undefined);
     toast.processing();
 
-    request('POST', endpoint('/api/v1/recurring_invoices'), recurringInvoice)
+    let endpointUrl = '/api/v1/recurring_invoices';
+
+    if (queryAction) {
+      endpointUrl = '/api/v1/recurring_invoices?' + queryAction + '=true';
+    }
+
+    request('POST', endpoint(endpointUrl), recurringInvoice)
       .then((response: GenericSingleResourceResponse<RecurringInvoice>) => {
         toast.success('created_recurring_invoice');
 

--- a/src/pages/recurring-invoices/common/hooks.tsx
+++ b/src/pages/recurring-invoices/common/hooks.tsx
@@ -210,7 +210,7 @@ export function useSave(props: RecurringInvoiceSaveProps) {
     let endpointUrl = '/api/v1/recurring_invoices/:id';
 
     if (queryAction) {
-      endpointUrl = '/api/v1/recurring_invoices/:id?' + queryAction + '=true';
+      endpointUrl = `/api/v1/recurring_invoices/:id?${queryAction}=true`;
     }
 
     request(
@@ -462,7 +462,7 @@ export function useCreate({ setErrors }: RecurringInvoiceSaveProps) {
     let endpointUrl = '/api/v1/recurring_invoices';
 
     if (queryAction) {
-      endpointUrl = '/api/v1/recurring_invoices?' + queryAction + '=true';
+      endpointUrl = `/api/v1/recurring_invoices?${queryAction}=true`;
     }
 
     request('POST', endpoint(endpointUrl), recurringInvoice)

--- a/src/pages/recurring-invoices/create/Create.tsx
+++ b/src/pages/recurring-invoices/create/Create.tsx
@@ -151,12 +151,12 @@ export function Create() {
   const saveOptions: SaveOption[] = [
     {
       onClick: () => save(recurringInvoice as RecurringInvoice, 'send_now'),
-      label: `${t('save')} & ${t('send')}`,
+      label: t('send_now'),
       icon: <Icon element={MdSend} />,
     },
     {
       onClick: () => save(recurringInvoice as RecurringInvoice, 'start'),
-      label: `${t('save')} & ${t('start')}`,
+      label: t('start'),
       icon: <Icon element={MdNotStarted} />,
     },
   ];
@@ -166,7 +166,6 @@ export function Create() {
       title={documentTitle}
       breadcrumbs={pages}
       disableSaveButton={!recurringInvoice?.client_id}
-      saveButtonLabel={t('save_draft')}
       onSaveClick={() => save(recurringInvoice as RecurringInvoice)}
       additionalSaveOptions={saveOptions}
     >

--- a/src/pages/recurring-invoices/create/Create.tsx
+++ b/src/pages/recurring-invoices/create/Create.tsx
@@ -17,7 +17,7 @@ import { InvoiceItemType } from '$app/common/interfaces/invoice-item';
 import { RecurringInvoice } from '$app/common/interfaces/recurring-invoice';
 import { ValidationBag } from '$app/common/interfaces/validation-bag';
 import { Page } from '$app/components/Breadcrumbs';
-import { Default } from '$app/components/layouts/Default';
+import { Default, SaveOption } from '$app/components/layouts/Default';
 import { Spinner } from '$app/components/Spinner';
 import { useAtom } from 'jotai';
 import { cloneDeep } from 'lodash';
@@ -34,6 +34,8 @@ import { InvoiceDetails } from '../common/components/InvoiceDetails';
 import { InvoiceFooter } from '../common/components/InvoiceFooter';
 import { useCreate, useRecurringInvoiceUtilities } from '../common/hooks';
 import { useBlankRecurringInvoiceQuery } from '../common/queries';
+import { Icon } from '$app/components/icons/Icon';
+import { MdNotStarted, MdSend } from 'react-icons/md';
 
 export function Create() {
   const { documentTitle } = useTitle('new_recurring_invoice');
@@ -146,12 +148,27 @@ export function Create() {
 
   const save = useCreate({ setErrors });
 
+  const saveOptions: SaveOption[] = [
+    {
+      onClick: () => save(recurringInvoice as RecurringInvoice, 'send_now'),
+      label: `${t('save')} & ${t('send')}`,
+      icon: <Icon element={MdSend} />,
+    },
+    {
+      onClick: () => save(recurringInvoice as RecurringInvoice, 'start'),
+      label: `${t('save')} & ${t('start')}`,
+      icon: <Icon element={MdNotStarted} />,
+    },
+  ];
+
   return (
     <Default
       title={documentTitle}
       breadcrumbs={pages}
+      disableSaveButton={!recurringInvoice?.client_id}
+      saveButtonLabel={t('save_draft')}
       onSaveClick={() => save(recurringInvoice as RecurringInvoice)}
-      disableSaveButton={recurringInvoice?.client_id.length === 0}
+      additionalSaveOptions={saveOptions}
     >
       <div className="grid grid-cols-12 gap-4">
         <ClientSelector

--- a/src/pages/recurring-invoices/edit/Edit.tsx
+++ b/src/pages/recurring-invoices/edit/Edit.tsx
@@ -16,7 +16,7 @@ import { Client } from '$app/common/interfaces/client';
 import { InvoiceItemType } from '$app/common/interfaces/invoice-item';
 import { ValidationBag } from '$app/common/interfaces/validation-bag';
 import { Page } from '$app/components/Breadcrumbs';
-import { Default } from '$app/components/layouts/Default';
+import { Default, SaveOption } from '$app/components/layouts/Default';
 import { ResourceActions } from '$app/components/ResourceActions';
 import { Spinner } from '$app/components/Spinner';
 import { useAtom } from 'jotai';
@@ -39,6 +39,10 @@ import {
   useSave,
 } from '../common/hooks';
 import { useRecurringInvoiceQuery } from '../common/queries';
+import { Icon } from '$app/components/icons/Icon';
+import { RecurringInvoice } from '$app/common/interfaces/recurring-invoice';
+import { MdSend } from 'react-icons/md';
+import { RecurringInvoiceStatus } from '$app/common/enums/recurring-invoice-status';
 
 export function Edit() {
   const { t } = useTranslation();
@@ -99,11 +103,24 @@ export function Edit() {
   const actions = useActions();
   const save = useSave({ setErrors });
 
+  const saveOptions: SaveOption[] | undefined =
+    recurringInvoice?.status_id === RecurringInvoiceStatus.DRAFT
+      ? [
+          {
+            onClick: () =>
+              save(recurringInvoice as RecurringInvoice, 'send_now'),
+            label: `${t('save')} & ${t('send')}`,
+            icon: <Icon element={MdSend} />,
+          },
+        ]
+      : undefined;
+
   return (
     <Default
       title={documentTitle}
       breadcrumbs={pages}
       onSaveClick={() => recurringInvoice && save(recurringInvoice)}
+      additionalSaveOptions={saveOptions}
       navigationTopRight={
         recurringInvoice && (
           <ResourceActions


### PR DESCRIPTION
@beganovich @turbo124 PR includes adding new save options to the `Recurring Invoice` creation and editing page to avoid two steps for sending and starting invoice. I've tried several solutions and this one makes the most sense for me, and this one is much more customizable than the others.

- We have a solution to put additional actions in the `More Actions` dropdown, but I haven't implemented it because I'm not sure it will be good for UX. I don't think the user will ever open that extra drop down menu to see if there is an extra way to save the invoice.

- Also, I tried the solution from the Flutter app with all separate buttons. But it will create a problem with responsiveness, there will be many more buttons to fit on a small screen. Screenshot:

![Screenshot 2023-04-02 at 01 52 48](https://user-images.githubusercontent.com/51542191/229360491-dea505b1-38ca-457f-a9e8-cc622f5997fc.png)

There is a solution to keep only the `Save Draft CTA` on small screens, but include everything on large screens. Let me know your thoughts about this one.

- IMO, the best solution for us here is to implement something very similar to the solution for expense categories and other entities where we have an additional `Save & Create` action. So, I implemented it here. We have two additional CTAs `Save & Send` and `Save & Start`. On the edit page, `Save & Send` is only available if the invoice is in Draft status. Screenshots:

![Screenshot 2023-04-02 at 03 10 14](https://user-images.githubusercontent.com/51542191/229360746-76c16b44-41be-4ff2-885f-e358a0451632.png)

![Screenshot 2023-04-02 at 02 40 23](https://user-images.githubusercontent.com/51542191/229360762-b4fcda72-230b-4c95-bd73-8f23b69235f3.png)

Let me know your thoughts.