### PR TITLE
[Bugfix] Line Items | Product Selection

### DIFF
--- a/src/pages/invoices/common/hooks/useHandleProductChange.ts
+++ b/src/pages/invoices/common/hooks/useHandleProductChange.ts
@@ -21,33 +21,37 @@ interface Props {
 export function useHandleProductChange(props: Props) {
   const resource = props.resource;
 
-  return (index: number, product_key: string, product: Product) => {
+  return (index: number, product_key: string, product?: Product) => {
     const lineItem = { ...resource.line_items[index] };
 
-    lineItem.product_key = product.product_key || product_key;
-    lineItem.quantity = product.quantity || 1;
-    lineItem.cost = product.price || 0;
+    lineItem.product_key = product?.product_key || product_key;
+    lineItem.quantity = product?.quantity || 0;
+    lineItem.cost = product?.price || 0;
 
-    if (props.type == 'product' && product.notes) {
+    if (!product) {
+      lineItem.notes = '';
+    }
+
+    if (props.type == 'product' && product?.notes) {
+      lineItem.notes = product?.notes;
+    }
+
+    if (props.type == 'task' && product?.notes && !lineItem.notes) {
       lineItem.notes = product.notes;
     }
 
-    if (props.type == 'task' && product.notes && !lineItem.notes) {
-      lineItem.notes = product.notes;
-    }
+    lineItem.tax_name1 = product?.tax_name1 || '';
+    lineItem.tax_name2 = product?.tax_name2 || '';
+    lineItem.tax_name3 = product?.tax_name3 || '';
 
-    lineItem.tax_name1 = product.tax_name1 || '';
-    lineItem.tax_name2 = product.tax_name2 || '';
-    lineItem.tax_name3 = product.tax_name3 || '';
+    lineItem.tax_rate1 = product?.tax_rate1 || 0;
+    lineItem.tax_rate2 = product?.tax_rate2 || 0;
+    lineItem.tax_rate3 = product?.tax_rate3 || 0;
 
-    lineItem.tax_rate1 = product.tax_rate1 || 0;
-    lineItem.tax_rate2 = product.tax_rate2 || 0;
-    lineItem.tax_rate3 = product.tax_rate3 || 0;
-
-    lineItem.custom_value1 = product.custom_value1 || '';
-    lineItem.custom_value2 = product.custom_value2 || '';
-    lineItem.custom_value3 = product.custom_value3 || '';
-    lineItem.custom_value4 = product.custom_value4 || '';
+    lineItem.custom_value1 = product?.custom_value1 || '';
+    lineItem.custom_value2 = product?.custom_value2 || '';
+    lineItem.custom_value3 = product?.custom_value3 || '';
+    lineItem.custom_value4 = product?.custom_value4 || '';
 
     return props.onChange(index, lineItem);
   };

--- a/src/pages/invoices/common/hooks/useResolveInputField.tsx
+++ b/src/pages/invoices/common/hooks/useResolveInputField.tsx
@@ -93,6 +93,7 @@ export function useResolveInputField(props: Props) {
     if (property === 'product_key') {
       return (
         <ProductSelector
+          key={resource?.line_items[index][property]}
           onChange={(value) =>
             value.resource &&
             handleProductChange(index, value.label, value.resource)
@@ -102,6 +103,8 @@ export function useResolveInputField(props: Props) {
           onProductCreated={(product) =>
             product && handleProductChange(index, product.product_key, product)
           }
+          clearButton
+          onClearButtonClick={() => handleProductChange(index, '')}
         />
       );
     }


### PR DESCRIPTION
@beganovich @turbo124 PR includes fixing a bug in `product selection` when a user entered a search term. We didn't have the combobox value updated correctly when the user finally clicked on one of the filtered product. This behavior occurred in the Products/Tasks table for each item. Additionally, I added a clear option to this combo box, we didn't have that and IMO the UX was a bit weird. When we selected a product we had to delete the entire line item to change to something else.

`Note`: David also mentioned in the ticket that an `onKeyDown` option would be nice to have to select product. If you mean product selection by clicking enter, that option is already available. But, if you think of any other option, just let me know.

Let me know your thoughts.