### PR TITLE
Fixes for organising results (clearing)

### DIFF
--- a/src/components/forms/DebouncedCombobox.tsx
+++ b/src/components/forms/DebouncedCombobox.tsx
@@ -253,6 +253,15 @@ export function DebouncedCombobox(props: Props) {
               ]
             : [...current];
         });
+      } else {
+        setSelectedOption({
+          record: {
+            label: '',
+            value: '',
+            internal: true,
+          },
+          withoutEvents: true,
+        });
       }
 
       filter();


### PR DESCRIPTION
This implements a fallback to empty records when organizing (fixes for clearing the results).