### PR TITLE
[Feature] Sidebar Background Color

### DIFF
--- a/src/common/constants/colors.ts
+++ b/src/common/constants/colors.ts
@@ -10,6 +10,7 @@
 
 export default {
   accent: '#117DC0',
+  ninjaGray: '#454544',
   primary: '#2F7DC3',
   secondary: '#7081e0',
 };

--- a/src/common/hooks/useAdjustColorDarkness.ts
+++ b/src/common/hooks/useAdjustColorDarkness.ts
@@ -1,0 +1,33 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+export function useAdjustColorDarkness() {
+  return (color: string, amount: number) => {
+    const initialColorHex = color.replace(/^#/, '');
+
+    const updatedColorHex = initialColorHex.replace(/../g, (colorSubstring) => {
+      const updatedColorSubstring =
+        '0' +
+        Math.min(
+          255,
+          Math.max(0, parseInt(colorSubstring, 16) + amount)
+        ).toString(16);
+
+      const subStringLength = updatedColorSubstring.length;
+
+      return updatedColorSubstring.substring(
+        subStringLength - 2,
+        subStringLength
+      );
+    });
+
+    return '#' + updatedColorHex;
+  };
+}

--- a/src/common/hooks/useSidebarBackgroundColor.ts
+++ b/src/common/hooks/useSidebarBackgroundColor.ts
@@ -1,0 +1,25 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import colors from '$app/common/constants/colors';
+import { RootState } from '$app/common/stores/store';
+import { useSelector } from 'react-redux';
+import { useCurrentUser } from './useCurrentUser';
+
+export function useSidebarBackgroundColor() {
+  const user = useCurrentUser();
+  const userState = useSelector((state: RootState) => state.user);
+
+  return (
+    userState.changes?.company_user?.react_settings?.sidebar_background ||
+    user?.company_user?.react_settings?.sidebar_background ||
+    colors.ninjaGray
+  );
+}

--- a/src/common/interfaces/company-user.ts
+++ b/src/common/interfaces/company-user.ts
@@ -14,6 +14,7 @@ import { User } from './user';
 
 export interface ReactSettings {
   show_pdf_preview: boolean;
+  sidebar_background: string;
 }
 
 export interface CompanyUser {

--- a/src/components/layouts/components/DesktopSidebar.tsx
+++ b/src/components/layouts/components/DesktopSidebar.tsx
@@ -9,12 +9,15 @@
  */
 
 import { useLogo } from '$app/common/hooks/useLogo';
+import { useSidebarBackgroundColor } from '$app/common/hooks/useSidebarBackgroundColor';
 import { RootState } from '$app/common/stores/store';
 import { CompanySwitcher } from '$app/components/CompanySwitcher';
 import { HelpSidebarIcons } from '$app/components/HelpSidebarIcons';
 import { Icon } from 'react-feather';
 import { useSelector } from 'react-redux';
 import { SidebarItem } from './SidebarItem';
+import colors from '$app/common/constants/colors';
+import classNames from 'classnames';
 
 export interface NavigationItem {
   name: string;
@@ -42,13 +45,24 @@ export function DesktopSidebar(props: Props) {
 
   const logo = useLogo();
 
+  const sideBarColor = useSidebarBackgroundColor();
+
   return (
     <div
       className={`hidden md:flex z-10 ${
         isMiniSidebar ? 'md:w-16' : 'md:w-64'
       } md:flex-col md:fixed md:inset-y-0`}
     >
-      <div className="flex flex-col flex-grow border-gray-100 bg-ninja-gray dark:bg-gray-800 dark:border-transparent overflow-y-auto border-r">
+      <div
+        className={classNames(
+          'flex flex-col flex-grow border-gray-100 overflow-y-auto border-r',
+          {
+            'dark:bg-gray-800 dark:border-transparent':
+              colors.ninjaGray === sideBarColor,
+          }
+        )}
+        style={{ backgroundColor: sideBarColor }}
+      >
         <div className="flex items-center flex-shrink-0 px-4 bg-white h-16">
           {isMiniSidebar ? (
             <img className="w-8" src={logo} alt="Company logo" />

--- a/src/components/layouts/components/MobileSidebar.tsx
+++ b/src/components/layouts/components/MobileSidebar.tsx
@@ -14,6 +14,9 @@ import { Fragment } from 'react';
 import { X } from 'react-feather';
 import { NavigationItem } from './DesktopSidebar';
 import { SidebarItem } from './SidebarItem';
+import classNames from 'classnames';
+import colors from '$app/common/constants/colors';
+import { useSidebarBackgroundColor } from '$app/common/hooks/useSidebarBackgroundColor';
 
 interface Props {
   navigation: NavigationItem[];
@@ -22,6 +25,8 @@ interface Props {
 }
 
 export function MobileSidebar(props: Props) {
+  const sideBarColor = useSidebarBackgroundColor();
+
   return (
     <Transition.Root show={props.sidebarOpen} as={Fragment}>
       <Dialog
@@ -49,7 +54,17 @@ export function MobileSidebar(props: Props) {
           leaveFrom="translate-x-0"
           leaveTo="-translate-x-full"
         >
-          <div className="relative flex-1 flex flex-col max-w-xs w-full pb-4 bg-ninja-gray dark:bg-gray-900">
+          <div
+            className={classNames(
+              'relative flex-1 flex flex-col max-w-xs w-full pb-4',
+              {
+                'dark:bg-gray-900': colors.ninjaGray === sideBarColor,
+              }
+            )}
+            style={{
+              backgroundColor: sideBarColor,
+            }}
+          >
             <Transition.Child
               as={Fragment}
               enter="ease-in-out duration-300"

--- a/src/components/layouts/components/SidebarItem.tsx
+++ b/src/components/layouts/components/SidebarItem.tsx
@@ -8,11 +8,15 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
-import { classNames } from '$app/common/helpers';
+import { useSidebarBackgroundColor } from '$app/common/hooks/useSidebarBackgroundColor';
 import { RootState } from '$app/common/stores/store';
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { NavigationItem } from './DesktopSidebar';
+import colors from '$app/common/constants/colors';
+import classNames from 'classnames';
+import { useState } from 'react';
+import { useAdjustColorDarkness } from '$app/common/hooks/useAdjustColorDarkness';
 
 interface Props {
   item: NavigationItem;
@@ -21,9 +25,25 @@ interface Props {
 export function SidebarItem(props: Props) {
   const { item } = props;
 
+  const [isHovered, setIsHovered] = useState<boolean>(false);
+
+  const sideBarColor = useSidebarBackgroundColor();
+
   const isMiniSidebar = useSelector(
     (state: RootState) => state.settings.isMiniSidebar
   );
+
+  const adjustColorDarkness = useAdjustColorDarkness();
+
+  const getItemBackgroundColor = (isCurrent: boolean) => {
+    if (colors.ninjaGray !== sideBarColor) {
+      if (isCurrent || isHovered) {
+        return adjustColorDarkness(sideBarColor, -40);
+      }
+
+      return 'transparent';
+    }
+  };
 
   if (!item.visible) {
     return <></>;
@@ -32,22 +52,31 @@ export function SidebarItem(props: Props) {
   return (
     <div
       key={item.name}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
       className={classNames(
         'flex items-center justify-between group px-4 text-sm font-medium',
-        item.current
-          ? 'text-white border-l-4 border-transparent bg-ninja-gray-darker dark:bg-gray-700'
-          : 'text-gray-300 hover:text-white border-l-4 border-transparent hover:bg-ninja-gray-darker dark:hover:bg-gray-700'
+        {
+          'bg-ninja-gray-darker dark:bg-gray-700':
+            item.current && colors.ninjaGray === sideBarColor,
+          'hover:bg-ninja-gray-darker dark:hover:bg-gray-700':
+            !item.current && colors.ninjaGray === sideBarColor,
+          'text-white border-l-4 border-transparent': item.current,
+          'text-gray-300 hover:text-white border-l-4 border-transparent':
+            !item.current,
+        }
       )}
+      style={{
+        backgroundColor: getItemBackgroundColor(item.current),
+      }}
     >
       <Link to={item.href} className="w-full">
         <div className="flex justify-start items-center my-2">
           <item.icon
-            className={classNames(
-              'mr-3 flex-shrink-0 h-6 w-6',
-              item.current
-                ? 'text-white'
-                : 'text-gray-300 group-hover:text-white'
-            )}
+            className={classNames('mr-3 flex-shrink-0 h-6 w-6', {
+              'text-white': item.current,
+              'text-gray-300 group-hover:text-white': !item.current,
+            })}
             aria-hidden="true"
           />
           {!isMiniSidebar && item.name}

--- a/src/pages/settings/user/components/AccentColor.tsx
+++ b/src/pages/settings/user/components/AccentColor.tsx
@@ -15,10 +15,12 @@ import { updateChanges } from '$app/common/stores/slices/user';
 import { RootState } from '../../../../common/stores/store';
 import colors from '$app/common/constants/colors';
 import { ColorPicker } from '$app/components/forms/ColorPicker';
+import { useReactSettings } from '$app/common/hooks/useReactSettings';
 
 export function AccentColor() {
   const [t] = useTranslation();
   const dispatch = useDispatch();
+  const reactSettings = useReactSettings();
 
   const userChanges = useSelector((state: RootState) => state.user.changes);
 
@@ -33,6 +35,20 @@ export function AccentColor() {
             dispatch(
               updateChanges({
                 property: 'company_user.settings.accent_color',
+                value: color,
+              })
+            )
+          }
+        />
+      </Element>
+
+      <Element leftSide={t('sidebar_active_background_color')}>
+        <ColorPicker
+          value={reactSettings.sidebar_background || colors.ninjaGray}
+          onValueChange={(color) =>
+            dispatch(
+              updateChanges({
+                property: 'company_user.react_settings.sidebar_background',
                 value: color,
               })
             )


### PR DESCRIPTION
@beganovich @turbo124 PR includes adding a field to customize the background color on the left main sidebar. Screenshot:

![Screenshot 2023-04-23 at 02 50 33](https://user-images.githubusercontent.com/51542191/233814778-3f670b00-6748-47ba-96c1-a7c082c2c9b9.png)

`Important note`: Updating this property in the DB does not work. David, please just do a quick check and let me know if you need anything from me. I used `sidebar_background` as the property name under the `react_settings` object.

`Suggestion`: Some parts of the feature are dynamically calculated, but what I couldn't dynamically calculate was the text and icon color. Users will not be able to select some colors because the contrast may be poor, and the text and icons may be almost or completely invisible. My suggestion is to also add a custom color for this purpose, that color will be applied to the text and icons.

Let me know your thoughts.