### PR TITLE
Add default headers

### DIFF
--- a/src/common/queries/common/headers.ts
+++ b/src/common/queries/common/headers.ts
@@ -12,5 +12,6 @@ export function defaultHeaders() {
   return {
     'X-Api-Token': localStorage.getItem('X-NINJA-TOKEN') as string,
     'X-Requested-With': 'XMLHttpRequest',
+    'X-React': 'true'
   };
 }

--- a/src/pages/settings/user/components/Connect.tsx
+++ b/src/pages/settings/user/components/Connect.tsx
@@ -49,8 +49,7 @@ export function Connect() {
     request(
       'POST',
       endpoint('/api/v1/users/:id/disconnect_mailer', { id: user!.id }),
-      {},
-      { headers: { 'X-REACT': true } }
+      {}
     )
       .then((response) => {
         toast.success(response.data.message);


### PR DESCRIPTION
Sets default headers so we can differentiate in the API which AP type has sent the request