### PR TITLE
[Bugfix] Time Log Modal Time Updating | Kanban

### DIFF
--- a/src/pages/tasks/common/hooks.tsx
+++ b/src/pages/tasks/common/hooks.tsx
@@ -296,6 +296,14 @@ export function useSave() {
         toast.success('updated_task');
 
         queryClient.invalidateQueries(
+          route('/api/v1/tasks?project_tasks=:projectId&per_page=1000', {
+            projectId: task.project_id,
+          })
+        );
+
+        queryClient.invalidateQueries('/api/v1/tasks?per_page=1000');
+
+        queryClient.invalidateQueries(
           route('/api/v1/tasks/:id', { id: task.id })
         );
       })

--- a/src/pages/tasks/kanban/components/EditSlider.tsx
+++ b/src/pages/tasks/kanban/components/EditSlider.tsx
@@ -67,7 +67,7 @@ export function EditSlider() {
     if (task?.time_log) {
       setTimeLog(parseTimeLog(task.time_log));
     }
-  }, [timeLogIndex]);
+  }, [timeLogIndex, task?.time_log]);
 
   const handleDateChange = (
     unix: number,


### PR DESCRIPTION
@beganovich @turbo124 The PR includes resolving a bug that prevents the `Time Log` modal on Kanban from updating correctly when any of the pickers (Start Date, End Date, Start Time, End Time) are changed. If you switch to the `develop` branch and attempt to change the `End Time` picker, for example, the `Duration` will not be updated. Additionally, if you modify any of the pickers and click "Done" to close the modal, when you reopen it, you will find the old values still present. All of these issues have been resolved in this PR.

![Screenshot 2023-07-03 at 21 07 57](https://github.com/invoiceninja/ui/assets/51542191/939b3f24-66b9-4e3b-9b9d-29c47ffb0c8e)

Let me know your thoughts.