### PR TITLE
[Bugfix] Expense Settings | Expense Pages

### DIFF
--- a/src/common/interfaces/company.interface.ts
+++ b/src/common/interfaces/company.interface.ts
@@ -17,6 +17,9 @@ export interface Company {
   enabled_tax_rates: number;
   enabled_item_tax_rates: number;
   enable_product_discount: boolean;
+  mark_expenses_paid: boolean;
+  mark_expenses_invoiceable: boolean;
+  invoice_expense_documents: boolean;
   convert_expense_currency: boolean;
   custom_surcharge_taxes1: boolean;
   custom_surcharge_taxes2: boolean;

--- a/src/pages/expenses/create/Create.tsx
+++ b/src/pages/expenses/create/Create.tsx
@@ -30,11 +30,15 @@ import { useAtom } from 'jotai';
 import { expenseAtom } from '../common/atoms';
 import { useHandleChange } from '../common/hooks';
 import { cloneDeep } from 'lodash';
+import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
+import dayjs from 'dayjs';
 
 export default function Create() {
   const [t] = useTranslation();
 
   const navigate = useNavigate();
+
+  const company = useCurrentCompany();
 
   const { documentTitle } = useTitle('new_expense');
 
@@ -82,7 +86,14 @@ export default function Create() {
           _expense.vendor_id = searchParams.get('client') as string;
         }
 
-        value = _expense;
+        value = {
+          ..._expense,
+          payment_date: company?.mark_expenses_paid
+            ? dayjs().format('YYYY-MM-DD')
+            : '',
+          should_be_invoiced: company?.mark_expenses_invoiceable,
+          invoice_documents: company?.invoice_expense_documents,
+        };
       }
 
       return value;


### PR DESCRIPTION
@beganovich @turbo124 Alex reported a bug for the `Mark Paid` field in the support-ninja group, but I noticed that we also have a bug with the `Should be invoiced` and `Add documents to invoice` fields, so the PR includes bug fixes for mismatched settings on `Expense` pages. We missed setting the `Should Invoice`, `Mark Paid` and `Add Documents to Invoice` fields due to changes in the cost settings. This is only important on the `Expense creation page`, on the expense edit page we will display the saved details. Let me know your thoughts.