### PR TITLE
[Bugfix] Missing Custom Fields | Product Task Tables

### DIFF
--- a/src/pages/invoices/common/components/ProductsTable.tsx
+++ b/src/pages/invoices/common/components/ProductsTable.tsx
@@ -66,7 +66,7 @@ export function ProductsTable(props: Props) {
 
   const isEditPage = location.pathname.includes(id!);
 
-  const resolveTranslation = useResolveTranslation();
+  const resolveTranslation = useResolveTranslation({ type: props.type });
 
   const resolveInputField = useResolveInputField({
     type: props.type,

--- a/src/pages/invoices/common/hooks/useProductColumns.ts
+++ b/src/pages/invoices/common/hooks/useProductColumns.ts
@@ -54,6 +54,12 @@ export function useProductColumns() {
       }
 
       variables = variables.filter((variable) => variable !== '$product.tax');
+
+      ['product1', 'product2', 'product3', 'product4'].forEach((field) => {
+        if (company?.custom_fields[field]) {
+          variables.splice(variables.length - 1, 0, field);
+        }
+      });
     }
 
     setColumns(variables);

--- a/src/pages/invoices/common/hooks/useResolveTotalVariable.tsx
+++ b/src/pages/invoices/common/hooks/useResolveTotalVariable.tsx
@@ -40,7 +40,7 @@ export function useResolveTotalVariable(props: Props) {
   const handleChange = (property: keyof ProductTableResource, value: unknown) =>
     props.onChange(property, value);
 
-  const resolveTranslation = useResolveTranslation();
+  const resolveTranslation = useResolveTranslation({});
   const invoiceSum = props.invoiceSum;
 
   // discount => invoice.discount,

--- a/src/pages/invoices/common/hooks/useResolveTranslation.ts
+++ b/src/pages/invoices/common/hooks/useResolveTranslation.ts
@@ -12,10 +12,13 @@ import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { resolveKey } from '$app/pages/invoices/common/helpers/resolve-key';
 import { useTranslation } from 'react-i18next';
 
-export function useResolveTranslation() {
+export function useResolveTranslation({ type }: { type?: 'product' | 'task' }) {
   const [t] = useTranslation();
   const company = useCurrentCompany();
-  const customFields = ['product1', 'product2', 'product3', 'product4'];
+  const customFields =
+    type === 'product' || !type
+      ? ['product1', 'product2', 'product3', 'product4']
+      : ['task1', 'task2', 'task3', 'task4'];
 
   const aliases: Record<string, string> = {
     '$product.tax_rate1': t('tax_rate1'),
@@ -30,8 +33,8 @@ export function useResolveTranslation() {
 
     const { property } = resolveKey(key, delimiter);
 
-    if (customFields.includes(property)) {
-      const customField = company.custom_fields?.[property];
+    if (customFields.includes(key)) {
+      const customField = company.custom_fields?.[key];
 
       if (customField) {
         return customField.split('|')[0];

--- a/src/pages/invoices/common/hooks/useTaskColumns.ts
+++ b/src/pages/invoices/common/hooks/useTaskColumns.ts
@@ -48,6 +48,12 @@ export function useTaskColumns() {
       variables.splice(taxVariableIndex + 1, 0, ...taxes);
 
       variables = variables.filter((variable) => variable !== '$task.tax');
+
+      ['task1', 'task2', 'task3', 'task4'].forEach((field) => {
+        if (company?.custom_fields[field]) {
+          variables.splice(variables.length - 1, 0, field);
+        }
+      });
     }
 
     setColumns(variables);


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adding custom fields as columns to the product and task tables. Additionally, I found a bug with the header of columns for those fields, which is also resolved in this PR. Screenshot:

![Screenshot 2023-06-20 at 01 26 02](https://github.com/invoiceninja/ui/assets/51542191/33fab3f0-a336-4a65-a507-dc9673841627)

Let me know your thoughts.