### PR TITLE
[Feature] Add Field - Tax Category | Products

### DIFF
--- a/src/common/interfaces/product.ts
+++ b/src/common/interfaces/product.ts
@@ -19,6 +19,7 @@ export interface Product {
   price: number;
   quantity: number;
   max_quantity: number;
+  tax_id: string;
   product_image: string;
   tax_name1: string;
   tax_rate1: number;

--- a/src/pages/products/common/components/ProductForm.tsx
+++ b/src/pages/products/common/components/ProductForm.tsx
@@ -9,7 +9,7 @@
  */
 
 import { useTranslation } from 'react-i18next';
-import { InputField } from '$app/components/forms';
+import { InputField, SelectField } from '$app/components/forms';
 import { Element } from '$app/components/cards';
 import { CustomField } from '$app/components/CustomField';
 import { TaxRateSelector } from '$app/components/tax-rates/TaxRateSelector';
@@ -96,6 +96,24 @@ export function ProductForm(props: Props) {
           onValueChange={(value) => handleChange('max_quantity', value)}
           errorMessage={errors?.errors.max_quantity}
         />
+      </Element>
+
+      <Element leftSide={t('tax_category')}>
+        <SelectField
+          value={props.product.tax_id}
+          onValueChange={(value) => handleChange('tax_id', value)}
+          errorMessage={errors?.errors.tax_id}
+        >
+          <option value="1">{t('physical_goods')}</option>
+          <option value="2">{t('services')}</option>
+          <option value="3">{t('digital_products')}</option>
+          <option value="4">{t('shipping')}</option>
+          <option value="5">{t('tax_exempt')}</option>
+          <option value="6">{t('reduced_tax')}</option>
+          <option value="7">{t('override_tax')}</option>
+          <option value="8">{t('zero_rated')}</option>
+          <option value="9">{t('reverse_tax')}</option>
+        </SelectField>
       </Element>
 
       <Element leftSide={t('image_url')}>


### PR DESCRIPTION
@beganovich @turbo124 PR includes implementation for new Product's field (`Tax Category`). Screenshot:

![Screenshot 2023-04-30 at 18 25 22](https://user-images.githubusercontent.com/51542191/235364635-305fe769-b531-4471-9085-e6c41ea9553b.png)

We miss just a few translation keywords: `reduced_tax`, `override_tax`, `zero_rated` and `reverse_tax`. Let me know your thoughts.