### PR TITLE
[Cleanup] Email Confirmation Banner | Implementation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,10 +11,8 @@
 import { isHosted } from '$app/common/helpers';
 import { useCurrentAccount } from '$app/common/hooks/useCurrentAccount';
 import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
-import { useCurrentUser } from '$app/common/hooks/useCurrentUser';
 import { useResolveLanguage } from '$app/common/hooks/useResolveLanguage';
 import { AccountWarningsModal } from '$app/components/AccountWarningsModal';
-import { VerifyModal } from '$app/components/VerifyModal';
 import { useEffect, useState } from 'react';
 import { Toaster } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
@@ -32,13 +30,9 @@ export function App() {
 
   const company = useCurrentCompany();
 
-  const user = useCurrentUser();
-
   const account = useCurrentAccount();
 
   const updateDayJSLocale = useSetAtom(dayJSLocaleAtom);
-
-  const [isEmailVerified, setIsEmailVerified] = useState<boolean>(true);
 
   const [showCompanyActivityModal, setShowCompanyActivityModal] =
     useState<boolean>(false);
@@ -88,12 +82,6 @@ export function App() {
   }, [darkMode, resolvedLanguage]);
 
   useEffect(() => {
-    if (user && Object.keys(user).length) {
-      setIsEmailVerified(Boolean(user.email_verified_at));
-    }
-  }, [user]);
-
-  useEffect(() => {
     const modalShown = sessionStorage.getItem('PHONE-VERIFICATION-SHOWN');
 
     if (account && (modalShown === 'false' || !modalShown)) {
@@ -115,8 +103,6 @@ export function App() {
 
   return (
     <div className="App">
-      <VerifyModal visible={!isEmailVerified && isHosted()} type="email" />
-
       <AccountWarningsModal
         type="activity"
         visible={Boolean(company) && showCompanyActivityModal}

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -1,0 +1,35 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import CommonProps from '$app/common/interfaces/common-props.interface';
+import classNames from 'classnames';
+
+type BannerVariant = 'orange';
+
+interface Props extends CommonProps {
+  variant?: BannerVariant;
+}
+
+export function Banner(props: Props) {
+  const { variant } = props;
+
+  return (
+    <div
+      className={classNames(
+        `flex justify-center items-center px-3.5 py-3.5 text-xs md:px-6 md:text-sm leading-6 text-gray-900 ${props.className}`,
+        {
+          'bg-orange-300': !variant || variant === 'orange',
+        }
+      )}
+    >
+      {props.children}
+    </div>
+  );
+}

--- a/src/components/EmailConfirmationBanner.tsx
+++ b/src/components/EmailConfirmationBanner.tsx
@@ -1,0 +1,52 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { endpoint } from '$app/common/helpers';
+import { request } from '$app/common/helpers/request';
+import { toast } from '$app/common/helpers/toast/toast';
+import { useCurrentUser } from '$app/common/hooks/useCurrentUser';
+import { Banner } from './Banner';
+import { useTranslation } from 'react-i18next';
+
+export function EmailConfirmationBanner() {
+  const [t] = useTranslation();
+
+  const user = useCurrentUser();
+
+  const handleResendEmail = () => {
+    toast.processing();
+
+    request('POST', endpoint('/api/v1/user/:id/reconfirm', { id: user!.id }))
+      .then((response) => {
+        toast.success(response.data.message);
+      })
+      .catch((error) => {
+        toast.error();
+        console.error(error);
+      });
+  };
+
+  return (
+    <Banner className="space-x-3">
+      <span>{t('confirm_your_email_address')}.</span>
+
+      <div className="flex space-x-1">
+        <span
+          className="font-medium text-xs md:text-sm text-blue-500 hover:underline cursor-pointer"
+          onClick={handleResendEmail}
+        >
+          {t('resend_email')}
+        </span>
+
+        <span className="font-medium text-blue-500">&rarr;</span>
+      </div>
+    </Banner>
+  );
+}

--- a/src/components/layouts/components/DesktopSidebar.tsx
+++ b/src/components/layouts/components/DesktopSidebar.tsx
@@ -15,6 +15,7 @@ import { HelpSidebarIcons } from '$app/components/HelpSidebarIcons';
 import { Icon } from 'react-feather';
 import { useSelector } from 'react-redux';
 import { SidebarItem } from './SidebarItem';
+import classNames from 'classnames';
 
 export interface NavigationItem {
   name: string;
@@ -33,6 +34,7 @@ export interface NavigationItem {
 interface Props {
   navigation: NavigationItem[];
   docsLink?: string;
+  isBannerDisplayed?: boolean;
 }
 
 export function DesktopSidebar(props: Props) {
@@ -44,9 +46,14 @@ export function DesktopSidebar(props: Props) {
 
   return (
     <div
-      className={`hidden md:flex z-10 ${
-        isMiniSidebar ? 'md:w-16' : 'md:w-64'
-      } md:flex-col md:fixed md:inset-y-0`}
+      className={classNames(
+        'hidden md:flex z-10 md:flex-col md:fixed md:inset-y-0',
+        {
+          'md:w-16': isMiniSidebar,
+          'md:w-64': !isMiniSidebar,
+          'mt-12': props.isBannerDisplayed,
+        }
+      )}
     >
       <div className="flex flex-col flex-grow border-gray-100 bg-ninja-gray overflow-y-auto border-r">
         <div className="flex items-center flex-shrink-0 pl-3 pr-6 bg-ninja-gray h-16 border-b border-gray-600">


### PR DESCRIPTION
@beganovich @turbo124 PR includes implementing banner at the top of the page instead of modal we already had. Here is the screenshot:

![Screenshot 2023-06-09 at 19 02 54](https://github.com/invoiceninja/ui/assets/51542191/64998d39-c148-4029-8bd6-939d05ff3fd6)

The CTA `Resend Email` will resend email via API through `/api/v1/user/:id/reconfirm` endpoint. This banner will be displayed only for `HOSTED` users.

Let me know your thoughts.