### PR TITLE
[Feature] Auto Billing Invoices Functionality

### DIFF
--- a/src/pages/invoices/common/hooks/useCustomBulkActions.tsx
+++ b/src/pages/invoices/common/hooks/useCustomBulkActions.tsx
@@ -16,6 +16,9 @@ import { useTranslation } from 'react-i18next';
 import { MdDownload, MdPrint } from 'react-icons/md';
 import { usePrintPdf } from './usePrintPdf';
 import { useDownloadPdfs } from './useDownloadPdfs';
+import { BiMoney } from 'react-icons/bi';
+import { useBulk } from '$app/common/queries/invoices';
+import { InvoiceStatus } from '$app/common/enums/invoice-status';
 
 export const useCustomBulkActions = () => {
   const [t] = useTranslation();
@@ -23,23 +26,51 @@ export const useCustomBulkActions = () => {
   const printPdf = usePrintPdf({ entity: 'invoice' });
   const downloadPdfs = useDownloadPdfs({ entity: 'invoice' });
 
+  const bulk = useBulk();
+
+  const isInvoiceAutoBillable = (invoice: Invoice) => {
+    return (
+      invoice.balance > 0 &&
+      (invoice.status_id === InvoiceStatus.Sent ||
+        invoice.status_id === InvoiceStatus.Partial) &&
+      Boolean(invoice.client?.gateway_tokens.length)
+    );
+  };
+
+  const showAutoBillAction = (invoices: Invoice[]) => {
+    return (
+      invoices.some((invoice) => isInvoiceAutoBillable(invoice)) ||
+      !invoices.length
+    );
+  };
+
   const customBulkActions: CustomBulkAction<Invoice>[] = [
     (selectedIds) => (
-      <>
       <DropdownElement
         onClick={() => printPdf(selectedIds)}
         icon={<Icon element={MdPrint} />}
       >
         {t('print_pdf')}
       </DropdownElement>
+    ),
+    (selectedIds) => (
       <DropdownElement
         onClick={() => downloadPdfs(selectedIds)}
-          icon={<Icon element={MdDownload} />}
+        icon={<Icon element={MdDownload} />}
       >
         {t('download_pdf')}
       </DropdownElement>
-      </>
     ),
+    (selectedIds, selectedInvoices) =>
+      selectedInvoices &&
+      showAutoBillAction(selectedInvoices) && (
+        <DropdownElement
+          onClick={() => bulk(selectedIds, 'auto_bill')}
+          icon={<Icon element={BiMoney} />}
+        >
+          {t('auto_bill')}
+        </DropdownElement>
+      ),
   ];
 
   return customBulkActions;

--- a/src/pages/invoices/edit/components/Actions.tsx
+++ b/src/pages/invoices/edit/components/Actions.tsx
@@ -58,6 +58,15 @@ import dayjs from 'dayjs';
 import { useEntityPageIdentifier } from '$app/common/hooks/useEntityPageIdentifier';
 import { useBulk } from '$app/common/queries/invoices';
 
+export const isInvoiceAutoBillable = (invoice: Invoice) => {
+  return (
+    invoice.balance > 0 &&
+    (invoice.status_id === InvoiceStatus.Sent ||
+      invoice.status_id === InvoiceStatus.Partial) &&
+    Boolean(invoice.client?.gateway_tokens.length)
+  );
+};
+
 export function useActions() {
   const { t } = useTranslation();
 
@@ -82,15 +91,6 @@ export function useActions() {
   const [, setCredit] = useAtom(creditAtom);
   const [, setRecurringInvoice] = useAtom(recurringInvoiceAtom);
   const [, setPurchaseOrder] = useAtom(purchaseOrderAtom);
-
-  const showAutoBillAction = (invoice: Invoice) => {
-    return (
-      invoice.balance > 0 &&
-      (invoice.status_id === InvoiceStatus.Sent ||
-        invoice.status_id === InvoiceStatus.Partial) &&
-      Boolean(invoice.client?.gateway_tokens.length)
-    );
-  };
 
   const cloneToInvoice = (invoice: Invoice) => {
     setInvoice({
@@ -262,7 +262,7 @@ export function useActions() {
         </DropdownElement>
       ),
     (invoice: Invoice) =>
-      showAutoBillAction(invoice) && (
+      isInvoiceAutoBillable(invoice) && (
         <DropdownElement
           onClick={() => bulk([invoice.id], 'auto_bill')}
           icon={<Icon element={BiMoney} />}

--- a/src/pages/invoices/edit/components/Actions.tsx
+++ b/src/pages/invoices/edit/components/Actions.tsx
@@ -27,7 +27,7 @@ import { purchaseOrderAtom } from '$app/pages/purchase-orders/common/atoms';
 import { quoteAtom } from '$app/pages/quotes/common/atoms';
 import { recurringInvoiceAtom } from '$app/pages/recurring-invoices/common/atoms';
 import { useTranslation } from 'react-i18next';
-import { BiPlusCircle } from 'react-icons/bi';
+import { BiMoney, BiPlusCircle } from 'react-icons/bi';
 import {
   MdArchive,
   MdCancel,
@@ -56,6 +56,7 @@ import { getEntityState } from '$app/common/helpers';
 import { EntityState } from '$app/common/enums/entity-state';
 import dayjs from 'dayjs';
 import { useEntityPageIdentifier } from '$app/common/hooks/useEntityPageIdentifier';
+import { useBulk } from '$app/common/queries/invoices';
 
 export function useActions() {
   const { t } = useTranslation();
@@ -66,6 +67,8 @@ export function useActions() {
   const markSent = useMarkSent();
   const markPaid = useMarkPaid();
   const scheduleEmailRecord = useScheduleEmailRecord({ entity: 'invoice' });
+
+  const bulk = useBulk();
 
   const { isEditPage } = useEntityPageIdentifier({ entity: 'invoice' });
 
@@ -79,6 +82,15 @@ export function useActions() {
   const [, setCredit] = useAtom(creditAtom);
   const [, setRecurringInvoice] = useAtom(recurringInvoiceAtom);
   const [, setPurchaseOrder] = useAtom(purchaseOrderAtom);
+
+  const showAutoBillAction = (invoice: Invoice) => {
+    return (
+      invoice.balance > 0 &&
+      (invoice.status_id === InvoiceStatus.Sent ||
+        invoice.status_id === InvoiceStatus.Partial) &&
+      Boolean(invoice.client?.gateway_tokens.length)
+    );
+  };
 
   const cloneToInvoice = (invoice: Invoice) => {
     setInvoice({
@@ -247,6 +259,15 @@ export function useActions() {
           icon={<Icon element={MdPaid} />}
         >
           {t('mark_paid')}
+        </DropdownElement>
+      ),
+    (invoice: Invoice) =>
+      showAutoBillAction(invoice) && (
+        <DropdownElement
+          onClick={() => bulk([invoice.id], 'auto_bill')}
+          icon={<Icon element={BiMoney} />}
+        >
+          {t('auto_bill')}
         </DropdownElement>
       ),
     (invoice: Invoice) =>

--- a/src/pages/invoices/index/Invoices.tsx
+++ b/src/pages/invoices/index/Invoices.tsx
@@ -80,6 +80,7 @@ export default function Invoices() {
           />
         }
         linkToCreateGuards={[permission('create_invoice')]}
+        includeObjectSelection
       />
     </Default>
   );


### PR DESCRIPTION
@beganovich @turbo124 The PR includes implementation of `auto_billing` functionality for Invoices. The `auto_bill` option will be shown if three requirements are passed:

- The `balance` of invoice must be > 0
- The Invoice must be in one of two statuses `Send` | `Partial` (2,3)
- The Invoice's Client must have at least one "gateway_token" in the array of `gateway_tokens`

To display the bulk action in the dropdown, we can have two situations, if no invoices are selected, the option will be shown or if only one of the selected invoices passes those three checks, the action will also be shown in the dropdown.

`Important note`: Only the `invoice_ids` that are eligible for auto-billing will be included in the payload. Others will be excluded, even if they are selected during the bulk action.

Screenshots:

![Screenshot 2023-07-13 at 19 41 22](https://github.com/invoiceninja/ui/assets/51542191/6f8f0d5f-c61f-4bef-a6cc-bb14868e3d33)

![Screenshot 2023-07-13 at 19 40 48](https://github.com/invoiceninja/ui/assets/51542191/04cb9e81-3739-4a4b-a919-75203fb1c70e)

Let me know your thoughts.