### PR TITLE
[Cleanup] connect_bank Translation Keyword Change

### DIFF
--- a/src/common/hooks/entities/useQuickCreateActions.ts
+++ b/src/common/hooks/entities/useQuickCreateActions.ts
@@ -143,7 +143,7 @@ export function useQuickCreateActions() {
       visible: Boolean(!gateways?.length),
     },
     {
-      key: 'connect_bank',
+      key: 'add_bank_account',
       url: '/settings/bank_accounts/create',
       section: 'settings',
       visible: enterprisePlan() && Boolean(!bankAccounts?.length),


### PR DESCRIPTION
@beganovich @turbo124 PR includes changing `connect_bank` translation keyword to `add_bank_account`. Screenshot:

![Screenshot 2023-04-16 at 12 45 06](https://user-images.githubusercontent.com/51542191/232301147-4ede5153-de78-456b-a418-d79f6d73034f.png)

Let me know your thoughts.