### PR TITLE
[Cleanup] bank_account_details translation keyword

### DIFF
--- a/src/pages/settings/bank-accounts/show/BankAccount.tsx
+++ b/src/pages/settings/bank-accounts/show/BankAccount.tsx
@@ -19,7 +19,7 @@ import { useBankAccountQuery } from '../common/queries';
 import { Details } from '../components/Details';
 
 export function BankAccount() {
-  useTitle('bank_account_details');
+  useTitle('bank_account');
 
   const { id } = useParams();
 
@@ -29,7 +29,7 @@ export function BankAccount() {
     { name: t('settings'), href: '/settings' },
     { name: t('bank_accounts'), href: '/settings/bank_accounts' },
     {
-      name: t('bank_account_details'),
+      name: t('bank_account'),
       href: route('/settings/bank_accounts/:id/details', { id }),
     },
   ];
@@ -44,7 +44,7 @@ export function BankAccount() {
 
   return (
     <Settings
-      title={t('bank_account_details')}
+      title={t('bank_account')}
       breadcrumbs={pages}
       docsLink="docs/basic-settings/#bank_account_details"
     >


### PR DESCRIPTION
@beganovich @turbo124 Changed `bank_account_details` translation keyword to `bank_account`. Screenshot:

<img width="1111" alt="Screenshot 2023-04-30 at 14 35 06" src="https://user-images.githubusercontent.com/51542191/235353376-2789f792-4403-42cd-9192-e20994d15898.png">

Let me know your thoughts.