### PR TITLE
[Bugfix] Client Create Modal | Client Combobox

### DIFF
--- a/src/components/clients/ClientSelector.tsx
+++ b/src/components/clients/ClientSelector.tsx
@@ -75,7 +75,7 @@ export function ClientSelector(props: ClientSelectorProps) {
         entryOptions={{ id: 'id', label: 'display_name', value: 'id' }}
         onChange={(value) => value.resource && props.onChange(value.resource)}
         staleTime={props.staleTime || 500}
-        sortBy="display_name|asc"
+        sortBy="created_at|desc"
         exclude={props.exclude}
         action={{
           label: t('new_client'),

--- a/src/pages/clients/edit/components/AdditionalInfo.tsx
+++ b/src/pages/clients/edit/components/AdditionalInfo.tsx
@@ -163,7 +163,7 @@ export function AdditionalInfo(props: Props) {
 
           <Element leftSide={t('send_reminders')}>
             <Toggle
-              checked={props.client?.settings.send_reminders}
+              checked={Boolean(props.client?.settings.send_reminders)}
               onChange={(value) =>
                 props.setClient(
                   (client) =>

--- a/src/pages/clients/edit/components/AdditionalInfo.tsx
+++ b/src/pages/clients/edit/components/AdditionalInfo.tsx
@@ -163,7 +163,7 @@ export function AdditionalInfo(props: Props) {
 
           <Element leftSide={t('send_reminders')}>
             <Toggle
-              checked={Boolean(props.client?.settings.send_reminders)}
+              checked={Boolean(props.client?.settings?.send_reminders)}
               onChange={(value) =>
                 props.setClient(
                   (client) =>

--- a/src/pages/clients/edit/components/Contacts.tsx
+++ b/src/pages/clients/edit/components/Contacts.tsx
@@ -123,7 +123,7 @@ export function Contacts(props: Props) {
 
           <Element leftSide={t('add_to_invoices')}>
             <Toggle
-              checked={contact.send_email}
+              checked={Boolean(contact.send_email)}
               onChange={(value) =>
                 handleChange(value, 'send_email', contact.id as string)
               }

--- a/src/pages/clients/edit/components/Contacts.tsx
+++ b/src/pages/clients/edit/components/Contacts.tsx
@@ -123,7 +123,7 @@ export function Contacts(props: Props) {
 
           <Element leftSide={t('add_to_invoices')}>
             <Toggle
-              checked={Boolean(contact.send_email)}
+              checked={Boolean(contact?.send_email)}
               onChange={(value) =>
                 handleChange(value, 'send_email', contact.id as string)
               }

--- a/src/pages/clients/edit/components/Details.tsx
+++ b/src/pages/clients/edit/components/Details.tsx
@@ -146,7 +146,7 @@ export function Details(props: Props) {
       <Element leftSide={t('valid_vat_number')}>
         <Toggle
           id="has_valid_vat_number"
-          checked={props.client?.has_valid_vat_number}
+          checked={Boolean(props.client?.has_valid_vat_number)}
           onValueChange={(value) =>
             handleCustomFieldChange('has_valid_vat_number', value)
           }
@@ -156,7 +156,7 @@ export function Details(props: Props) {
       <Element leftSide={t('tax_exempt')}>
         <Toggle
           id="is_tax_exempt"
-          checked={props.client?.is_tax_exempt}
+          checked={Boolean(props.client?.is_tax_exempt)}
           onValueChange={(value) =>
             handleCustomFieldChange('is_tax_exempt', value)
           }


### PR DESCRIPTION
@beganovich @turbo124 While testing query invalidation for comboboxes, I discovered a few bugs in the Client creation modal that I have prioritized to resolve in this PR:

- The combobox for clients had sorting by `display_name|asc`, which caused an issue when there were more than 20 clients. If a newly created client appeared after the first 20 clients based on this sorting, it wouldn't be selected in the combobox after creation. To resolve this, I have decided to use sorting by `created_at|desc`, which seems to be a logical solution. I hope you agree with this change, as it will fix the bug.

- When opening the modal twice in a row, we encountered 2-3 strange bugs related to setting the Client object. As a result, we ended up with a situation where a Client was created without any entered details. It seems that the API was creating a blank Client object, leading to additional issues. Additionally we had bugs in the console for uncontrolled toggles which is also resolved here. I just slightly changed the logic in the modal to resolve those bugs.

- The Cancel button had `type='minimal'`, which made it look unusual. I have simply changed it to `secondary`, which is consistent with how Cancel buttons look throughout our app. I hope you agree with this UI change.

![Screenshot 2023-06-19 at 18 45 30](https://github.com/invoiceninja/ui/assets/51542191/c3f8fd99-3c36-4fc6-8a65-da9679f2fc8e)

Let me know your thoughts.