### PR TITLE
[Bugfix] Quote Linked Invoice Additional Condition & Handling 404 Error On Entier App

### DIFF
--- a/src/common/helpers/request.ts
+++ b/src/common/helpers/request.ts
@@ -22,6 +22,10 @@ client.interceptors.response.use(
       window.location.reload();
     }
 
+    if (error.response?.status === 404) {
+      window.location.href = '/#/not_found';
+    }
+
     return Promise.reject(error);
   }
 );

--- a/src/pages/quotes/common/hooks.tsx
+++ b/src/pages/quotes/common/hooks.tsx
@@ -633,7 +633,7 @@ export function useQuoteColumns() {
         <div className="flex items-center space-x-2">
           <QuoteStatusBadge entity={quote} />
 
-          {quote.status_id === QuoteStatus.Converted && (
+          {quote.status_id === QuoteStatus.Converted && quote.invoice_id && (
             <MdTextSnippet
               className="cursor-pointer"
               fontSize={19}


### PR DESCRIPTION
@beganovich @turbo124 David experienced receiving a 404 error when clicking the small icon located to the right of the status badge of the `Quote`. This icon is supposed to navigate to the edit page of the linked `Invoice`, but instead, it resulted in a 404 error and a blank page. 

In light of this issue, we are considering handling the 404 error by redirecting to the 404 page that we have already created. Additionally, I have included an additional condition for displaying this small icon. In addition to checking `quote.status_id === QuoteStatus.Converted`, I have also added a check to see if `invoice_id` exists. If it does, the icon will be shown. I hope that these additional checks will prevent any instances of having a broken page.

`Important note`: The navigation to the "not_found" (404) page after encountering a 404 error from the API will be applied throughout the entire app. This means that whenever we encounter a 404 error from the API, the user will be automatically redirected to the 404 page.

Let me know your thoughts.