### PR TITLE
[Cleanup] Improve Gateway Refund Logic

### DIFF
--- a/src/pages/payments/refund/Refund.tsx
+++ b/src/pages/payments/refund/Refund.tsx
@@ -131,7 +131,7 @@ export default function Refund() {
       const gateway: Gateway = companyGateway.data.data.gateway;
       const gatewayTypeId = payment.data.data.gateway_type_id;
 
-      const showGatewayRefund = gateway.options[gatewayTypeId].refund;
+      const showGatewayRefund = Boolean(gateway.options[gatewayTypeId]?.refund);
 
       setShouldShowGatewayRefund(showGatewayRefund);
     }

--- a/src/pages/payments/refund/Refund.tsx
+++ b/src/pages/payments/refund/Refund.tsx
@@ -127,12 +127,11 @@ export default function Refund() {
   }, [formik.values.invoices]);
 
   useEffect(() => {
-    if (companyGateway) {
+    if (companyGateway && payment) {
       const gateway: Gateway = companyGateway.data.data.gateway;
+      const gatewayTypeId = payment.data.data.gateway_type_id;
 
-      const showGatewayRefund = Object.values(gateway.options).some(
-        (option) => option.refund
-      );
+      const showGatewayRefund = gateway.options[gatewayTypeId].refund;
 
       setShouldShowGatewayRefund(showGatewayRefund);
     }


### PR DESCRIPTION
@beganovich @turbo124 The PR includes improving the logic for the `Gateway Refund` option. Now we will first take the `gateway_type_id` from the `Payment` object and using this `gateway.options[gatewayTypeId].refund` logic we will take the right `optionObject` from the `gateway.options` and check the refund value. If the refund value is true, we will display a toggle. Let me know your thoughts.