### PR TITLE
Remove tinymce context menu

### DIFF
--- a/src/components/forms/MarkdownEditor.tsx
+++ b/src/components/forms/MarkdownEditor.tsx
@@ -78,6 +78,7 @@ export function MarkdownEditor(props: Props) {
             'removeformat | code | help',
           content_style:
             'body { font-family:Helvetica,Arial,sans-serif; font-size:14px }',
+          contextmenu: '',
         }}
         onEditorChange={handleChange}
       />


### PR DESCRIPTION
prevents tinymce from overriding the browser context menu on right click.