### PR TITLE
Fixes for filtering line items

### DIFF
--- a/src/common/interfaces/invoice-item.ts
+++ b/src/common/interfaces/invoice-item.ts
@@ -11,6 +11,9 @@
 export enum InvoiceItemType {
   Product = '1',
   Task = '2',
+  UnpaidFee = '3',
+  PaidFee = '4',
+  LateFee = '5',
 }
 
 export interface InvoiceItem {

--- a/src/pages/credits/create/Create.tsx
+++ b/src/pages/credits/create/Create.tsx
@@ -102,7 +102,8 @@ export default function Create() {
           _credit.client_id = searchParams.get('client')!;
         }
 
-        _credit.uses_inclusive_taxes = company?.settings?.inclusive_taxes ?? false;
+        _credit.uses_inclusive_taxes =
+          company?.settings?.inclusive_taxes ?? false;
 
         value = _credit;
       }
@@ -162,8 +163,13 @@ export default function Create() {
             <ProductsTable
               type="product"
               resource={credit}
-              items={credit.line_items.filter(
-                (item) => item.type_id === InvoiceItemType.Product
+              items={credit.line_items.filter((item) =>
+                [
+                  InvoiceItemType.Product,
+                  InvoiceItemType.UnpaidFee,
+                  InvoiceItemType.PaidFee,
+                  InvoiceItemType.LateFee,
+                ].includes(item.type_id)
               )}
               columns={productColumns}
               relationType="client_id"

--- a/src/pages/credits/edit/Edit.tsx
+++ b/src/pages/credits/edit/Edit.tsx
@@ -128,8 +128,13 @@ export default function Edit() {
             <ProductsTable
               type="product"
               resource={credit}
-              items={credit.line_items.filter(
-                (item) => item.type_id === InvoiceItemType.Product
+              items={credit.line_items.filter((item) =>
+                [
+                  InvoiceItemType.Product,
+                  InvoiceItemType.UnpaidFee,
+                  InvoiceItemType.PaidFee,
+                  InvoiceItemType.LateFee,
+                ].includes(item.type_id)
               )}
               columns={productColumns}
               relationType="client_id"

--- a/src/pages/invoices/create/Create.tsx
+++ b/src/pages/invoices/create/Create.tsx
@@ -133,7 +133,8 @@ export default function Create() {
           _invoice.client_id = searchParams.get('client')!;
         }
 
-        _invoice.uses_inclusive_taxes = company?.settings?.inclusive_taxes ?? false;
+        _invoice.uses_inclusive_taxes =
+          company?.settings?.inclusive_taxes ?? false;
 
         value = _invoice;
       }
@@ -206,8 +207,13 @@ export default function Create() {
                   shouldCreateInitialLineItem={
                     searchParams.get('table') !== 'tasks'
                   }
-                  items={invoice.line_items.filter(
-                    (item) => item.type_id === InvoiceItemType.Product
+                  items={invoice.line_items.filter((item) =>
+                    [
+                      InvoiceItemType.Product,
+                      InvoiceItemType.UnpaidFee,
+                      InvoiceItemType.PaidFee,
+                      InvoiceItemType.LateFee,
+                    ].includes(item.type_id)
                   )}
                   columns={productColumns}
                   relationType="client_id"

--- a/src/pages/invoices/edit/Edit.tsx
+++ b/src/pages/invoices/edit/Edit.tsx
@@ -153,7 +153,12 @@ export default function Edit() {
                     searchParams.get('table') !== 'tasks'
                   }
                   items={invoice.line_items.filter(
-                    (item) => item.type_id === InvoiceItemType.Product
+                    (item) => [
+                      InvoiceItemType.Product,
+                      InvoiceItemType.UnpaidFee,
+                      InvoiceItemType.PaidFee,
+                      InvoiceItemType.LateFee,
+                    ].includes(item.type_id)
                   )}
                   columns={productColumns}
                   relationType="client_id"

--- a/src/pages/quotes/edit/Edit.tsx
+++ b/src/pages/quotes/edit/Edit.tsx
@@ -129,7 +129,12 @@ export default function Edit() {
               type="product"
               resource={quote}
               items={quote.line_items.filter(
-                (item) => item.type_id === InvoiceItemType.Product
+                (item) => [
+                  InvoiceItemType.Product,
+                  InvoiceItemType.UnpaidFee,
+                  InvoiceItemType.PaidFee,
+                  InvoiceItemType.LateFee,
+                ].includes(item.type_id)
               )}
               columns={productColumns}
               relationType="client_id"

--- a/src/pages/recurring-invoices/create/Create.tsx
+++ b/src/pages/recurring-invoices/create/Create.tsx
@@ -189,7 +189,12 @@ export default function Create() {
               type="product"
               resource={recurringInvoice}
               items={recurringInvoice.line_items.filter(
-                (item) => item.type_id === InvoiceItemType.Product
+                (item) => [
+                  InvoiceItemType.Product,
+                  InvoiceItemType.UnpaidFee,
+                  InvoiceItemType.PaidFee,
+                  InvoiceItemType.LateFee,
+                ].includes(item.type_id)
               )}
               columns={productColumns}
               relationType="client_id"

--- a/src/pages/recurring-invoices/edit/Edit.tsx
+++ b/src/pages/recurring-invoices/edit/Edit.tsx
@@ -176,8 +176,13 @@ export default function Edit() {
             <ProductsTable
               type="product"
               resource={recurringInvoice}
-              items={recurringInvoice.line_items.filter(
-                (item) => item.type_id === InvoiceItemType.Product
+              items={recurringInvoice.line_items.filter((item) =>
+                [
+                  InvoiceItemType.Product,
+                  InvoiceItemType.UnpaidFee,
+                  InvoiceItemType.PaidFee,
+                  InvoiceItemType.LateFee,
+                ].includes(item.type_id)
               )}
               columns={productColumns}
               relationType="client_id"


### PR DESCRIPTION
Previously we only allowed `InvoiceItemType.Product` (1) to be part of the products table. This fixes it to support other types except for tasks.

The current filter:

```
InvoiceItemType.Product,
InvoiceItemType.UnpaidFee,
InvoiceItemType.PaidFee,
InvoiceItemType.LateFee,
```