### PR TITLE
[Cleanup] Populating Company Object When Signup | Showing Company Setup Wizard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@
 
 import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { useResolveLanguage } from '$app/common/hooks/useResolveLanguage';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Toaster } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
@@ -19,13 +19,12 @@ import { RootState } from './common/stores/store';
 import dayjs from 'dayjs';
 import { useResolveDayJSLocale } from './common/hooks/useResolveDayJSLocale';
 import { useResolveAntdLocale } from './common/hooks/useResolveAntdLocale';
-import { useAtom, useSetAtom } from 'jotai';
+import { useSetAtom } from 'jotai';
 import { useNavigate } from 'react-router-dom';
 import { dayJSLocaleAtom } from './components/forms';
 import { antdLocaleAtom } from './components/DropdownDateRangePicker';
 import { CompanyEdit } from './pages/settings/company/edit/CompanyEdit';
 import { useAdmin } from './common/hooks/permissions/useHasPermission';
-import { companyEditModalOpenedAtom } from './components/CompanySwitcher';
 
 export function App() {
   const [t] = useTranslation();
@@ -48,9 +47,8 @@ export function App() {
 
   const darkMode = useSelector((state: RootState) => state.settings.darkMode);
 
-  const [isCompanyEditModalOpened, setIsCompanyEditModalOpened] = useAtom(
-    companyEditModalOpenedAtom
-  );
+  const [isCompanyEditModalOpened, setIsCompanyEditModalOpened] =
+    useState(false);
 
   const resolvedLanguage = company
     ? resolveLanguage(company.settings.language_id)
@@ -102,9 +100,10 @@ export function App() {
 
     if (
       company &&
-      (companyName.includes(t('untitled')) || !companyName) &&
-      !isCompanyEditModalOpened
+      (!companyName || companyName === t('untitled_company')) &&
+      localStorage.getItem('COMPANY-EDIT-OPENED') !== 'true'
     ) {
+      localStorage.setItem('COMPANY-EDIT-OPENED', 'true');
       setIsCompanyEditModalOpened(true);
     }
   }, [company]);

--- a/src/components/CompanySwitcher.tsx
+++ b/src/components/CompanySwitcher.tsx
@@ -29,7 +29,7 @@ import { freePlan } from '$app/common/guards/guards/free-plan';
 import { Icon } from './icons/Icon';
 import { MdLogout, MdManageAccounts } from 'react-icons/md';
 import { BiPlusCircle } from 'react-icons/bi';
-import { atom, useSetAtom } from 'jotai';
+import { atom } from 'jotai';
 
 export const companyEditModalOpenedAtom = atom<boolean>(false);
 
@@ -58,8 +58,6 @@ export function CompanySwitcher() {
   const [isCompanyCreateModalOpened, setIsCompanyCreateModalOpened] =
     useState<boolean>(false);
 
-  const setIsCompanyEditModalOpened = useSetAtom(companyEditModalOpenedAtom);
-
   const switchCompany = (index: number) => {
     dispatch(
       authenticate({
@@ -70,8 +68,6 @@ export function CompanySwitcher() {
     );
 
     localStorage.setItem('X-CURRENT-INDEX', index.toString());
-
-    setIsCompanyEditModalOpened(false);
 
     sessionStorage.setItem('COMPANY-ACTIVITY-SHOWN', 'false');
 

--- a/src/components/CompanySwitcher.tsx
+++ b/src/components/CompanySwitcher.tsx
@@ -29,9 +29,6 @@ import { freePlan } from '$app/common/guards/guards/free-plan';
 import { Icon } from './icons/Icon';
 import { MdLogout, MdManageAccounts } from 'react-icons/md';
 import { BiPlusCircle } from 'react-icons/bi';
-import { atom } from 'jotai';
-
-export const companyEditModalOpenedAtom = atom<boolean>(false);
 
 export function CompanySwitcher() {
   const [t] = useTranslation();
@@ -68,6 +65,8 @@ export function CompanySwitcher() {
     );
 
     localStorage.setItem('X-CURRENT-INDEX', index.toString());
+
+    localStorage.setItem('COMPANY-EDIT-OPENED', 'false');
 
     sessionStorage.setItem('COMPANY-ACTIVITY-SHOWN', 'false');
 

--- a/src/components/CompanySwitcher.tsx
+++ b/src/components/CompanySwitcher.tsx
@@ -23,14 +23,15 @@ import { DropdownElement } from './dropdown/DropdownElement';
 import { useLogo } from '$app/common/hooks/useLogo';
 import { useCompanyName } from '$app/common/hooks/useLogo';
 import { CompanyCreate } from '$app/pages/settings/company/create/CompanyCreate';
-import { CompanyEdit } from '$app/pages/settings/company/edit/CompanyEdit';
 import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { isDemo, isHosted, isSelfHosted } from '$app/common/helpers';
 import { freePlan } from '$app/common/guards/guards/free-plan';
 import { Icon } from './icons/Icon';
 import { MdLogout, MdManageAccounts } from 'react-icons/md';
 import { BiPlusCircle } from 'react-icons/bi';
-import { useAdmin } from '$app/common/hooks/permissions/useHasPermission';
+import { atom, useSetAtom } from 'jotai';
+
+export const companyEditModalOpenedAtom = atom<boolean>(false);
 
 export function CompanySwitcher() {
   const [t] = useTranslation();
@@ -57,8 +58,7 @@ export function CompanySwitcher() {
   const [isCompanyCreateModalOpened, setIsCompanyCreateModalOpened] =
     useState<boolean>(false);
 
-  const [isCompanyEditModalOpened, setIsCompanyEditModalOpened] =
-    useState<boolean>(false);
+  const setIsCompanyEditModalOpened = useSetAtom(companyEditModalOpenedAtom);
 
   const switchCompany = (index: number) => {
     dispatch(
@@ -71,7 +71,7 @@ export function CompanySwitcher() {
 
     localStorage.setItem('X-CURRENT-INDEX', index.toString());
 
-    localStorage.setItem('COMPANY-EDIT-OPENED', 'false');
+    setIsCompanyEditModalOpened(false);
 
     sessionStorage.setItem('COMPANY-ACTIVITY-SHOWN', 'false');
 
@@ -90,32 +90,12 @@ export function CompanySwitcher() {
     }
   }, [currentCompany]);
 
-  useEffect(() => {
-    if (
-      currentCompany &&
-      currentCompany?.settings?.name.includes(t('untitled')) &&
-      localStorage.getItem('COMPANY-EDIT-OPENED') !== 'true'
-    ) {
-      localStorage.setItem('COMPANY-EDIT-OPENED', 'true');
-      setIsCompanyEditModalOpened(true);
-    }
-  }, []);
-
-  const { isOwner } = useAdmin();
-
   return (
     <>
       <CompanyCreate
         isModalOpen={isCompanyCreateModalOpened}
         setIsModalOpen={setIsCompanyCreateModalOpened}
       />
-
-      {isOwner && (
-        <CompanyEdit
-          isModalOpen={isCompanyEditModalOpened}
-          setIsModalOpen={setIsCompanyEditModalOpened}
-        />
-      )}
 
       <Menu as="div" className="relative inline-block text-left w-full">
         <Menu.Button className="flex items-center justify-between w-full rounded font-medium pl-2">

--- a/src/pages/authentication/Register.tsx
+++ b/src/pages/authentication/Register.tsx
@@ -26,6 +26,10 @@ import { Link } from '../../components/forms/Link';
 import { request } from '$app/common/helpers/request';
 import { SignInProviders } from './components/SignInProviders';
 import { GenericValidationBag } from '$app/common/interfaces/validation-bag';
+import {
+  changeCurrentIndex,
+  updateCompanyUsers,
+} from '$app/common/stores/slices/company-users';
 
 export function Register() {
   const [t] = useTranslation();
@@ -67,7 +71,7 @@ export function Register() {
 
       request(
         'POST',
-        endpoint('/api/v1/signup?include=token,user,company'),
+        endpoint('/api/v1/signup?include=token,user,company,account'),
         values
       )
         .then((response: AxiosResponse) => {
@@ -77,6 +81,9 @@ export function Register() {
               user: response.data.data[0].user,
             })
           );
+
+          dispatch(updateCompanyUsers(response.data.data));
+          dispatch(changeCurrentIndex(0));
         })
         .catch(
           (error: AxiosError<GenericValidationBag<RegisterValidation>>) => {

--- a/src/pages/authentication/Register.tsx
+++ b/src/pages/authentication/Register.tsx
@@ -65,7 +65,11 @@ export function Register() {
         return;
       }
 
-      request('POST', endpoint('/api/v1/signup?include=token,user'), values)
+      request(
+        'POST',
+        endpoint('/api/v1/signup?include=token,user,company'),
+        values
+      )
         .then((response: AxiosResponse) => {
           dispatch(
             register({

--- a/src/pages/authentication/Register.tsx
+++ b/src/pages/authentication/Register.tsx
@@ -91,8 +91,8 @@ export function Register() {
               setErrors(error.response.data.errors);
             }
 
-            setIsFormBusy(false);
             setMessage(error.response?.data.message as string);
+            setIsFormBusy(false);
           }
         );
     },

--- a/src/pages/authentication/Register.tsx
+++ b/src/pages/authentication/Register.tsx
@@ -71,7 +71,9 @@ export function Register() {
 
       request(
         'POST',
-        endpoint('/api/v1/signup?include=token,user,company,account'),
+        endpoint(
+          '/api/v1/signup?include=token,user.company_user,company,account'
+        ),
         values
       )
         .then((response: AxiosResponse) => {

--- a/src/pages/authentication/Register.tsx
+++ b/src/pages/authentication/Register.tsx
@@ -91,8 +91,8 @@ export function Register() {
               setErrors(error.response.data.errors);
             }
 
-            setMessage(error.response?.data.message as string);
             setIsFormBusy(false);
+            setMessage(error.response?.data.message as string);
           }
         );
     },

--- a/src/pages/settings/company/create/CompanyCreate.tsx
+++ b/src/pages/settings/company/create/CompanyCreate.tsx
@@ -88,7 +88,10 @@ export function CompanyCreate(props: Props) {
             .catch((error: AxiosError) => {
               console.error(error);
               toast.error();
-            });
+            })
+            .finally(() =>
+              localStorage.setItem('COMPANY-EDIT-OPENED', 'false')
+            );
         })
         .catch((error: AxiosError) => {
           console.error(error);

--- a/src/pages/settings/company/create/CompanyCreate.tsx
+++ b/src/pages/settings/company/create/CompanyCreate.tsx
@@ -22,8 +22,6 @@ import { useState, SetStateAction, Dispatch } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from 'react-query';
 import { useDispatch } from 'react-redux';
-import { useSetAtom } from 'jotai';
-import { companyEditModalOpenedAtom } from '$app/components/CompanySwitcher';
 
 interface Props {
   isModalOpen: boolean;
@@ -39,8 +37,6 @@ export function CompanyCreate(props: Props) {
 
   const [isFormBusy, setIsFormBusy] = useState<boolean>(false);
 
-  const setIsCompanyEditModalOpened = useSetAtom(companyEditModalOpenedAtom);
-
   const switchCompany = (
     index: number,
     passedUser: Record<string, unknown>,
@@ -55,8 +51,6 @@ export function CompanyCreate(props: Props) {
     );
 
     localStorage.setItem('X-CURRENT-INDEX', index.toString());
-
-    setIsCompanyEditModalOpened(false);
 
     queryClient.invalidateQueries();
 

--- a/src/pages/settings/company/create/CompanyCreate.tsx
+++ b/src/pages/settings/company/create/CompanyCreate.tsx
@@ -22,6 +22,8 @@ import { useState, SetStateAction, Dispatch } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from 'react-query';
 import { useDispatch } from 'react-redux';
+import { useSetAtom } from 'jotai';
+import { companyEditModalOpenedAtom } from '$app/components/CompanySwitcher';
 
 interface Props {
   isModalOpen: boolean;
@@ -36,6 +38,8 @@ export function CompanyCreate(props: Props) {
   const queryClient = useQueryClient();
 
   const [isFormBusy, setIsFormBusy] = useState<boolean>(false);
+
+  const setIsCompanyEditModalOpened = useSetAtom(companyEditModalOpenedAtom);
 
   const switchCompany = (
     index: number,
@@ -52,7 +56,7 @@ export function CompanyCreate(props: Props) {
 
     localStorage.setItem('X-CURRENT-INDEX', index.toString());
 
-    localStorage.setItem('COMPANY-EDIT-OPENED', 'false');
+    setIsCompanyEditModalOpened(false);
 
     queryClient.invalidateQueries();
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes logic for populating `company_users` once a user signs up. Additionally, the PR includes resolving a bug that prevented the `Company Edit Modal` from showing when a user has just signed up or when a company is just created. Let me know your thoughts.