### PR TITLE
[Bugfix] Displaying Connected Account Buttons

### DIFF
--- a/src/pages/settings/user/components/Connect.tsx
+++ b/src/pages/settings/user/components/Connect.tsx
@@ -83,7 +83,11 @@ export function Connect() {
           </Element>
 
           <Element leftSide="Gmail">
-            <Button type="minimal">{t('connect_gmail')}</Button>
+            {user?.oauth_user_token ? (
+              <Button type="minimal">{t('disconnect_gmail')}</Button>
+            ) : (
+              <Button type="minimal">{t('connect_gmail')}</Button>
+            )}
           </Element>
         </>
       )}
@@ -97,9 +101,13 @@ export function Connect() {
           </Element>
 
           <Element leftSide="Email">
-            <Button type="minimal" onClick={handleConnectEmail}>
-              {t('connect_email')}
-            </Button>
+            {user?.oauth_user_token ? (
+              <Button type="minimal">{t('disconnect_email')}</Button>
+            ) : (
+              <Button type="minimal" onClick={handleConnectEmail}>
+                {t('connect_email')}
+              </Button>
+            )}
           </Element>
         </>
       )}


### PR DESCRIPTION
@beganovich @turbo124 PR includes a bug fix for displaying mailer buttons. So now after checking the `oauth_provider_id` we also check the `oauth_user_token` to make sure which buttons we need to show, disconnecting or connecting the button. Let me know your thoughts.