### PR TITLE
[Cleanup] Applying Enable Modules Across The App Same As We Did For Quotes

### DIFF
--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -10,8 +10,14 @@
 
 import { route } from '$app/common/helpers/route';
 import { useAccentColor } from '$app/common/hooks/useAccentColor';
-import { MouseEvent, useRef } from 'react';
-import { Link, Params, useLocation, useParams } from 'react-router-dom';
+import { MouseEvent, useEffect, useRef } from 'react';
+import {
+  Link,
+  Params,
+  useLocation,
+  useNavigate,
+  useParams,
+} from 'react-router-dom';
 
 interface Props {
   className?: string;
@@ -25,6 +31,8 @@ export function Tabs(props: Props) {
   const accentColor = useAccentColor();
   const location = useLocation();
   const params = useParams();
+
+  const navigate = useNavigate();
 
   const isActive = (tab: Tab) => {
     return (
@@ -50,6 +58,18 @@ export function Tabs(props: Props) {
       left: clickedTab!.offsetLeft - scrollWidth - scrollBy,
     });
   };
+
+  useEffect(() => {
+    if (props.tabs.length) {
+      const doesDefaultUrlExist = props.tabs.some(
+        ({ href }) => href === location.pathname
+      );
+
+      if (!doesDefaultUrlExist) {
+        navigate(props.tabs[0].href);
+      }
+    }
+  }, []);
 
   return (
     <div className={props.className}>

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -58,13 +58,17 @@ export default function Dashboard() {
           <RecentPayments />
         </div>
 
-        <div className="col-span-12 xl:col-span-6">
-          <UpcomingInvoices />
-        </div>
+        {enabled(ModuleBitmask.Invoices) && (
+          <div className="col-span-12 xl:col-span-6">
+            <UpcomingInvoices />
+          </div>
+        )}
 
-        <div className="col-span-12 xl:col-span-6">
-          <PastDueInvoices />
-        </div>
+        {enabled(ModuleBitmask.Invoices) && (
+          <div className="col-span-12 xl:col-span-6">
+            <PastDueInvoices />
+          </div>
+        )}
 
         {enabled(ModuleBitmask.Quotes) && (
           <div className="col-span-12 xl:col-span-6">

--- a/src/pages/projects/show/Show.tsx
+++ b/src/pages/projects/show/Show.tsx
@@ -42,6 +42,8 @@ import { DataTableColumnsPicker } from '$app/components/DataTableColumnsPicker';
 import { permission } from '$app/common/guards/guards/permission';
 import { Task } from '$app/common/interfaces/task';
 import { useShowEditOption } from '$app/pages/tasks/common/hooks/useShowEditOption';
+import { useEnabled } from '$app/common/guards/guards/enabled';
+import { ModuleBitmask } from '$app/pages/settings';
 
 dayjs.extend(duration);
 
@@ -50,6 +52,8 @@ export default function Show() {
   const { t } = useTranslation();
   const { id } = useParams();
   const { dateFormat } = useCurrentCompanyDateFormats();
+
+  const enabled = useEnabled();
 
   const pages: Page[] = [
     { name: t('projects'), href: '/projects' },
@@ -154,32 +158,34 @@ export default function Show() {
         </InfoCard>
       </div>
 
-      <div className="my-4">
-        <DataTable
-          resource="task"
-          columns={columns}
-          customActions={taskActions}
-          endpoint={`/api/v1/tasks?include=status,client,project&sort=id|desc&project_tasks=${project.id}`}
-          bulkRoute="/api/v1/tasks/bulk"
-          linkToCreate={`/tasks/create?project=${id}&rate=${project.task_rate}`}
-          linkToEdit="/tasks/:id/edit"
-          showEdit={(task: Task) => showEditOption(task)}
-          customFilters={filters}
-          customBulkActions={customBulkActions}
-          customFilterQueryKey="client_status"
-          customFilterPlaceholder="status"
-          withResourcefulActions
-          leftSideChevrons={
-            <DataTableColumnsPicker
-              columns={taskColumns as unknown as string[]}
-              defaultColumns={defaultColumns}
-              table="task"
-            />
-          }
-          linkToCreateGuards={[permission('create_task')]}
-          includeObjectSelection
-        />
-      </div>
+      {enabled(ModuleBitmask.Tasks) && (
+        <div className="my-4">
+          <DataTable
+            resource="task"
+            columns={columns}
+            customActions={taskActions}
+            endpoint={`/api/v1/tasks?include=status,client,project&sort=id|desc&project_tasks=${project.id}`}
+            bulkRoute="/api/v1/tasks/bulk"
+            linkToCreate={`/tasks/create?project=${id}&rate=${project.task_rate}`}
+            linkToEdit="/tasks/:id/edit"
+            showEdit={(task: Task) => showEditOption(task)}
+            customFilters={filters}
+            customBulkActions={customBulkActions}
+            customFilterQueryKey="client_status"
+            customFilterPlaceholder="status"
+            withResourcefulActions
+            leftSideChevrons={
+              <DataTableColumnsPicker
+                columns={taskColumns as unknown as string[]}
+                defaultColumns={defaultColumns}
+                table="task"
+              />
+            }
+            linkToCreateGuards={[permission('create_task')]}
+            includeObjectSelection
+          />
+        </div>
+      )}
     </Default>
   );
 }

--- a/src/pages/settings/account-management/component/EnabledModules.tsx
+++ b/src/pages/settings/account-management/component/EnabledModules.tsx
@@ -34,37 +34,37 @@ export enum ModuleBitmask {
   Transactions = 32768,
 }
 
+export const modules: Module[] = [
+  { label: 'invoices', bitmask: ModuleBitmask.Invoices },
+  {
+    label: 'recurring_invoices',
+    bitmask: ModuleBitmask.RecurringInvoices,
+  },
+  { label: 'quotes', bitmask: ModuleBitmask.Quotes },
+  { label: 'credits', bitmask: ModuleBitmask.Credits },
+  { label: 'projects', bitmask: ModuleBitmask.Projects },
+  { label: 'tasks', bitmask: ModuleBitmask.Tasks },
+  { label: 'vendors', bitmask: ModuleBitmask.Vendors },
+  { label: 'expenses', bitmask: ModuleBitmask.Expenses },
+  { label: 'purchase_orders', bitmask: ModuleBitmask.PurchaseOrders },
+  {
+    label: 'recurring_expenses',
+    bitmask: ModuleBitmask.RecurringExpenses,
+  },
+  { label: 'transactions', bitmask: ModuleBitmask.Transactions },
+
+  // { label: t('tickets'), bitmask: 128 },
+  // { label: t('proposals'), bitmask: 256 },
+  // { label: t('recurring_tasks'), bitmask: 1024 },
+  // { label: t('recurring_quotes'), bitmask: 2048 },
+  // { label: t('proformal_invoices'), bitmask: 8192 },
+  // { label: t('purchase_orders'), bitmask: 16384 },
+];
+
 export function EnabledModules() {
   const [t] = useTranslation();
   const companyChanges = useCompanyChanges();
   const dispatch = useDispatch();
-
-  const modules: Module[] = [
-    { label: t('invoices'), bitmask: ModuleBitmask.Invoices },
-    {
-      label: t('recurring_invoices'),
-      bitmask: ModuleBitmask.RecurringInvoices,
-    },
-    { label: t('quotes'), bitmask: ModuleBitmask.Quotes },
-    { label: t('credits'), bitmask: ModuleBitmask.Credits },
-    { label: t('projects'), bitmask: ModuleBitmask.Projects },
-    { label: t('tasks'), bitmask: ModuleBitmask.Tasks },
-    { label: t('vendors'), bitmask: ModuleBitmask.Vendors },
-    { label: t('expenses'), bitmask: ModuleBitmask.Expenses },
-    { label: t('purchase_orders'), bitmask: ModuleBitmask.PurchaseOrders },
-    {
-      label: t('recurring_expenses'),
-      bitmask: ModuleBitmask.RecurringExpenses,
-    },
-    { label: t('transactions'), bitmask: ModuleBitmask.Transactions },
-
-    // { label: t('tickets'), bitmask: 128 },
-    // { label: t('proposals'), bitmask: 256 },
-    // { label: t('recurring_tasks'), bitmask: 1024 },
-    // { label: t('recurring_quotes'), bitmask: 2048 },
-    // { label: t('proformal_invoices'), bitmask: 8192 },
-    // { label: t('purchase_orders'), bitmask: 16384 },
-  ];
 
   const handleToggleChange = (value: boolean, bitmask: number) =>
     dispatch(
@@ -78,7 +78,7 @@ export function EnabledModules() {
   return (
     <Card title={t('enabled_modules')}>
       {modules.map((module, index) => (
-        <Element key={index} leftSide={module.label}>
+        <Element key={index} leftSide={t(module.label)}>
           <Toggle
             checked={Boolean(companyChanges?.enabled_modules & module.bitmask)}
             key={module.label}

--- a/src/pages/vendors/Vendor.tsx
+++ b/src/pages/vendors/Vendor.tsx
@@ -17,13 +17,14 @@ import { useVendorQuery } from '$app/common/queries/vendor';
 import { Page } from '$app/components/Breadcrumbs';
 import { InfoCard } from '$app/components/InfoCard';
 import { Default } from '$app/components/layouts/Default';
-import { Tab, Tabs } from '$app/components/Tabs';
+import { Tabs } from '$app/components/Tabs';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Outlet, useParams } from 'react-router-dom';
 import { ResourceActions } from '$app/components/ResourceActions';
 import { useActions } from './common/hooks/useActions';
 import { Inline } from '$app/components/Inline';
+import { useTabs } from './show/hooks/useTabs';
 
 export default function Vendor() {
   const { documentTitle, setDocumentTitle } = useTitle('view_vendor');
@@ -48,24 +49,7 @@ export default function Vendor() {
     { name: documentTitle || '', href: route('/vendors/:id', { id }) },
   ];
 
-  const tabs: Tab[] = [
-    {
-      name: t('purchase_orders'),
-      href: route('/vendors/:id', { id }),
-    },
-    {
-      name: t('expenses'),
-      href: route('/vendors/:id/expenses', { id }),
-    },
-    {
-      name: t('recurring_expenses'),
-      href: route('/vendors/:id/recurring_expenses', { id }),
-    },
-    {
-      name: t('documents'),
-      href: route('/vendors/:id/documents', { id }),
-    },
-  ];
+  const tabs = useTabs();
 
   return (
     <Default

--- a/src/pages/vendors/show/hooks/useTabs.tsx
+++ b/src/pages/vendors/show/hooks/useTabs.tsx
@@ -22,35 +22,21 @@ export function useTabs() {
   const { id } = useParams();
 
   let tabs: Tab[] = [
-    { name: t('invoices'), href: route('/clients/:id', { id }) },
-    { name: t('quotes'), href: route('/clients/:id/quotes', { id }) },
     {
-      name: t('payments'),
-      href: route('/clients/:id/payments', { id }),
-    },
-    {
-      name: t('recurring_invoices'),
-      href: route('/clients/:id/recurring_invoices', { id }),
-    },
-    {
-      name: t('credits'),
-      href: route('/clients/:id/credits', { id }),
-    },
-    {
-      name: t('projects'),
-      href: route('/clients/:id/projects', { id }),
-    },
-    {
-      name: t('tasks'),
-      href: route('/clients/:id/tasks', { id }),
+      name: t('purchase_orders'),
+      href: route('/vendors/:id', { id }),
     },
     {
       name: t('expenses'),
-      href: route('/clients/:id/expenses', { id }),
+      href: route('/vendors/:id/expenses', { id }),
     },
     {
       name: t('recurring_expenses'),
-      href: route('/clients/:id/recurring_expenses', { id }),
+      href: route('/vendors/:id/recurring_expenses', { id }),
+    },
+    {
+      name: t('documents'),
+      href: route('/vendors/:id/documents', { id }),
     },
   ];
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes implementation `enable_modules` across the app. This affects the `Client show page (tabs)`, `Dashboard page (tables)`, `Project show page for the Tasks table`, and `Vendor show page (tabs)`. If a module is disabled, the corresponding table/tab will not be shown on the mentioned pages. 

I think that this PR cover all pages where we need implementation of enabling modules, but let me know if there are some additional. Since the implementation for enabling modules is already present in the main left sidebar, no additional changes are required there. 

Let me know your thoughts.