### PR TITLE
[Bugfix] Query Invalidation Across the App

### DIFF
--- a/src/common/queries/clients.ts
+++ b/src/common/queries/clients.ts
@@ -16,6 +16,7 @@ import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission
 import { GenericQueryOptions } from './invoices';
 import { Client } from '../interfaces/client';
 import { GenericSingleResourceResponse } from '../interfaces/generic-api-response';
+import { route } from '../helpers/route';
 
 interface BlankQueryParams {
   refetchOnWindowFocus?: boolean;
@@ -44,7 +45,7 @@ interface Props {
 
 export function useClientsQuery(props: Props) {
   return useQuery(
-    ['/api/v1/clients?filter_deleted_clients=true?per_page=500'],
+    ['/api/v1/clients', 'filter_deleted_clients=true', 'per_page=500'],
     () =>
       request('GET', endpoint('/api/v1/clients?per_page=500')).then(
         (response) => response.data.data
@@ -54,16 +55,17 @@ export function useClientsQuery(props: Props) {
 }
 
 export function useClientQuery({ id, enabled }: GenericQueryOptions) {
-  return useQuery({
-    queryKey: ['/api/v1/clients', id],
-    queryFn: () =>
+  return useQuery(
+    route('/api/v1/clients/:id', { id }),
+    () =>
       request('GET', endpoint('/api/v1/clients/:id', { id })).then(
-        (response: GenericSingleResourceResponse<Client>) =>
-          response.data.data
+        (response: GenericSingleResourceResponse<Client>) => response.data.data
       ),
-    enabled,
-    staleTime: Infinity,
-  });
+    {
+      enabled,
+      staleTime: Infinity,
+    }
+  );
 }
 
 export function bulk(

--- a/src/common/queries/company-gateways.ts
+++ b/src/common/queries/company-gateways.ts
@@ -18,7 +18,7 @@ export function useCompanyGatewaysQuery() {
   const { isAdmin } = useAdmin();
 
   return useQuery(
-    '/api/v1/company_gateways?sort=id|desc',
+    ['/api/v1/company_gateways', 'sort=id|desc'],
     () => request('GET', endpoint('/api/v1/company_gateways?sort=id|desc')),
     { staleTime: Infinity, enabled: isAdmin }
   );

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -161,8 +161,8 @@ export function DataTable<T extends object>(props: Props<T>) {
 
   const { data, isLoading, isError } = useQuery(
     [
+      apiEndpoint.pathname,
       props.endpoint,
-      apiEndpoint.href,
       perPage,
       currentPage,
       filter,

--- a/src/pages/settings/system-logs/SystemLog.tsx
+++ b/src/pages/settings/system-logs/SystemLog.tsx
@@ -58,7 +58,7 @@ export function SystemLog() {
   const { dateFormat } = useCurrentCompanyDateFormats();
 
   const { data, isLoading } = useQuery(
-    '/api/v1/system_logs?per_page=200&sort=created_at|DESC',
+    ['/api/v1/system_logs', 'per_page=200', 'sort=created_at|DESC'],
     () =>
       request(
         'GET',

--- a/src/pages/tasks/common/components/CreateTaskModal.tsx
+++ b/src/pages/tasks/common/components/CreateTaskModal.tsx
@@ -76,6 +76,8 @@ export function CreateTaskModal(props: Props) {
         .then(() => {
           toast.success('created_task');
 
+          queryClient.invalidateQueries('/api/v1/tasks');
+
           queryClient.invalidateQueries('/api/v1/tasks?per_page=1000');
 
           queryClient.invalidateQueries(

--- a/src/pages/transactions/components/TransactionMatchDetails.tsx
+++ b/src/pages/transactions/components/TransactionMatchDetails.tsx
@@ -87,7 +87,7 @@ export function TransactionMatchDetails(props: Props) {
         ],
       })
         .then(() => {
-          queryClient.invalidateQueries(invalidationQuery);
+          queryClient.invalidateQueries([invalidationQuery]);
           queryClient.invalidateQueries('/api/v1/invoices');
           queryClient.invalidateQueries(
             route('/api/v1/bank_transactions/:id', {
@@ -124,7 +124,7 @@ export function TransactionMatchDetails(props: Props) {
         ],
       })
         .then(() => {
-          queryClient.invalidateQueries(invalidationQuery);
+          queryClient.invalidateQueries([invalidationQuery]);
           queryClient.invalidateQueries('/api/v1/invoices');
           queryClient.invalidateQueries('/api/v1/payments');
           queryClient.invalidateQueries(
@@ -163,7 +163,7 @@ export function TransactionMatchDetails(props: Props) {
         ],
       })
         .then((response: GenericSingleResourceResponse<Transaction[]>) => {
-          queryClient.invalidateQueries(invalidationQuery);
+          queryClient.invalidateQueries([invalidationQuery]);
 
           queryClient.invalidateQueries(
             route('/api/v1/bank_transactions/:id', {
@@ -206,7 +206,7 @@ export function TransactionMatchDetails(props: Props) {
         ],
       })
         .then((response: GenericSingleResourceResponse<Transaction[]>) => {
-          queryClient.invalidateQueries(invalidationQuery);
+          queryClient.invalidateQueries([invalidationQuery]);
 
           queryClient.invalidateQueries('/api/v1/expenses');
 


### PR DESCRIPTION
@turbo124 @beganovich I went through the entire app to ensure how we `defined` queries and how we `invalidate` them regarding the bug that Shalom reported for Client view page and David noticed in the Transactions. Both of them have been resolved, and additionally, I fixed the queries' definition where we were not doing it correctly. I have extensively tested this, and it appears to me that we do not have any instances of invalidation query bugs.

Let me know your thoughts.