### PR TITLE
[Cleanup] Translation Keyword | Marking PO Sent

### DIFF
--- a/src/pages/purchase-orders/common/queries.ts
+++ b/src/pages/purchase-orders/common/queries.ts
@@ -94,7 +94,7 @@ export function useMarkSent() {
       purchaseOrder
     )
       .then(() => {
-        toast.success('notification_purchase_order_sent');
+        toast.success('marked_purchase_order_as_sent');
 
         queryClient.invalidateQueries(
           route('/api/v1/purchase_orders/:id', { id: purchaseOrder.id })


### PR DESCRIPTION
@beganovich @turbo124 PR includes changing the translation keyword when Purchase order is marked sent to `marked_purchase_order_as_sent`. Let me know your thoughts.