### PR TITLE
[Cleanup] Handling Quote Module On Dashboard & Client Overview Page 

### DIFF
--- a/src/pages/clients/show/Client.tsx
+++ b/src/pages/clients/show/Client.tsx
@@ -17,7 +17,6 @@ import { Tabs } from '$app/components/Tabs';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Outlet, useParams } from 'react-router-dom';
-import { Tab } from '$app/components/Tabs';
 import { Address } from './components/Address';
 import { Contacts } from './components/Contacts';
 import { Details } from './components/Details';
@@ -30,6 +29,7 @@ import { ResourceActions } from '$app/components/ResourceActions';
 import { useActions } from '../common/hooks/useActions';
 import { MergeClientModal } from '../common/components/MergeClientModal';
 import { Button } from '$app/components/forms';
+import { useTabs } from './hooks/useTabs';
 
 export default function Client() {
   const { documentTitle, setDocumentTitle } = useTitle('view_client');
@@ -57,38 +57,7 @@ export default function Client() {
 
   const handlePurgeClient = usePurgeClient(id);
 
-  const tabs: Tab[] = [
-    { name: t('invoices'), href: route('/clients/:id', { id }) },
-    { name: t('quotes'), href: route('/clients/:id/quotes', { id }) },
-    {
-      name: t('payments'),
-      href: route('/clients/:id/payments', { id }),
-    },
-    {
-      name: t('recurring_invoices'),
-      href: route('/clients/:id/recurring_invoices', { id }),
-    },
-    {
-      name: t('credits'),
-      href: route('/clients/:id/credits', { id }),
-    },
-    {
-      name: t('projects'),
-      href: route('/clients/:id/projects', { id }),
-    },
-    {
-      name: t('tasks'),
-      href: route('/clients/:id/tasks', { id }),
-    },
-    {
-      name: t('expenses'),
-      href: route('/clients/:id/expenses', { id }),
-    },
-    {
-      name: t('recurring_expenses'),
-      href: route('/clients/:id/recurring_expenses', { id }),
-    },
-  ];
+  const tabs = useTabs();
 
   const actions = useActions({
     setIsMergeModalOpen,
@@ -124,9 +93,7 @@ export default function Client() {
             <Address client={client} />
             <Contacts client={client} />
             <Standing client={client} />
-            {client.gateway_tokens.length > 0 && (
-              <Gateways client={client} />
-            )}
+            {client.gateway_tokens.length > 0 && <Gateways client={client} />}
           </div>
 
           <Tabs tabs={tabs} className="mt-6" />

--- a/src/pages/clients/show/hooks/useTabs.ts
+++ b/src/pages/clients/show/hooks/useTabs.ts
@@ -1,0 +1,62 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { useEnabled } from '$app/common/guards/guards/enabled';
+import { route } from '$app/common/helpers/route';
+import { Tab } from '$app/components/Tabs';
+import { ModuleBitmask } from '$app/pages/settings';
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
+
+export function useTabs() {
+  const [t] = useTranslation();
+  const enabled = useEnabled();
+
+  const { id } = useParams();
+
+  let tabs: Tab[] = [
+    { name: t('invoices'), href: route('/clients/:id', { id }) },
+    { name: t('quotes'), href: route('/clients/:id/quotes', { id }) },
+    {
+      name: t('payments'),
+      href: route('/clients/:id/payments', { id }),
+    },
+    {
+      name: t('recurring_invoices'),
+      href: route('/clients/:id/recurring_invoices', { id }),
+    },
+    {
+      name: t('credits'),
+      href: route('/clients/:id/credits', { id }),
+    },
+    {
+      name: t('projects'),
+      href: route('/clients/:id/projects', { id }),
+    },
+    {
+      name: t('tasks'),
+      href: route('/clients/:id/tasks', { id }),
+    },
+    {
+      name: t('expenses'),
+      href: route('/clients/:id/expenses', { id }),
+    },
+    {
+      name: t('recurring_expenses'),
+      href: route('/clients/:id/recurring_expenses', { id }),
+    },
+  ];
+
+  if (!enabled(ModuleBitmask.Quotes)) {
+    tabs = tabs.filter((tab) => tab.name !== t('quotes'));
+  }
+
+  return tabs;
+}

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -22,6 +22,8 @@ import { useTranslation } from 'react-i18next';
 import { Default } from '../../components/layouts/Default';
 import { ExpiredQuotes } from './components/ExpiredQuotes';
 import { UpcomingQuotes } from './components/UpcomingQuotes';
+import { useEnabled } from '$app/common/guards/guards/enabled';
+import { ModuleBitmask } from '../settings';
 
 export default function Dashboard() {
   useTitle('dashboard');
@@ -30,6 +32,8 @@ export default function Dashboard() {
   const user = useCurrentUser();
 
   const { isAdmin } = useAdmin();
+
+  const enabled = useEnabled();
 
   return (
     <Default
@@ -62,13 +66,17 @@ export default function Dashboard() {
           <PastDueInvoices />
         </div>
 
-        <div className="col-span-12 xl:col-span-6">
-          <ExpiredQuotes />
-        </div>
+        {enabled(ModuleBitmask.Quotes) && (
+          <div className="col-span-12 xl:col-span-6">
+            <ExpiredQuotes />
+          </div>
+        )}
 
-        <div className="col-span-12 xl:col-span-6">
-          <UpcomingQuotes />
-        </div>
+        {enabled(ModuleBitmask.Quotes) && (
+          <div className="col-span-12 xl:col-span-6">
+            <UpcomingQuotes />
+          </div>
+        )}
       </div>
     </Default>
   );


### PR DESCRIPTION
@beganovich @turbo124 The PR includes handling `Quotes` tables on the `Dashboard` and handling the Quotes tab on the Client overview page. So, if the Quote module is enabled, it will be shown, if not, it will not be shown. Let me know your thoughts.