### PR TITLE
Fixes for combobox showing nothing on empty value

### DIFF
--- a/src/components/forms/Combobox.tsx
+++ b/src/components/forms/Combobox.tsx
@@ -355,9 +355,7 @@ export function ComboboxAsync<T = any>({
 
   const onEmptyValues = (query: string) => {
     setUrl((current) => {
-      if (query.length > 0 && current) {
-        current.searchParams.set('filter', query);
-      }
+      current.searchParams.set('filter', query);
 
       return new URL(current.href);
     });


### PR DESCRIPTION
This fixes empty results set when we delete the input (query).