### PR TITLE
[Feature] Additional e2e tests - Expense Entity

### DIFF
--- a/tests/e2e/expenses.spec.ts
+++ b/tests/e2e/expenses.spec.ts
@@ -1,53 +1,97 @@
 import { login, logout, permissions } from '$tests/e2e/helpers';
-import test, { expect } from '@playwright/test';
+import test, { expect, Page } from '@playwright/test';
+
+const createExpense = async (page: Page) => {
+  await page
+    .getByRole('main')
+    .getByRole('link', { name: 'Enter Expense' })
+    .click();
+
+  await page.waitForTimeout(200);
+
+  await page.getByRole('button', { name: 'Save' }).click();
+};
 
 test("can't view expenses without permission", async ({ page }) => {
   const { clear, save } = permissions(page);
 
   await login(page);
-  await clear();
+  await clear('expenses@example.com');
   await save();
   await logout(page);
 
-  await login(page, 'permissions@example.com', 'password');
+  await login(page, 'expenses@example.com', 'password');
 
   await expect(page.locator('.flex-grow > .flex-1').first()).not.toContainText(
     'Expenses'
   );
 });
 
-test('can view expenses', async ({ page }) => {
+test('can view expense', async ({ page }) => {
   const { clear, save, set } = permissions(page);
 
   await login(page);
-  await clear();
+  await clear('expenses@example.com');
   await set('view_expense');
   await save();
   await logout(page);
 
-  await login(page, 'permissions@example.com', 'password');
+  await login(page, 'expenses@example.com', 'password');
 
   await page.getByRole('link', { name: 'Expenses', exact: true }).click();
 
   await page.waitForURL('**/expenses');
 
-  await expect(
-    page.getByRole('heading', {
-      name: "Sorry, you don't have the needed permissions.",
-    })
-  ).not.toBeVisible();
+  const tableBody = page.locator('tbody').first();
+
+  const tableRow = tableBody.getByRole('row').first();
+
+  await page.waitForTimeout(200);
+
+  const doRecordsExist = await page.getByText('No records found').isHidden();
+
+  if (doRecordsExist) {
+    const moreActionsButton = tableRow
+      .getByRole('button')
+      .filter({ has: page.getByText('More Actions') });
+
+    await moreActionsButton.click();
+
+    await page.waitForTimeout(200);
+
+    await page
+      .getByRole('link')
+      .filter({ has: page.getByText('Edit') })
+      .first()
+      .click();
+
+    await expect(
+      page.getByRole('heading', {
+        name: 'Edit Expense',
+        exact: true,
+      })
+    ).toBeVisible();
+  } else {
+    await expect(
+      page.getByRole('heading', {
+        name: "Sorry, you don't have the needed permissions.",
+      })
+    ).not.toBeVisible();
+
+    await expect(page.getByText('No records found')).toBeVisible();
+  }
 });
 
 test("can't create an expense", async ({ page }) => {
   const { clear, save, set } = permissions(page);
 
   await login(page);
-  await clear();
+  await clear('expenses@example.com');
   await set('view_expense');
   await save();
   await logout(page);
 
-  await login(page, 'permissions@example.com', 'password');
+  await login(page, 'expenses@example.com', 'password');
 
   await page.getByRole('link', { name: 'Expenses', exact: true }).click();
   await page.getByText('Enter Expense').click();
@@ -63,12 +107,12 @@ test('can create an expense', async ({ page }) => {
   const { clear, save, set } = permissions(page);
 
   await login(page);
-  await clear();
+  await clear('expenses@example.com');
   await set('create_expense');
   await save();
   await logout(page);
 
-  await login(page, 'permissions@example.com', 'password');
+  await login(page, 'expenses@example.com', 'password');
 
   await page.getByRole('link', { name: 'Expenses', exact: true }).click();
   await page.getByText('Enter Expense').click();
@@ -84,22 +128,283 @@ test('can view assigned expense with create_expense', async ({ page }) => {
   const { clear, save, set } = permissions(page);
 
   await login(page);
-  await clear();
+  await clear('expenses@example.com');
   await set('create_expense');
   await save();
   await logout(page);
 
-  await login(page, 'permissions@example.com', 'password');
+  await login(page, 'expenses@example.com', 'password');
 
   await page.getByRole('link', { name: 'Expenses' }).click();
-  await page
-    .getByRole('main')
-    .getByRole('link', { name: 'Enter Expense' })
-    .click();
+
+  await createExpense(page);
+
+  await expect(page.getByText('Successfully created expense')).toBeVisible();
+});
+
+test('deleting expense', async ({ page }) => {
+  const { clear, save, set } = permissions(page);
+
+  await login(page);
+  await clear('expenses@example.com');
+  await set('create_expense');
+  await save();
+  await logout(page);
+
+  await login(page, 'expenses@example.com', 'password');
+
+  const tableBody = page.locator('tbody').first();
+
+  await page.getByRole('link', { name: 'Expenses', exact: true }).click();
+
+  const tableRow = tableBody.getByRole('row').first();
+
+  await page.waitForURL('**/expenses');
 
   await page.waitForTimeout(200);
+
+  const doRecordsExist = await page.getByText('No records found').isHidden();
+
+  if (!doRecordsExist) {
+    await createExpense(page);
+
+    const moreActionsButton = page
+      .getByRole('button')
+      .filter({ has: page.getByText('More Actions') })
+      .first();
+
+    await moreActionsButton.click();
+
+    await page.getByText('Delete').click();
+  } else {
+    const moreActionsButton = tableRow
+      .getByRole('button')
+      .filter({ has: page.getByText('More Actions') });
+
+    await moreActionsButton.click();
+
+    await page.getByText('Delete').click();
+  }
+
+  await expect(page.getByText('Successfully deleted expense')).toBeVisible();
+});
+
+test('archiving expense', async ({ page }) => {
+  const { clear, save, set } = permissions(page);
+
+  await login(page);
+  await clear('expenses@example.com');
+  await set('create_expense');
+  await save();
+  await logout(page);
+
+  await login(page, 'expenses@example.com', 'password');
+
+  const tableBody = page.locator('tbody').first();
+
+  await page.getByRole('link', { name: 'Expenses', exact: true }).click();
+
+  await page.waitForURL('**/expenses');
+
+  const tableRow = tableBody.getByRole('row').first();
+
+  await page.waitForTimeout(200);
+
+  const doRecordsExist = await page.getByText('No records found').isHidden();
+
+  if (!doRecordsExist) {
+    await createExpense(page);
+
+    const moreActionsButton = page
+      .getByRole('button')
+      .filter({ has: page.getByText('More Actions') })
+      .first();
+
+    await moreActionsButton.click();
+
+    await page.getByText('Archive').click();
+  } else {
+    const moreActionsButton = tableRow
+      .getByRole('button')
+      .filter({ has: page.getByText('More Actions') })
+      .first();
+
+    await moreActionsButton.click();
+
+    await page.getByText('Archive').click();
+  }
+
+  await expect(page.getByText('Successfully archived expense')).toBeVisible();
+});
+
+test('cloning expense', async ({ page }) => {
+  const { clear, save, set } = permissions(page);
+
+  await login(page);
+  await clear('expenses@example.com');
+  await set('create_expense');
+  await save();
+  await logout(page);
+
+  await login(page, 'expenses@example.com', 'password');
+
+  const tableBody = page.locator('tbody').first();
+
+  await page.getByRole('link', { name: 'Expenses', exact: true }).click();
+
+  await page.waitForURL('**/expenses');
+
+  const tableRow = tableBody.getByRole('row').first();
+
+  await page.waitForTimeout(200);
+
+  const doRecordsExist = await page.getByText('No records found').isHidden();
+
+  if (!doRecordsExist) {
+    await createExpense(page);
+
+    const moreActionsButton = page
+      .getByRole('button')
+      .filter({ has: page.getByText('More Actions') });
+
+    await moreActionsButton.click();
+  } else {
+    const moreActionsButton = tableRow
+      .getByRole('button')
+      .filter({ has: page.getByText('More Actions') });
+
+    await moreActionsButton.click();
+  }
+
+  await page.getByText('Clone').first().click();
+
+  await page.waitForURL('**/expenses/create?action=clone');
 
   await page.getByRole('button', { name: 'Save' }).click();
 
   await expect(page.getByText('Successfully created expense')).toBeVisible();
+
+  await page.waitForURL('**/expenses/**/edit');
+
+  await expect(
+    page.getByRole('heading', { name: 'Edit Expense' }).first()
+  ).toBeVisible();
+});
+
+test('expense documents preview', async ({ page }) => {
+  const { clear, save, set } = permissions(page);
+
+  await login(page);
+  await clear('expenses@example.com');
+  await set('create_expense');
+  await save();
+  await logout(page);
+
+  await login(page, 'expenses@example.com', 'password');
+
+  const tableBody = page.locator('tbody').first();
+
+  await page.getByRole('link', { name: 'Expenses', exact: true }).click();
+
+  await page.waitForURL('**/expenses');
+
+  const tableRow = tableBody.getByRole('row').first();
+
+  await page.waitForTimeout(200);
+
+  const doRecordsExist = await page.getByText('No records found').isHidden();
+
+  if (!doRecordsExist) {
+    await createExpense(page);
+
+    const moreActionsButton = page
+      .getByRole('button')
+      .filter({ has: page.getByText('More Actions') })
+      .first();
+
+    await moreActionsButton.click();
+  } else {
+    const moreActionsButton = tableRow
+      .getByRole('button')
+      .filter({ has: page.getByText('More Actions') })
+      .first();
+
+    await moreActionsButton.click();
+  }
+
+  await page.getByText('Edit').first().click();
+
+  await page.waitForURL('**/expenses/**/edit');
+
+  await page
+    .getByRole('link', {
+      name: 'Documents',
+      exact: true,
+    })
+    .click();
+
+  await expect(page.getByText('Drop files or click to upload')).toBeVisible();
+});
+
+test('expense documents uploading', async ({ page }) => {
+  const { clear, save, set } = permissions(page);
+
+  await login(page);
+  await clear('expenses@example.com');
+  await set('create_expense');
+  await save();
+  await logout(page);
+
+  await login(page, 'expenses@example.com', 'password');
+
+  const tableBody = page.locator('tbody').first();
+
+  await page.getByRole('link', { name: 'Expenses', exact: true }).click();
+
+  await page.waitForURL('**/expenses');
+
+  const tableRow = tableBody.getByRole('row').first();
+
+  await page.waitForTimeout(200);
+
+  const doRecordsExist = await page.getByText('No records found').isHidden();
+
+  if (!doRecordsExist) {
+    await createExpense(page);
+
+    const moreActionsButton = page
+      .getByRole('button')
+      .filter({ has: page.getByText('More Actions') })
+      .first();
+
+    await moreActionsButton.click();
+  } else {
+    const moreActionsButton = tableRow
+      .getByRole('button')
+      .filter({ has: page.getByText('More Actions') })
+      .first();
+
+    await moreActionsButton.click();
+  }
+
+  await page.getByText('Edit').first().click();
+
+  await page.waitForURL('**/expenses/**/edit');
+
+  await page
+    .getByRole('link', {
+      name: 'Documents',
+      exact: true,
+    })
+    .click();
+
+  await page
+    .locator('input[type="file"]')
+    .setInputFiles('./tests/assets/images/test-image.png');
+
+  await expect(page.getByText('Successfully uploaded document')).toBeVisible();
+
+  await expect(
+    page.getByText('test-image.png', { exact: true }).first()
+  ).toBeVisible();
 });


### PR DESCRIPTION
@beganovich @turbo124 The PR includes:

- Improving the `can view expense` test with additional checks
- Creating a expense deletion test
- Creating test for archiving expense
- Creating test for cloning expense
- Creating test for previewing documents tab
- Creating test for uploading documents

Let me know your thoughts.