### PR TITLE
Tax rate selector improvements

### DIFF
--- a/src/components/forms/DebouncedCombobox.tsx
+++ b/src/components/forms/DebouncedCombobox.tsx
@@ -38,7 +38,7 @@ interface Props {
   formatLabel?: (resource: any) => any;
   onActionClick?: () => any;
   actionLabel?: string | null;
-  defaultValue?: string | number | boolean;
+  defaultValue?: string | number | boolean | null;
   disabled?: boolean;
   clearButton?: any;
   onClearButtonClick?: any;

--- a/src/components/tax-rates/TaxRateSelector.tsx
+++ b/src/components/tax-rates/TaxRateSelector.tsx
@@ -45,7 +45,7 @@ export function TaxRateSelector(props: Props) {
           props.onChange && props.onChange(record)
         }
         value="rate"
-        defaultValue={props.defaultValue}
+        defaultValue={props.defaultValue === 0 ? null : props.defaultValue}
         clearButton={props.clearButton}
         onClearButtonClick={props.onClearButtonClick}
         actionLabel={t('create_tax_rate')}


### PR DESCRIPTION
This passes `null` if the tax_rate value is 0 (essentially fixes the bug with tax rate valued at 0%).