### PR TITLE
Fixes for credits not populating

### DIFF
--- a/src/pages/payments/create/Create.tsx
+++ b/src/pages/payments/create/Create.tsx
@@ -356,7 +356,7 @@ export default function Create() {
                       entryOptions={{
                         id: 'id',
                         label: 'number',
-                        value: 'id`',
+                        value: 'id',
                       }}
                       onChange={(entry) =>
                         entry.resource


### PR DESCRIPTION
This fixes an issue with credits not populating on payments create page.