### PR TITLE
[Feature] Expense Payment Type Field

### DIFF
--- a/src/components/forms/SelectField.tsx
+++ b/src/components/forms/SelectField.tsx
@@ -20,6 +20,7 @@ interface Props extends CommonProps {
   withBlank?: boolean;
   onValueChange?: (value: string) => unknown;
   errorMessage?: string | string[];
+  blankOptionValue?: string | number;
 }
 
 export function SelectField(props: Props) {
@@ -46,7 +47,9 @@ export function SelectField(props: Props) {
         ref={props.innerRef}
         disabled={props.disabled}
       >
-        {props.withBlank && <option value=""></option>}
+        {props.withBlank && (
+          <option value={props.blankOptionValue ?? ''}></option>
+        )}
         {props.children}
       </select>
 

--- a/src/pages/settings/company/components/Defaults.tsx
+++ b/src/pages/settings/company/components/Defaults.tsx
@@ -83,6 +83,23 @@ export function Defaults() {
             </Element>
           )}
 
+          <Element leftSide={t('expense_payment_type')}>
+            <SelectField
+              value={companyChanges?.settings?.default_expense_payment_type_id}
+              onChange={handleChange}
+              id="settings.default_expense_payment_type_id"
+            >
+              <option value="0"></option>
+              {statics?.payment_types.map(
+                (type: { id: string; name: string }) => (
+                  <option key={type.id} value={type.id}>
+                    {type.name}
+                  </option>
+                )
+              )}
+            </SelectField>
+          </Element>
+
           <div className="pt-6 border-b"></div>
 
           <Element className="mt-6" leftSide={t('manual_payment_email')}>

--- a/src/pages/settings/company/components/Defaults.tsx
+++ b/src/pages/settings/company/components/Defaults.tsx
@@ -54,8 +54,9 @@ export function Defaults() {
               value={companyChanges?.settings?.payment_type_id}
               onChange={handleChange}
               id="settings.payment_type_id"
+              blankOptionValue="0"
+              withBlank
             >
-              <option value="0"></option>
               {statics?.payment_types.map(
                 (type: { id: string; name: string }) => (
                   <option key={type.id} value={type.id}>
@@ -72,8 +73,8 @@ export function Defaults() {
                 value={companyChanges?.settings?.valid_until}
                 id="settings.valid_until"
                 onChange={handleChange}
+                withBlank
               >
-                <option value=""></option>
                 {terms.data.data.map((type: PaymentTerm) => (
                   <option key={type.id} value={type.num_days}>
                     {type.name}
@@ -88,8 +89,9 @@ export function Defaults() {
               value={companyChanges?.settings?.default_expense_payment_type_id}
               onChange={handleChange}
               id="settings.default_expense_payment_type_id"
+              blankOptionValue="0"
+              withBlank
             >
-              <option value="0"></option>
               {statics?.payment_types.map(
                 (type: { id: string; name: string }) => (
                   <option key={type.id} value={type.id}>


### PR DESCRIPTION
@beganovich @turbo124 PR includes implementation of `Expense Payment Type` field under `Defaults`. Screenshot:

![Screenshot 2023-04-30 at 19 14 00](https://user-images.githubusercontent.com/51542191/235366948-d747cf50-1921-4b96-8e23-25acf1bcfc05.png)

We miss `expense_payment_type` translation keyword from the translation files, so if you agree please just add it. Let me know your thoughts.