### PR TITLE
[Bugfix] Payment Terms Text Centering

### DIFF
--- a/src/pages/settings/online-payments/OnlinePayments.tsx
+++ b/src/pages/settings/online-payments/OnlinePayments.tsx
@@ -115,24 +115,28 @@ export function OnlinePayments() {
         </Element>
 
         {paymentTerms && (
-          <Element leftSide={t('payment_terms')}>
-            <SelectField
-              value={company?.settings?.payment_terms}
-              id="settings.payment_terms"
-              onChange={handleChange}
-            >
-              <option value=""></option>
-              {paymentTerms.map((type: PaymentTerm) => (
-                <option key={type.id} value={type.num_days}>
-                  {type.name}
-                </option>
-              ))}
-            </SelectField>
+          <>
+            <Element leftSide={t('payment_terms')}>
+              <SelectField
+                value={company?.settings?.payment_terms}
+                id="settings.payment_terms"
+                onChange={handleChange}
+              >
+                <option value=""></option>
+                {paymentTerms.map((type: PaymentTerm) => (
+                  <option key={type.id} value={type.num_days}>
+                    {type.name}
+                  </option>
+                ))}
+              </SelectField>
+            </Element>
 
-            <Link to="/settings/payment_terms" className="block mt-2">
-              {t('configure_payment_terms')}
-            </Link>
-          </Element>
+            <Element className="py-0 sm:py-0">
+              <Link to="/settings/payment_terms">
+                {t('configure_payment_terms')}
+              </Link>
+            </Element>
+          </>
         )}
 
         <Element leftSide={t('enable_applying_payments')}>


### PR DESCRIPTION
@beganovich @turbo124 PR includes vertical centering of the `Payment Terms` text on the `Payment Settings` page. This bug occurred because we had the text `Configure Payment Terms` in the same box with dropdown menu on the right side. Screenshot with fixed bug:

![Screenshot 2023-04-02 at 17 44 40](https://user-images.githubusercontent.com/51542191/229364046-fcf13b33-3462-409e-807a-f026f3bc369b.png)

Let me know your thoughts.