### PR TITLE
[Cleanup] View Pdf Pages | Navigation Bar Refactoring

### DIFF
--- a/src/pages/credits/pdf/Pdf.tsx
+++ b/src/pages/credits/pdf/Pdf.tsx
@@ -10,8 +10,7 @@
 
 import { route } from '$app/common/helpers/route';
 import { useTitle } from '$app/common/hooks/useTitle';
-import { Dropdown } from '$app/components/dropdown/Dropdown';
-import { DropdownElement } from '$app/components/dropdown/DropdownElement';
+import { Button } from '$app/components/forms';
 import { Icon } from '$app/components/icons/Icon';
 import { Default } from '$app/components/layouts/Default';
 import { Spinner } from '$app/components/Spinner';
@@ -19,12 +18,13 @@ import { InvoiceViewer } from '$app/pages/invoices/common/components/InvoiceView
 import { useDownloadPdf } from '$app/pages/invoices/common/hooks/useDownloadPdf';
 import { useGeneratePdfUrl } from '$app/pages/invoices/common/hooks/useGeneratePdfUrl';
 import { useTranslation } from 'react-i18next';
-import { MdCreditCard, MdDownload } from 'react-icons/md';
-import { useParams } from 'react-router-dom';
+import { MdDownload, MdSend } from 'react-icons/md';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useCreditQuery } from '../common/queries';
 
 export function Pdf() {
   const [t] = useTranslation();
+  const navigate = useNavigate();
 
   const { documentTitle } = useTitle('view_pdf');
   const { id } = useParams();
@@ -41,23 +41,29 @@ export function Pdf() {
       title={documentTitle}
       navigationTopRight={
         credit && (
-          <Dropdown label={t('more_actions')}>
-            <DropdownElement
-              onClick={() => downloadPdf(credit)}
-              icon={<Icon element={MdDownload} />}
+          <div className="flex space-x-3">
+            <Button
+              className="flex items-center space-x-1"
+              onClick={() =>
+                navigate(
+                  route('/credits/:id/email', {
+                    id: credit.id,
+                  })
+                )
+              }
             >
-              {t('download')}
-            </DropdownElement>
+              <Icon element={MdSend} color="white" />
+              <span>{t('email_credit')}</span>
+            </Button>
 
-            <DropdownElement
-              to={route('/credits/:id/email', {
-                id: credit.id,
-              })}
-              icon={<Icon element={MdCreditCard} />}
+            <Button
+              className="flex items-center space-x-1"
+              onClick={() => downloadPdf(credit)}
             >
-              {t('email_credit')}
-            </DropdownElement>
-          </Dropdown>
+              <Icon element={MdDownload} color="white" />
+              <span>{t('download')}</span>
+            </Button>
+          </div>
         )
       }
     >

--- a/src/pages/invoices/pdf/components/Actions.tsx
+++ b/src/pages/invoices/pdf/components/Actions.tsx
@@ -11,15 +11,14 @@
 import { endpoint } from '$app/common/helpers';
 import { route } from '$app/common/helpers/route';
 import { Invoice } from '$app/common/interfaces/invoice';
-import { Dropdown } from '$app/components/dropdown/Dropdown';
-import { DropdownElement } from '$app/components/dropdown/DropdownElement';
+import { Button } from '$app/components/forms';
 import Toggle from '$app/components/forms/Toggle';
 import { Icon } from '$app/components/icons/Icon';
 import { useDownloadPdf } from '$app/pages/invoices/common/hooks/useDownloadPdf';
 import { Dispatch, SetStateAction, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MdDownload, MdSend } from 'react-icons/md';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 interface Props {
   blobUrl: string;
@@ -31,6 +30,7 @@ interface Props {
 
 export function Actions(props: Props) {
   const [t] = useTranslation();
+  const navigate = useNavigate();
 
   const { id } = useParams();
 
@@ -62,7 +62,7 @@ export function Actions(props: Props) {
   }, []);
 
   return (
-    <>
+    <div className="flex space-x-3">
       <span className="inline-flex items-center">
         <Toggle
           label={t('delivery_note')}
@@ -71,21 +71,27 @@ export function Actions(props: Props) {
         />
       </span>
 
-      <Dropdown label={t('more_actions')}>
-        <DropdownElement
-          to={route('/invoices/:id/email', { id })}
-          icon={<Icon element={MdSend} />}
-        >
-          {t('email_invoice')}
-        </DropdownElement>
+      <Button
+        className="flex items-center space-x-1"
+        onClick={() =>
+          navigate(
+            route('/invoices/:id/email', {
+              id: invoice.id,
+            })
+          )
+        }
+      >
+        <Icon element={MdSend} color="white" />
+        <span>{t('email_invoice')}</span>
+      </Button>
 
-        <DropdownElement
-          onClick={() => downloadPdf(invoice)}
-          icon={<Icon element={MdDownload} />}
-        >
-          {t('download')}
-        </DropdownElement>
-      </Dropdown>
-    </>
+      <Button
+        className="flex items-center space-x-1"
+        onClick={() => downloadPdf(invoice)}
+      >
+        <Icon element={MdDownload} color="white" />
+        <span>{t('download')}</span>
+      </Button>
+    </div>
   );
 }

--- a/src/pages/quotes/pdf/Pdf.tsx
+++ b/src/pages/quotes/pdf/Pdf.tsx
@@ -10,8 +10,7 @@
 
 import { route } from '$app/common/helpers/route';
 import { useTitle } from '$app/common/hooks/useTitle';
-import { Dropdown } from '$app/components/dropdown/Dropdown';
-import { DropdownElement } from '$app/components/dropdown/DropdownElement';
+import { Button } from '$app/components/forms';
 import { Icon } from '$app/components/icons/Icon';
 import { Default } from '$app/components/layouts/Default';
 import { Spinner } from '$app/components/Spinner';
@@ -20,11 +19,12 @@ import { useDownloadPdf } from '$app/pages/invoices/common/hooks/useDownloadPdf'
 import { useGeneratePdfUrl } from '$app/pages/invoices/common/hooks/useGeneratePdfUrl';
 import { useTranslation } from 'react-i18next';
 import { MdDownload, MdSend } from 'react-icons/md';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useQuoteQuery } from '../common/queries';
 
 export function Pdf() {
   const [t] = useTranslation();
+  const navigate = useNavigate();
 
   const { documentTitle } = useTitle('view_pdf');
   const { id } = useParams();
@@ -40,21 +40,29 @@ export function Pdf() {
       title={documentTitle}
       navigationTopRight={
         quote && (
-          <Dropdown label={t('more_actions')}>
-            <DropdownElement
-              onClick={() => downloadPdf(quote)}
-              icon={<Icon element={MdDownload} />}
+          <div className="flex space-x-3">
+            <Button
+              className="flex items-center space-x-1"
+              onClick={() =>
+                navigate(
+                  route('/quotes/:id/email', {
+                    id: quote.id,
+                  })
+                )
+              }
             >
-              {t('download')}
-            </DropdownElement>
+              <Icon element={MdSend} color="white" />
+              <span>{t('email_quote')}</span>
+            </Button>
 
-            <DropdownElement
-              to={route('/quotes/:id/email', { id: quote.id })}
-              icon={<Icon element={MdSend} />}
+            <Button
+              className="flex items-center space-x-1"
+              onClick={() => downloadPdf(quote)}
             >
-              {t('email_quote')}
-            </DropdownElement>
-          </Dropdown>
+              <Icon element={MdDownload} color="white" />
+              <span>{t('download')}</span>
+            </Button>
+          </div>
         )
       }
     >


### PR DESCRIPTION
@beganovich @turbo124 PR includes refactoring for navigation bar for `View Pdf` pages. We have a PDF preview page for `Credits, Invoices, Purchase Orders, Quotes and Recurring Invoices entities`. We've implemented a `More Actions` drop-down menu with email and download functionality for `Credits, Invoices and Quotes`. So I refactored it there, but didn't add actions where we probably missed them (`Recurring Invoices and Purchase Orders`). Please let me know if I need to add actions to View Pdf pages where we don't have them. Screenshot:

![Screenshot 2023-04-02 at 18 43 06](https://user-images.githubusercontent.com/51542191/229367198-63cda32e-7f99-405a-80bd-13c53dc9eba5.png)

Let me know your thoughts.