### PR TITLE
[Cleanup] Recurring Expense Edit Page | Missing Bulk Actions

### DIFF
--- a/src/common/queries/recurring-expense.ts
+++ b/src/common/queries/recurring-expense.ts
@@ -10,11 +10,15 @@
 
 import { endpoint } from '$app/common/helpers';
 import { request } from '$app/common/helpers/request';
-import { useQuery } from 'react-query';
+import { useQuery, useQueryClient } from 'react-query';
 import { route } from '$app/common/helpers/route';
 import { RecurringExpense } from '$app/common/interfaces/recurring-expense';
 import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-api-response';
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
+import { useAtomValue } from 'jotai';
+import { invalidationQueryAtom } from '../atoms/data-table';
+import { toast } from '../helpers/toast/toast';
+import { AxiosError } from 'axios';
 
 interface BlankQueryParams {
   enabled?: boolean;
@@ -57,4 +61,32 @@ export function useRecurringExpenseQuery(params: Params) {
       ),
     { enabled: params.enabled ?? true, staleTime: Infinity }
   );
+}
+
+export function useBulk() {
+  const queryClient = useQueryClient();
+  const invalidateQueryValue = useAtomValue(invalidationQueryAtom);
+
+  return (id: string, action: 'archive' | 'restore' | 'delete') => {
+    toast.processing();
+
+    request('POST', endpoint('/api/v1/recurring_expenses/bulk'), {
+      action,
+      ids: [id],
+    })
+      .then(() => {
+        toast.success(`${action}d_recurring_expense`);
+
+        invalidateQueryValue &&
+          queryClient.invalidateQueries([invalidateQueryValue]);
+
+        queryClient.invalidateQueries(
+          route('/api/v1/recurring_expenses/:id', { id })
+        );
+      })
+      .catch((error: AxiosError) => {
+        console.error(error);
+        toast.error();
+      });
+  };
 }


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adding Archive/Restore/Delete actions on Edit Recurring Expense page. Screenshot:

![Screenshot 2023-07-04 at 00 32 47](https://github.com/invoiceninja/ui/assets/51542191/f84719b1-5aa2-417b-9826-625207c8ffd6)

@turbo124 `One note`: For `deleted_recurring_expense` translation key we get the message `Successfully deleted project`. So that is just small bug that we have to fix regarding translation files.

Let me know your thoughts.