### PR TITLE
[Cleanup] Plan Text Refactoring

### DIFF
--- a/src/pages/settings/account-management/component/Plan.tsx
+++ b/src/pages/settings/account-management/component/Plan.tsx
@@ -25,7 +25,16 @@ export function Plan() {
 
   return (
     <Card title={t('plan')}>
-      <Element leftSide={t('plan')}>{account?.plan || t('free')}</Element>
+      <Element leftSide={t('plan')}>
+        <span>
+          {account?.plan
+            ? `${t(account.plan)} ${t('plan')} `
+            : `${t('free')} ${t('plan')} `}
+        </span>
+        <span>
+          / {account.num_users} {t('users')}
+        </span>
+      </Element>
 
       {account?.plan_expires !== '' && (
         <Element leftSide={t('expires_on')}>


### PR DESCRIPTION
@beganovich @turbo124 PR includes changing the text format for the current user's plan. David, you mentioned in the ticket to specify the number of users with text like `1-3 Users`, but I did not find such a result in the `account` object, I only found the `num_users` property. Regarding that, I have implemented this solution and I hope this is satisfying. Screenshot:

![Screenshot 2023-04-17 at 05 40 07](https://user-images.githubusercontent.com/51542191/232373269-81f632d9-47a8-4477-b825-c0231bd00be7.png)

Let me know your thoughts.