### PR TITLE
[Feature] Refresh | Bank Accounts

### DIFF
--- a/src/pages/settings/bank-accounts/index/BankAccounts.tsx
+++ b/src/pages/settings/bank-accounts/index/BankAccounts.tsx
@@ -24,6 +24,7 @@ import { useNavigate } from 'react-router-dom';
 import { AxiosError } from 'axios';
 import { ValidationBag } from '$app/common/interfaces/validation-bag';
 import { toast } from '$app/common/helpers/toast/toast';
+import { Icon } from '$app/components/icons/Icon';
 import { proPlan } from '$app/common/guards/guards/pro-plan';
 
 export function BankAccounts() {
@@ -87,26 +88,33 @@ export function BankAccounts() {
         rightSide={
           <div className="flex space-x-2">
             {isHosted() && enterprisePlan() && (
-              <Button onClick={handleConnectAccounts}>
-                <span className="mr-2">{<MdLink fontSize={20} />}</span>
+              <Button type="secondary" onClick={handleConnectAccounts}>
+                <span className="mr-2">
+                  {<Icon element={MdLink} size={20} />}
+                </span>
                 {t('connect_accounts')}
               </Button>
             )}
 
             {isHosted() && enterprisePlan() && (
-              <Button onClick={handleRefresh}>
-                <span className="mr-2">{<MdRefresh fontSize={20} />}</span>
+              <Button type="secondary" onClick={handleRefresh}>
+                <span className="mr-2">
+                  {<Icon element={MdRefresh} size={20} />}
+                </span>
                 {t('refresh')}
               </Button>
             )}
 
             {isHosted() && (proPlan() || enterprisePlan()) && (
               <Button
+                type="secondary"
                 onClick={() =>
                   navigate('/settings/bank_accounts/transaction_rules')
                 }
               >
-                <span className="mr-2">{<MdRuleFolder fontSize={20} />}</span>
+                <span className="mr-2">
+                  {<Icon element={MdRuleFolder} size={20} />}
+                </span>
                 {t('rules')}
               </Button>
             )}

--- a/src/pages/settings/bank-accounts/index/BankAccounts.tsx
+++ b/src/pages/settings/bank-accounts/index/BankAccounts.tsx
@@ -14,13 +14,16 @@ import { Settings } from '$app/components/layouts/Settings';
 import { useTranslation } from 'react-i18next';
 import { useBankAccountColumns } from '../common/hooks/useBankAccountColumns';
 import { Button } from '$app/components/forms';
-import { MdLink, MdRuleFolder } from 'react-icons/md';
+import { MdLink, MdRefresh, MdRuleFolder } from 'react-icons/md';
 import { endpoint, isHosted } from '$app/common/helpers';
 import { request } from '$app/common/helpers/request';
 import { route } from '$app/common/helpers/route';
 import { enterprisePlan } from '$app/common/guards/guards/enterprise-plan';
 import { AdvancedSettingsPlanAlert } from '$app/components/AdvancedSettingsPlanAlert';
 import { useNavigate } from 'react-router-dom';
+import { AxiosError } from 'axios';
+import { ValidationBag } from '$app/common/interfaces/validation-bag';
+import { toast } from '$app/common/helpers/toast/toast';
 import { proPlan } from '$app/common/guards/guards/pro-plan';
 
 export function BankAccounts() {
@@ -50,6 +53,16 @@ export function BankAccounts() {
     );
   };
 
+  const handleRefresh = () => {
+    request('POST', endpoint('/api/v1/bank_integrations/refresh_accounts'), {})
+      .then((response) => {
+        toast.success(response.data.message);
+      })
+      .catch((error: AxiosError<ValidationBag>) => {
+        toast.error(error.response?.data.message);
+      });
+  };
+
   return (
     <Settings
       title={t('bank_accounts')}
@@ -77,6 +90,13 @@ export function BankAccounts() {
               <Button onClick={handleConnectAccounts}>
                 <span className="mr-2">{<MdLink fontSize={20} />}</span>
                 {t('connect_accounts')}
+              </Button>
+            )}
+
+            {isHosted() && enterprisePlan() && (
+              <Button onClick={handleRefresh}>
+                <span className="mr-2">{<MdRefresh fontSize={20} />}</span>
+                {t('refresh')}
               </Button>
             )}
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adding a `Refresh` functionality to the main page of bank accounts. It is a `POST` request to the `'/api/v1/bank_integrations/refresh_accounts'` endpoint with an `empty object payload`. Screenshot:

![Screenshot 2023-05-02 at 15 41 08](https://user-images.githubusercontent.com/51542191/235687877-cafe7d92-934c-4007-8e25-ec271fc7445c.png)

This is only available for `Enterprise` plan on the `Hosted` platform. Let me know your thoughts.