### PR TITLE
[Cleanup] Connect Translation Keyword

### DIFF
--- a/src/pages/settings/user/common/hooks/useUserDetailsTabs.tsx
+++ b/src/pages/settings/user/common/hooks/useUserDetailsTabs.tsx
@@ -21,7 +21,7 @@ export function useUserDetailsTabs() {
       href: '/settings/user_details/password',
     },
     {
-      name: t('connect'),
+      name: t('oauth_mail'),
       href: '/settings/user_details/connect',
     },
     {


### PR DESCRIPTION
@beganovich @turbo124 PR includes changing `connect` translation keyword to `oauth_mail` keyword. Screenshot:

![Screenshot 2023-04-16 at 12 37 58](https://user-images.githubusercontent.com/51542191/232300263-c0c1315a-3192-497d-8881-1202b3545064.png)

Let me know your thoughts.