### PR TITLE
[Feature] Show Credits Table | Client Statement

### DIFF
--- a/src/common/interfaces/schedule.ts
+++ b/src/common/interfaces/schedule.ts
@@ -11,6 +11,7 @@
 export interface Parameters {
   date_range: string;
   show_payments_table: boolean;
+  show_credits_table: boolean;
   show_aging_table: boolean;
   status: string;
   clients: string[];

--- a/src/pages/clients/common/hooks/useScheduleStatement.tsx
+++ b/src/pages/clients/common/hooks/useScheduleStatement.tsx
@@ -22,6 +22,7 @@ export function useScheduleStatement() {
     setScheduleParameters({
       clients: [statement.client_id],
       show_aging_table: statement.show_aging_table,
+      show_credits_table: statement.show_credits_table,
       show_payments_table: statement.show_payments_table,
       status: statement.status,
       date_range:

--- a/src/pages/clients/statement/Statement.tsx
+++ b/src/pages/clients/statement/Statement.tsx
@@ -42,6 +42,7 @@ export interface Statement {
   end_date: string;
   show_aging_table: boolean;
   show_payments_table: boolean;
+  show_credits_table: boolean;
   start_date: string;
   status: StatementStatus;
   dateRangeId: string;
@@ -131,6 +132,7 @@ export default function Statement() {
     end_date: dayjs().format('YYYY-MM-DD'),
     show_aging_table: true,
     show_payments_table: true,
+    show_credits_table: true,
     status: 'all',
     dateRangeId: 'last7_days',
   });
@@ -308,6 +310,18 @@ export default function Statement() {
         </Card>
 
         <Card className="col-span-12 xl:col-span-4 h-max">
+          <Element leftSide={t('credits')}>
+            <Toggle
+              checked={statement.show_credits_table}
+              onValueChange={(value) =>
+                setStatement((current) => ({
+                  ...current,
+                  show_credits_table: value,
+                }))
+              }
+            />
+          </Element>
+
           <Element leftSide={t('payments')}>
             <Toggle
               checked={statement.show_payments_table}

--- a/src/pages/invoices/common/hooks/useScheduleEmailRecord.tsx
+++ b/src/pages/invoices/common/hooks/useScheduleEmailRecord.tsx
@@ -25,6 +25,7 @@ export function useScheduleEmailRecord({ entity }: Props) {
     setScheduleParameters({
       clients: [],
       show_aging_table: false,
+      show_credits_table: false,
       show_payments_table: false,
       status: 'all',
       date_range: 'last7_days',

--- a/src/pages/settings/schedules/common/components/EmailStatement.tsx
+++ b/src/pages/settings/schedules/common/components/EmailStatement.tsx
@@ -130,6 +130,18 @@ export function EmailStatement(props: Props) {
         />
       </Element>
 
+      <Element leftSide={t('show_credits_table')}>
+        <Toggle
+          checked={schedule.parameters.show_credits_table}
+          onValueChange={(value) =>
+            handleChange(
+              'parameters.show_credits_table' as keyof Schedule,
+              value
+            )
+          }
+        />
+      </Element>
+
       <Element leftSide={t('client')}>
         <ClientSelector
           onChange={(client) =>

--- a/src/pages/settings/schedules/common/hooks/useFormatSchedulePayload.tsx
+++ b/src/pages/settings/schedules/common/hooks/useFormatSchedulePayload.tsx
@@ -27,6 +27,7 @@ const TemplateParametersProperties = {
     'date_range',
     'status',
     'show_aging_table',
+    'show_credits_table',
     'show_payments_table',
     'clients',
   ],

--- a/src/pages/settings/schedules/common/hooks/useHandleChange.tsx
+++ b/src/pages/settings/schedules/common/hooks/useHandleChange.tsx
@@ -41,6 +41,7 @@ export function useHandleChange(params: Params) {
           clients: [],
           date_range: 'last7_days',
           show_aging_table: false,
+          show_credits_table: false,
           show_payments_table: false,
           status: 'all',
           entity: 'invoice',

--- a/src/pages/settings/schedules/create/Create.tsx
+++ b/src/pages/settings/schedules/create/Create.tsx
@@ -81,6 +81,7 @@ export function Create() {
             clients: [],
             date_range: 'last7_days',
             show_aging_table: false,
+            show_credits_table: false,
             show_payments_table: false,
             status: 'all',
             entity: 'invoice',


### PR DESCRIPTION
@beganovich @turbo124 PR includes adding the functionality of the `show_credits_table` property to the `Client Statement page`, but also to the `Schedule` pages. Screenshots:

![Screenshot 2023-04-20 at 06 13 49](https://user-images.githubusercontent.com/51542191/233258377-37a9b0ea-f9cc-4fb0-a5d9-960dd8f3a4ba.png)

![Screenshot 2023-04-20 at 06 16 01](https://user-images.githubusercontent.com/51542191/233258392-ad14eceb-455f-482f-859d-441dba7dcaf6.png)

`Note`: We don't have the `show_credits_table` keyword in the translation files, so just add it to them.

Let me know your thoughts.