### PR TITLE
[Feature] Not Found Page

### DIFF
--- a/src/common/routes.tsx
+++ b/src/common/routes.tsx
@@ -30,6 +30,7 @@ import { purchaseOrderRoutes } from '$app/pages/purchase-orders/routes';
 import { reportRoutes } from '$app/pages/reports/routes';
 import { transactionRoutes } from '$app/pages/transactions/routes';
 import { recurringExpenseRoutes } from '$app/pages/recurring-expenses/routes';
+import { NotFound } from '$app/components/NotFound';
 
 export const routes = (
   <Routes>
@@ -55,5 +56,6 @@ export const routes = (
       {settingsRoutes}
       {systemlogRoutes}
     </Route>
+    <Route path="*" element={<NotFound />} />
   </Routes>
 );

--- a/src/components/NotFound.tsx
+++ b/src/components/NotFound.tsx
@@ -1,0 +1,52 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { useLogo } from '$app/common/hooks/useLogo';
+import { Button } from '$app/components/forms';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+
+export function NotFound() {
+  const [t] = useTranslation();
+  const navigate = useNavigate();
+  const logo = useLogo();
+
+  return (
+    <div className="flex flex-col items-center justify-center h-screen space-y-10 py-16 px-5">
+      <div className="flex flex-col flex-1 justify-center items-center space-y-7">
+        <h1 className="text-8xl font-bold">404</h1>
+
+        <div className="flex flex-col text-center">
+          <h3 className="text-lg">Oops! Page not found!</h3>
+          <span>
+            <i>
+              We are sorry, it looks like the page you are looking for is not in
+              our system.
+            </i>
+          </span>
+        </div>
+
+        <Button onClick={() => navigate('/dashboard')}>
+          Back To Dashboard
+        </Button>
+      </div>
+
+      <div className="flex">
+        <div className="bg-gray-900 rounded-lg p-4 self-end">
+          <img
+            src={logo}
+            alt={t('company_logo') ?? 'Company logo'}
+            className="w-64"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/NotFound.tsx
+++ b/src/components/NotFound.tsx
@@ -8,45 +8,25 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
-import { useLogo } from '$app/common/hooks/useLogo';
-import { Button } from '$app/components/forms';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import Logo from '../resources/images/invoiceninja-logo@dark.png';
 
 export function NotFound() {
   const [t] = useTranslation();
-  const navigate = useNavigate();
-  const logo = useLogo();
 
   return (
     <div className="flex flex-col items-center justify-center h-screen space-y-10 py-16 px-5">
       <div className="flex flex-col flex-1 justify-center items-center space-y-7">
-        <h1 className="text-8xl font-bold">404</h1>
-
-        <div className="flex flex-col text-center">
-          <h3 className="text-lg">Oops! Page not found!</h3>
-          <span>
-            <i>
-              We are sorry, it looks like the page you are looking for is not in
-              our system.
-            </i>
-          </span>
-        </div>
-
-        <Button onClick={() => navigate('/dashboard')}>
-          Back To Dashboard
-        </Button>
+        <h1 className="text-2xl md:text-4xl font-bold text-center">
+          {t('api_404')}
+        </h1>
       </div>
 
-      <div className="flex">
-        <div className="bg-gray-900 rounded-lg p-4 self-end">
-          <img
-            src={logo}
-            alt={t('company_logo') ?? 'Company logo'}
-            className="w-64"
-          />
-        </div>
-      </div>
+      <img
+        src={Logo}
+        alt={t('company_logo') ?? 'Company logo'}
+        className="w-52 md:w-64"
+      />
     </div>
   );
 }

--- a/src/components/NotFound.tsx
+++ b/src/components/NotFound.tsx
@@ -15,8 +15,8 @@ export function NotFound() {
   const [t] = useTranslation();
 
   return (
-    <div className="flex flex-col items-center justify-center h-screen space-y-10 py-16 px-5">
-      <div className="flex flex-col flex-1 justify-center items-center space-y-7">
+    <div className="flex flex-col items-center h-screen py-16 px-5">
+      <div className="flex flex-1 items-center">
         <h1 className="text-2xl md:text-4xl font-bold text-center">
           {t('api_404')}
         </h1>


### PR DESCRIPTION
@beganovich @turbo124 PR includes creating a `Not-Found` page for all routes that we don't have in our application, but the user somehow enters them. I tried to make the page as simple and clear as possible without any background images and stuff like that. Here is a screenshot:

![Screenshot 2023-04-08 at 16 46 10](https://user-images.githubusercontent.com/51542191/230728578-7987b76f-297a-4715-86de-cd7b091b5d8c.png)

`Note`: I used plain text with no translation keywords to show how the UI might end up looking once we get the translation keywords. If you agree with this text concept, just give me suggestions for translation keywords.

Let me know your thoughs.