### PR TITLE
Bring the rate with a project

### DIFF
--- a/src/pages/tasks/common/components/TaskDetails.tsx
+++ b/src/pages/tasks/common/components/TaskDetails.tsx
@@ -58,7 +58,7 @@ export function TaskDetails(props: Props) {
                   handleChange(
                     'rate',
                     client?.settings?.default_task_rate ?? 0
-                  )
+                  );
                 }
               }}
               value={task.client_id}
@@ -73,6 +73,7 @@ export function TaskDetails(props: Props) {
             onChange={(project) => {
               handleChange('project_id', project.id);
               handleChange('client_id', '');
+              handleChange('rate', project.task_rate);
             }}
             value={task.project_id}
             clearButton={Boolean(task.project_id)}


### PR DESCRIPTION
The task rate will now be populated in two ways:
1. When we're on the project page and click "New task", the project/rate will auto-fill.
2. When we create a new task, after changing the project task rate will auto-fill.