### PR TITLE
[Bugfix] Auto Bill Recurring Invoices Dropdown Removing Blank Option

### DIFF
--- a/src/pages/settings/online-payments/OnlinePayments.tsx
+++ b/src/pages/settings/online-payments/OnlinePayments.tsx
@@ -93,11 +93,10 @@ export function OnlinePayments() {
 
         <Element leftSide={`${t('auto_bill')} ${t('recurring_invoices')}`}>
           <SelectField
-            value={company?.settings?.auto_bill}
+            value={company?.settings?.auto_bill || 'off'}
             onChange={handleChange}
             id="settings.auto_bill"
           >
-            <option defaultChecked></option>
             <option value="always">
               {t('enabled')} ({t('auto_bill_help_always')})
             </option>

--- a/src/pages/settings/online-payments/OnlinePayments.tsx
+++ b/src/pages/settings/online-payments/OnlinePayments.tsx
@@ -93,7 +93,7 @@ export function OnlinePayments() {
 
         <Element leftSide={`${t('auto_bill')} ${t('recurring_invoices')}`}>
           <SelectField
-            value={company?.settings?.auto_bill || 'off'}
+            value={company?.settings.auto_bill || 'off'}
             onChange={handleChange}
             id="settings.auto_bill"
           >


### PR DESCRIPTION
@beganovich @turbo124 The PR includes removing blank option for `Auto Bill Recurring Invoices Dropdown` on Payment Settings page. If we do not have any value returned from the API we will set `off` as default value. Screenshot:

![Screenshot 2023-07-01 at 12 38 24](https://github.com/invoiceninja/ui/assets/51542191/88540755-26bc-4c09-aa66-c3a312cd10c4)

Let me know your thoughts.