### PR TITLE
[Bugfix] Navigation Links For Quotes Tables On Dashboard

### DIFF
--- a/src/pages/dashboard/components/ExpiredQuotes.tsx
+++ b/src/pages/dashboard/components/ExpiredQuotes.tsx
@@ -28,13 +28,11 @@ export function ExpiredQuotes() {
     {
       id: 'number',
       label: t('number'),
-      format: (value, quote) => {
-        return (
-          <Link to={route('/invoices/:id/edit', { id: quote.id })}>
-            {quote.number}
-          </Link>
-        );
-      },
+      format: (value, quote) => (
+        <Link to={route('/quotes/:id/edit', { id: quote.id })}>
+          {quote.number}
+        </Link>
+      ),
     },
     {
       id: 'client_id',

--- a/src/pages/dashboard/components/UpcomingQuotes.tsx
+++ b/src/pages/dashboard/components/UpcomingQuotes.tsx
@@ -28,13 +28,11 @@ export function UpcomingQuotes() {
     {
       id: 'number',
       label: t('number'),
-      format: (value, quote) => {
-        return (
-          <Link to={route('/invoices/:id/edit', { id: quote.id })}>
-            {quote.number}
-          </Link>
-        );
-      },
+      format: (value, quote) => (
+        <Link to={route('/quotes/:id/edit', { id: quote.id })}>
+          {quote.number}
+        </Link>
+      ),
     },
     {
       id: 'client_id',


### PR DESCRIPTION
@beganovich @turbo124 The PR includes bug fixes for incorrect navigation when a user clicks on the `number` link in the `number column` on the Quotes tables on the Dashboard. Previously, it would navigate to the `invoices edit page` instead of the quotes edit page. Now, this has been corrected, and it navigates to the quotes edit page as intended. Let me know your thoughts.