### PR TITLE
Stack both keys for cache invalidation

### DIFF
--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -161,7 +161,8 @@ export function DataTable<T extends object>(props: Props<T>) {
 
   const { data, isLoading, isError } = useQuery(
     [
-      apiEndpoint.pathname,
+      props.endpoint,
+      apiEndpoint.href,
       perPage,
       currentPage,
       filter,


### PR DESCRIPTION
This fixes an issue with the datatable caching mechanism.