### PR TITLE
[Bugfix] Document Title

### DIFF
--- a/src/common/hooks/useTitle.ts
+++ b/src/common/hooks/useTitle.ts
@@ -10,16 +10,34 @@
 
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useCurrentCompany } from './useCurrentCompany';
 
 export function useTitle(title: string, translate = true) {
   const [t] = useTranslation();
+  const company = useCurrentCompany();
 
   const [documentTitle, setDocumentTitle] = useState(
     translate ? t(title) || '' : title
   );
 
+  const getAppTitle = () => {
+    let appTitle = '';
+
+    if (import.meta.env.VITE_APP_TITLE) {
+      appTitle = import.meta.env.VITE_APP_TITLE;
+    } else {
+      if (company?.settings.name) {
+        appTitle = company.settings.name;
+      } else {
+        appTitle = t('untitled');
+      }
+    }
+
+    return `${appTitle}: ${documentTitle}`;
+  };
+
   useEffect(() => {
-    document.title = `${import.meta.env.VITE_APP_TITLE}: ${documentTitle}`;
+    document.title = getAppTitle();
   }, [documentTitle]);
 
   return {


### PR DESCRIPTION
@beganovich @turbo124 The PR includes a bug fix for the first part of the document title/browser tab title. Now if we have `import.meta.env.VITE_APP_TITLE`, it will be displayed as the first part of the title, if we don't have it but we have `company.settings.name`, the company name will be displayed, otherwise we will display the translated `untitled` keyword as the first part of the title. Let me know your thoughts.