### PR TITLE
[Bugfix] Adding Validation | Emailing Pages

### DIFF
--- a/src/pages/invoices/email/components/Mailer.tsx
+++ b/src/pages/invoices/email/components/Mailer.tsx
@@ -124,7 +124,7 @@ export const Mailer = forwardRef<MailerComponent, Props>((props, ref) => {
             <SelectField
               defaultValue={templateId}
               onValueChange={(value) => handleTemplateChange(value)}
-              errorMessage={errors?.errors.template_id}
+              errorMessage={errors?.errors.template}
             >
               {Object.entries(props.list).map(
                 ([templateId, translation], index) => (

--- a/src/pages/invoices/email/components/Mailer.tsx
+++ b/src/pages/invoices/email/components/Mailer.tsx
@@ -30,6 +30,7 @@ import { useTranslation } from 'react-i18next';
 import { isHosted, isSelfHosted } from '$app/common/helpers';
 import { MarkdownEditor } from '$app/components/forms/MarkdownEditor';
 import { useReactSettings } from '$app/common/hooks/useReactSettings';
+import { ValidationBag } from '$app/common/interfaces/validation-bag';
 
 export type MailerResourceType =
   | 'invoice'
@@ -52,6 +53,8 @@ interface Props {
 
 export const Mailer = forwardRef<MailerComponent, Props>((props, ref) => {
   const [t] = useTranslation();
+
+  const [errors, setErrors] = useState<ValidationBag>();
 
   const [templateId, setTemplateId] = useState(props.defaultEmail);
   const [subject, setSubject] = useState('');
@@ -84,7 +87,7 @@ export const Mailer = forwardRef<MailerComponent, Props>((props, ref) => {
     resourceType: props.resourceType,
   });
 
-  const handleSend = useHandleSend();
+  const handleSend = useHandleSend({ setErrors });
 
   useImperativeHandle(
     ref,
@@ -121,6 +124,7 @@ export const Mailer = forwardRef<MailerComponent, Props>((props, ref) => {
             <SelectField
               defaultValue={templateId}
               onValueChange={(value) => handleTemplateChange(value)}
+              errorMessage={errors?.errors.template_id}
             >
               {Object.entries(props.list).map(
                 ([templateId, translation], index) => (
@@ -157,6 +161,7 @@ export const Mailer = forwardRef<MailerComponent, Props>((props, ref) => {
               label={t('cc_email')}
               value={ccEmail || template?.cc_email}
               onValueChange={(value) => setCcEmail(value)}
+              errorMessage={errors?.errors.cc_email}
             />
           )}
 
@@ -165,6 +170,7 @@ export const Mailer = forwardRef<MailerComponent, Props>((props, ref) => {
             value={subject || template?.raw_subject}
             onValueChange={(value) => setSubject(value)}
             disabled={freePlan() && isHosted()}
+            errorMessage={errors?.errors.subject}
           />
 
           {(proPlan() || enterprisePlan()) && (


### PR DESCRIPTION
@beganovich @turbo124 This PR includes the addition of missing validation for Mailing pages. Here is a screenshot of the updated functionality:

<img width="1262" alt="Screenshot 2023-06-20 at 17 05 05" src="https://github.com/invoiceninja/ui/assets/51542191/923e72f2-496d-4154-961d-f903b2ff3a40">

@turbo124 Validation will be shown for the `template`, `subject`, and `cc_email` fields, I'm not sure that I see any other fields where we can have scenario of showing validation. Let me know if we have any other scenarios.

Let me know your thoughts.