### PR TITLE
[Bugfix] Money Formatting

### DIFF
--- a/src/common/hooks/money/useFormatMoney.ts
+++ b/src/common/hooks/money/useFormatMoney.ts
@@ -18,9 +18,16 @@ export function useFormatMoney() {
   const resolveCurrency = useResolveCurrency();
   const company = useCurrentCompany();
 
-  return (value: string | number, countryId: string, currencyId: string) => {
-    const country = resolveCountry(countryId);
-    const currency = resolveCurrency(currencyId);
+  return (
+    value: string | number,
+    countryId: string | undefined,
+    currencyId: string | undefined
+  ) => {
+    const currentCountryId = countryId || company?.settings.country_id;
+    const currentCurrencyId = currencyId || company?.settings.currency_id;
+
+    const country = resolveCountry(currentCountryId);
+    const currency = resolveCurrency(currentCurrencyId);
 
     if (country && currency) {
       return Number.formatMoney(value, currency, country, {

--- a/src/common/queries/expenses.ts
+++ b/src/common/queries/expenses.ts
@@ -61,6 +61,7 @@ export function useExpenseQuery(params: ExpenseParams) {
 interface ExpensesParams extends Params {
   enabled?: boolean;
   matchTransactions?: boolean;
+  include?: string;
 }
 
 export function useExpensesQuery(params: ExpensesParams) {
@@ -70,7 +71,7 @@ export function useExpensesQuery(params: ExpensesParams) {
       request(
         'GET',
         endpoint(
-          '/api/v1/expenses?filter=:filter&per_page=:per_page&status=:status&page=:page&match_transactions=:match_transactions&includes=:includes',
+          '/api/v1/expenses?filter=:filter&per_page=:per_page&status=:status&page=:page&match_transactions=:match_transactions&includes=:includes&include=:include',
           {
             per_page: params.perPage ?? '100',
             page: params.currentPage ?? '1',
@@ -78,6 +79,7 @@ export function useExpensesQuery(params: ExpensesParams) {
             filter: params.filter ?? '',
             match_transactions: params.matchTransactions ?? false,
             includes: 'category',
+            include: params.include || '',
           }
         )
       ).then(

--- a/src/common/queries/expenses.ts
+++ b/src/common/queries/expenses.ts
@@ -71,7 +71,7 @@ export function useExpensesQuery(params: ExpensesParams) {
       request(
         'GET',
         endpoint(
-          '/api/v1/expenses?filter=:filter&per_page=:per_page&status=:status&page=:page&match_transactions=:match_transactions&includes=:includes&include=:include',
+          '/api/v1/expenses?filter=:filter&per_page=:per_page&status=:status&page=:page&match_transactions=:match_transactions&include=:include',
           {
             per_page: params.perPage ?? '100',
             page: params.currentPage ?? '1',

--- a/src/common/queries/payments.ts
+++ b/src/common/queries/payments.ts
@@ -45,6 +45,7 @@ export function usePaymentQuery(params: PaymentParams) {
 interface PaymentsParams extends Params {
   enabled?: boolean;
   matchTransactions?: boolean;
+  include?: string;
 }
 
 export function usePaymentsQuery(params: PaymentsParams) {
@@ -54,13 +55,14 @@ export function usePaymentsQuery(params: PaymentsParams) {
       request(
         'GET',
         endpoint(
-          '/api/v1/payments?filter=:filter&per_page=:per_page&status=:status&page=:page&match_transactions=:match_transactions',
+          '/api/v1/payments?filter=:filter&per_page=:per_page&status=:status&page=:page&match_transactions=:match_transactions&include=:include',
           {
             per_page: params.perPage ?? '100',
             page: params.currentPage ?? '1',
             status: params.status ?? 'active',
             filter: params.filter ?? '',
             match_transactions: params.matchTransactions ?? false,
+            include: params.include || '',
           }
         )
       ).then(

--- a/src/common/queries/products.ts
+++ b/src/common/queries/products.ts
@@ -18,11 +18,20 @@ import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-ap
 import { GenericQueryOptions } from './invoices';
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 
-export function useProductsQuery() {
+interface Params {
+  include?: string;
+}
+
+export function useProductsQuery(params?: Params) {
   return useQuery<Product[]>(
     '/api/v1/products',
     () =>
-      request('GET', endpoint('/api/v1/products?per_page=500')).then(
+      request(
+        'GET',
+        endpoint('/api/v1/products?per_page=500&include=:include', {
+          include: params?.include || '',
+        })
+      ).then(
         (response: GenericSingleResourceResponse<Product[]>) =>
           response.data.data
       ),

--- a/src/pages/credits/common/hooks.tsx
+++ b/src/pages/credits/common/hooks.tsx
@@ -629,7 +629,6 @@ export function useCreditColumns() {
   const creditColumns = useAllCreditColumns();
   type CreditColumns = (typeof creditColumns)[number];
 
-  const company = useCurrentCompany();
   const formatMoney = useFormatMoney();
   const resolveCountry = useResolveCountry();
 
@@ -672,8 +671,8 @@ export function useCreditColumns() {
       format: (value, credit) =>
         formatMoney(
           value,
-          credit.client?.country_id || company.settings.country_id,
-          credit.client?.settings.currency_id || company.settings.currency_id
+          credit.client?.country_id,
+          credit.client?.settings.currency_id
         ),
     },
     {
@@ -686,13 +685,12 @@ export function useCreditColumns() {
       column: 'remaining',
       id: 'balance',
       label: t('remaining'),
-      format: (_, credit) => {
-        return formatMoney(
+      format: (_, credit) =>
+        formatMoney(
           credit.balance,
-          credit.client?.country_id || company.settings.country_id,
-          credit.client?.settings.currency_id || company.settings.currency_id
-        );
-      },
+          credit.client?.country_id,
+          credit.client?.settings.currency_id
+        ),
     },
     {
       column: 'archived_at',
@@ -778,8 +776,8 @@ export function useCreditColumns() {
       format: (value, credit) =>
         formatMoney(
           value,
-          credit.client?.country_id || company?.settings.country_id,
-          credit.client?.settings.currency_id || company?.settings.currency_id
+          credit.client?.country_id,
+          credit.client?.settings.currency_id
         ),
     },
     {
@@ -827,8 +825,8 @@ export function useCreditColumns() {
       format: (value, credit) =>
         formatMoney(
           value,
-          credit.client?.country_id || company?.settings.country_id,
-          credit.client?.settings.currency_id || company?.settings.currency_id
+          credit.client?.country_id,
+          credit.client?.settings.currency_id
         ),
     },
     {
@@ -879,8 +877,8 @@ export function useCreditColumns() {
       format: (value, credit) =>
         formatMoney(
           value,
-          credit.client?.country_id || company?.settings.country_id,
-          credit.client?.settings.currency_id || company?.settings.currency_id
+          credit.client?.country_id,
+          credit.client?.settings.currency_id
         ),
     },
     {

--- a/src/pages/dashboard/components/Chart.tsx
+++ b/src/pages/dashboard/components/Chart.tsx
@@ -177,7 +177,7 @@ export function Chart(props: Props) {
     return formatMoney(
       Number(number) || 0,
       company.settings.country_id,
-      currency ?? company.settings.currency_id
+      currency
     ).toString();
   };
 

--- a/src/pages/dashboard/components/ExpiredQuotes.tsx
+++ b/src/pages/dashboard/components/ExpiredQuotes.tsx
@@ -12,7 +12,6 @@ import { useFormatMoney } from '$app/common/hooks/money/useFormatMoney';
 import { DataTable, DataTableColumns } from '$app/components/DataTable';
 import { route } from '$app/common/helpers/route';
 import { Link } from '$app/components/forms/Link';
-import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { Card } from '$app/components/cards';
 import { Quote } from '$app/common/interfaces/quote';
 import { useTranslation } from 'react-i18next';
@@ -21,7 +20,6 @@ import { Badge } from '$app/components/Badge';
 
 export function ExpiredQuotes() {
   const [t] = useTranslation();
-  const company = useCurrentCompany();
   const formatMoney = useFormatMoney();
 
   const columns: DataTableColumns<Quote> = [
@@ -55,8 +53,8 @@ export function ExpiredQuotes() {
         <Badge variant="light-blue">
           {formatMoney(
             value,
-            quote.client?.country_id || company.settings.country_id,
-            quote.client?.settings.currency_id || company.settings.currency_id
+            quote.client?.country_id,
+            quote.client?.settings.currency_id
           )}
         </Badge>
       ),

--- a/src/pages/dashboard/components/PastDueInvoices.tsx
+++ b/src/pages/dashboard/components/PastDueInvoices.tsx
@@ -14,14 +14,12 @@ import { t } from 'i18next';
 import { route } from '$app/common/helpers/route';
 import { Link } from '$app/components/forms/Link';
 import { Invoice } from '$app/common/interfaces/invoice';
-import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { Card } from '$app/components/cards';
 import dayjs from 'dayjs';
 import { Badge } from '$app/components/Badge';
 
 export function PastDueInvoices() {
   const formatMoney = useFormatMoney();
-  const company = useCurrentCompany();
 
   const columns: DataTableColumns<Invoice> = [
     {
@@ -56,8 +54,8 @@ export function PastDueInvoices() {
         <Badge variant="red">
           {formatMoney(
             value,
-            invoice.client?.country_id || company.settings.country_id,
-            invoice.client?.settings.currency_id || company.settings.currency_id
+            invoice.client?.country_id,
+            invoice.client?.settings.currency_id
           )}
         </Badge>
       ),

--- a/src/pages/dashboard/components/RecentPayments.tsx
+++ b/src/pages/dashboard/components/RecentPayments.tsx
@@ -14,7 +14,6 @@ import { t } from 'i18next';
 import { route } from '$app/common/helpers/route';
 import { Link } from '$app/components/forms/Link';
 import { Payment } from '$app/common/interfaces/payment';
-import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { Card } from '$app/components/cards';
 import { generatePath } from 'react-router-dom';
 import { Badge } from '$app/components/Badge';
@@ -23,7 +22,6 @@ import { useCurrentCompanyDateFormats } from '$app/common/hooks/useCurrentCompan
 
 export function RecentPayments() {
   const formatMoney = useFormatMoney();
-  const company = useCurrentCompany();
   const { dateFormat } = useCurrentCompanyDateFormats();
 
   const columns: DataTableColumns<Payment> = [
@@ -74,8 +72,8 @@ export function RecentPayments() {
         <Badge variant="green">
           {formatMoney(
             value,
-            payment.client?.country_id || company.settings.country_id,
-            payment.client?.settings.currency_id || company.settings.currency_id
+            payment.client?.country_id,
+            payment.client?.settings.currency_id
           )}
         </Badge>
       ),

--- a/src/pages/dashboard/components/Totals.tsx
+++ b/src/pages/dashboard/components/Totals.tsx
@@ -315,7 +315,7 @@ export function Totals() {
                       {formatMoney(
                         totalsData[currency]?.invoices.invoiced_amount || 0,
                         company.settings.country_id,
-                        currency.toString() ?? company.settings.currency_id
+                        currency.toString()
                       )}
                     </span>
                   </Badge>
@@ -328,7 +328,7 @@ export function Totals() {
                       {formatMoney(
                         totalsData[currency]?.revenue.paid_to_date || 0,
                         company.settings.country_id,
-                        currency.toString() ?? company.settings.currency_id
+                        currency.toString()
                       )}
                     </span>
                   </Badge>
@@ -341,7 +341,7 @@ export function Totals() {
                       {formatMoney(
                         totalsData[currency]?.outstanding.amount || 0,
                         company.settings.country_id,
-                        currency.toString() ?? company.settings.currency_id
+                        currency.toString()
                       )}
                     </span>
                   </Badge>

--- a/src/pages/dashboard/components/UpcomingInvoices.tsx
+++ b/src/pages/dashboard/components/UpcomingInvoices.tsx
@@ -14,14 +14,12 @@ import { t } from 'i18next';
 import { route } from '$app/common/helpers/route';
 import { Link } from '$app/components/forms/Link';
 import { Invoice } from '$app/common/interfaces/invoice';
-import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { Card } from '$app/components/cards';
 import dayjs from 'dayjs';
 import { Badge } from '$app/components/Badge';
 
 export function UpcomingInvoices() {
   const formatMoney = useFormatMoney();
-  const company = useCurrentCompany();
 
   const columns: DataTableColumns<Invoice> = [
     {
@@ -56,8 +54,8 @@ export function UpcomingInvoices() {
         <Badge variant="blue">
           {formatMoney(
             value,
-            invoice.client?.country_id || company.settings.country_id,
-            invoice.client?.settings.currency_id || company.settings.currency_id
+            invoice.client?.country_id,
+            invoice.client?.settings.currency_id
           )}
         </Badge>
       ),

--- a/src/pages/dashboard/components/UpcomingQuotes.tsx
+++ b/src/pages/dashboard/components/UpcomingQuotes.tsx
@@ -12,7 +12,6 @@ import { useFormatMoney } from '$app/common/hooks/money/useFormatMoney';
 import { DataTable, DataTableColumns } from '$app/components/DataTable';
 import { route } from '$app/common/helpers/route';
 import { Link } from '$app/components/forms/Link';
-import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { Card } from '$app/components/cards';
 import { Quote } from '$app/common/interfaces/quote';
 import { useTranslation } from 'react-i18next';
@@ -21,7 +20,6 @@ import { Badge } from '$app/components/Badge';
 
 export function UpcomingQuotes() {
   const [t] = useTranslation();
-  const company = useCurrentCompany();
   const formatMoney = useFormatMoney();
 
   const columns: DataTableColumns<Quote> = [
@@ -55,8 +53,8 @@ export function UpcomingQuotes() {
         <Badge variant="orange">
           {formatMoney(
             value,
-            quote.client?.country_id || company.settings.country_id,
-            quote.client?.settings.currency_id || company.settings.currency_id
+            quote.client?.country_id,
+            quote.client?.settings.currency_id
           )}
         </Badge>
       ),

--- a/src/pages/expenses/common/hooks.tsx
+++ b/src/pages/expenses/common/hooks.tsx
@@ -161,7 +161,6 @@ export function useActions() {
     };
 
     const formatMoney = useFormatMoney();
-    const company = useCurrentCompany();
 
     if (!data) {
       return null;
@@ -185,7 +184,7 @@ export function useActions() {
               <p>
                 {formatMoney(
                   invoice.amount,
-                  invoice.client?.country_id ?? company.settings.country_id,
+                  invoice.client?.country_id,
                   invoice.client?.settings.currency_id
                 )}
               </p>
@@ -412,13 +411,7 @@ export function useExpenseColumns() {
       id: 'amount',
       label: t('amount'),
       format: (value, expense) =>
-        formatMoney(
-          value,
-          company?.settings.country_id,
-          expense.currency_id
-            ? expense.currency_id
-            : company?.settings.currency_id
-        ),
+        formatMoney(value, company?.settings.country_id, expense.currency_id),
     },
     {
       column: 'public_notes',
@@ -494,12 +487,8 @@ export function useExpenseColumns() {
       column: 'net_amount',
       id: 'amount',
       label: t('net_amount'),
-      format: (value) =>
-        formatMoney(
-          value,
-          company?.settings.country_id,
-          company?.settings.currency_id
-        ),
+      format: (value, expense) =>
+        formatMoney(value, company?.settings.country_id, expense.currency_id),
     },
     {
       column: 'payment_date',

--- a/src/pages/expenses/common/hooks.tsx
+++ b/src/pages/expenses/common/hooks.tsx
@@ -13,7 +13,6 @@ import paymentType from '$app/common/constants/payment-type';
 import { date, endpoint, getEntityState } from '$app/common/helpers';
 import { route } from '$app/common/helpers/route';
 import { useFormatMoney } from '$app/common/hooks/money/useFormatMoney';
-import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { useCurrentCompanyDateFormats } from '$app/common/hooks/useCurrentCompanyDateFormats';
 import { Expense } from '$app/common/interfaces/expense';
 import { RecurringExpense } from '$app/common/interfaces/recurring-expense';
@@ -337,7 +336,6 @@ export function useExpenseColumns() {
   const { dateFormat } = useCurrentCompanyDateFormats();
 
   const formatMoney = useFormatMoney();
-  const company = useCurrentCompany();
 
   const reactSettings = useReactSettings();
 
@@ -492,7 +490,11 @@ export function useExpenseColumns() {
       id: 'amount',
       label: t('net_amount'),
       format: (value, expense) =>
-        formatMoney(value, company?.settings.country_id, expense.currency_id),
+        formatMoney(
+          value,
+          expense.client?.country_id,
+          expense.currency_id || expense.client?.settings.currency_id
+        ),
     },
     {
       column: 'payment_date',

--- a/src/pages/expenses/common/hooks.tsx
+++ b/src/pages/expenses/common/hooks.tsx
@@ -411,7 +411,11 @@ export function useExpenseColumns() {
       id: 'amount',
       label: t('amount'),
       format: (value, expense) =>
-        formatMoney(value, company?.settings.country_id, expense.currency_id),
+        formatMoney(
+          value,
+          expense.client?.country_id,
+          expense.currency_id || expense.client?.settings.currency_id
+        ),
     },
     {
       column: 'public_notes',

--- a/src/pages/invoices/common/components/InvoiceSlider.tsx
+++ b/src/pages/invoices/common/components/InvoiceSlider.tsx
@@ -9,7 +9,6 @@
  */
 
 import { useFormatMoney } from '$app/common/hooks/money/useFormatMoney';
-import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { Invoice } from '$app/common/interfaces/invoice';
 import { TabGroup } from '$app/components/TabGroup';
 import { ClickableElement, Element } from '$app/components/cards';
@@ -89,7 +88,6 @@ export function InvoiceSlider() {
   const [t] = useTranslation();
 
   const formatMoney = useFormatMoney();
-  const company = useCurrentCompany();
   const actions = useActions();
 
   const { dateFormat } = useCurrentCompanyDateFormats();
@@ -165,9 +163,8 @@ export function InvoiceSlider() {
               {invoice
                 ? formatMoney(
                     invoice?.amount,
-                    invoice.client?.country_id || company?.settings.country_id,
-                    invoice.client?.settings.currency_id ||
-                      company?.settings.currency_id
+                    invoice.client?.country_id,
+                    invoice.client?.settings.currency_id
                   )
                 : null}
             </Element>
@@ -176,9 +173,8 @@ export function InvoiceSlider() {
               {invoice
                 ? formatMoney(
                     invoice.balance,
-                    invoice.client?.country_id || company?.settings.country_id,
-                    invoice.client?.settings.currency_id ||
-                      company?.settings.currency_id
+                    invoice.client?.country_id,
+                    invoice.client?.settings.currency_id
                   )
                 : null}
             </Element>
@@ -238,10 +234,8 @@ export function InvoiceSlider() {
                       <p>
                         {formatMoney(
                           payment.amount,
-                          payment.client?.country_id ||
-                            company.settings.country_id,
-                          payment.client?.settings.currency_id ||
-                            company.settings.currency_id
+                          payment.client?.country_id,
+                          payment.client?.settings.currency_id
                         )}
                       </p>
                       <p>&middot;</p>
@@ -292,10 +286,8 @@ export function InvoiceSlider() {
                       {invoice?.client
                         ? formatMoney(
                             activity.history.amount,
-                            invoice?.client?.country_id ||
-                              company.settings.country_id,
-                            invoice?.client?.settings.currency_id ||
-                              company.settings.currency_id
+                            invoice?.client?.country_id,
+                            invoice?.client?.settings.currency_id
                           )
                         : null}
                     </span>

--- a/src/pages/invoices/common/hooks/useInvoiceColumns.tsx
+++ b/src/pages/invoices/common/hooks/useInvoiceColumns.tsx
@@ -12,7 +12,6 @@ import { Link } from '$app/components/forms';
 import { date } from '$app/common/helpers';
 import { route } from '$app/common/helpers/route';
 import { useFormatMoney } from '$app/common/hooks/money/useFormatMoney';
-import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { useCurrentCompanyDateFormats } from '$app/common/hooks/useCurrentCompanyDateFormats';
 import { useResolveCountry } from '$app/common/hooks/useResolveCountry';
 import { Credit } from '$app/common/interfaces/credit';
@@ -25,8 +24,6 @@ import { useTranslation } from 'react-i18next';
 import { InvoiceStatus } from '../components/InvoiceStatus';
 import { useEntityCustomFields } from '$app/common/hooks/useEntityCustomFields';
 import { useReactSettings } from '$app/common/hooks/useReactSettings';
-
-
 
 export type DataTableColumnsExtended<TResource = any, TColumn = string> = {
   column: TColumn;
@@ -117,7 +114,6 @@ export function useInvoiceColumns(): DataTableColumns<Invoice> {
   const { dateFormat } = useCurrentCompanyDateFormats();
 
   const formatMoney = useFormatMoney();
-  const company = useCurrentCompany();
   const resolveCountry = useResolveCountry();
 
   const reactSettings = useReactSettings();
@@ -149,8 +145,8 @@ export function useInvoiceColumns(): DataTableColumns<Invoice> {
       format: (value, invoice) =>
         formatMoney(
           value,
-          invoice.client?.country_id || company?.settings.country_id,
-          invoice.client?.settings.currency_id || company?.settings.currency_id
+          invoice.client?.country_id,
+          invoice.client?.settings.currency_id
         ),
     },
     {
@@ -170,8 +166,8 @@ export function useInvoiceColumns(): DataTableColumns<Invoice> {
       format: (value, invoice) =>
         formatMoney(
           value,
-          invoice.client?.country_id || company?.settings.country_id,
-          invoice.client?.settings.currency_id || company?.settings.currency_id
+          invoice.client?.country_id,
+          invoice.client?.settings.currency_id
         ),
     },
     {
@@ -277,8 +273,8 @@ export function useInvoiceColumns(): DataTableColumns<Invoice> {
       format: (value, invoice) =>
         formatMoney(
           value,
-          invoice.client?.country_id || company?.settings.country_id,
-          invoice.client?.settings.currency_id || company?.settings.currency_id
+          invoice.client?.country_id,
+          invoice.client?.settings.currency_id
         ),
     },
     {
@@ -338,8 +334,8 @@ export function useInvoiceColumns(): DataTableColumns<Invoice> {
       format: (value, invoice) =>
         formatMoney(
           value,
-          invoice.client?.country_id || company?.settings.country_id,
-          invoice.client?.settings.currency_id || company?.settings.currency_id
+          invoice.client?.country_id,
+          invoice.client?.settings.currency_id
         ),
     },
     {
@@ -414,8 +410,8 @@ export function useInvoiceColumns(): DataTableColumns<Invoice> {
       format: (value, invoice) =>
         formatMoney(
           value,
-          invoice.client?.country_id || company?.settings.country_id,
-          invoice.client?.settings.currency_id || company?.settings.currency_id
+          invoice.client?.country_id,
+          invoice.client?.settings.currency_id
         ),
     },
     {

--- a/src/pages/invoices/common/queries.ts
+++ b/src/pages/invoices/common/queries.ts
@@ -20,6 +20,7 @@ interface InvoiceParams extends Params {
   clientId?: string;
   withoutDeletedClients?: boolean;
   enabled?: boolean;
+  include?: string;
 }
 
 export function useInvoicesQuery(params: InvoiceParams) {
@@ -29,7 +30,7 @@ export function useInvoicesQuery(params: InvoiceParams) {
       request(
         'GET',
         endpoint(
-          '/api/v1/invoices?client_status=:client_status&filter=:filter&client_id=:client_id&without_deleted_clients=:without_deleted_clients&per_page=:per_page&page=:page',
+          '/api/v1/invoices?client_status=:client_status&filter=:filter&client_id=:client_id&without_deleted_clients=:without_deleted_clients&per_page=:per_page&page=:page&include=:include',
           {
             per_page: params.perPage ?? '100',
             page: params.currentPage ?? '1',
@@ -37,6 +38,7 @@ export function useInvoicesQuery(params: InvoiceParams) {
             client_id: params.clientId ?? '',
             filter: params.filter ?? '',
             without_deleted_clients: params.withoutDeletedClients || true,
+            include: params.include || '',
           }
         )
       ).then(

--- a/src/pages/payments/apply/Apply.tsx
+++ b/src/pages/payments/apply/Apply.tsx
@@ -31,7 +31,6 @@ import { useFormatMoney } from '$app/common/hooks/money/useFormatMoney';
 import collect from 'collect.js';
 import { useSaveBtn } from '$app/components/layouts/common/hooks';
 import { ComboboxAsync } from '$app/components/forms/Combobox';
-import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 
 export default function Apply() {
   const queryClient = useQueryClient();
@@ -101,8 +100,6 @@ export default function Apply() {
     [formik.values, formik.isSubmitting]
   );
 
-  const company = useCurrentCompany();
-
   return (
     <Card title={t('apply_payment')}>
       <Element leftSide={t('number')}>{payment?.number}</Element>
@@ -112,27 +109,24 @@ export default function Apply() {
           <Element leftSide={t('amount')}>
             {formatMoney(
               payment?.amount - payment?.refunded,
-              payment.client?.country_id || company.settings.country_id,
-              payment.client?.settings.currency_id ||
-                company.settings.currency_id
+              payment.client?.country_id,
+              payment.client?.settings.currency_id
             )}
           </Element>
 
           <Element leftSide={t('applied')}>
             {formatMoney(
               payment?.applied,
-              payment.client?.country_id || company.settings.country_id,
-              payment.client?.settings.currency_id ||
-                company.settings.currency_id
+              payment.client?.country_id,
+              payment.client?.settings.currency_id
             )}
           </Element>
 
           <Element leftSide={t('unapplied')}>
             {formatMoney(
               payment?.amount - payment?.refunded - payment?.applied,
-              payment.client?.country_id || company.settings.country_id,
-              payment.client?.settings.currency_id ||
-                company.settings.currency_id
+              payment.client?.country_id,
+              payment.client?.settings.currency_id
             )}
           </Element>
         </>
@@ -158,8 +152,8 @@ export default function Apply() {
                   'balance'
                 )} ${formatMoney(
                   invoice.balance,
-                  payment.client?.country_id ?? '1',
-                  payment.client?.settings.currency_id ?? '1'
+                  payment.client?.country_id,
+                  payment.client?.settings.currency_id
                 )}`,
             }}
             onChange={({ resource }) =>

--- a/src/pages/payments/common/hooks/usePaymentColumns.tsx
+++ b/src/pages/payments/common/hooks/usePaymentColumns.tsx
@@ -13,7 +13,6 @@ import paymentType from '$app/common/constants/payment-type';
 import { date } from '$app/common/helpers';
 import { route } from '$app/common/helpers/route';
 import { useFormatMoney } from '$app/common/hooks/money/useFormatMoney';
-import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { useCurrentCompanyDateFormats } from '$app/common/hooks/useCurrentCompanyDateFormats';
 import { useResolveCurrency } from '$app/common/hooks/useResolveCurrency';
 import { Payment } from '$app/common/interfaces/payment';
@@ -81,7 +80,6 @@ export function usePaymentColumns() {
   const paymentColumns = useAllPaymentColumns();
   type PaymentColumns = (typeof paymentColumns)[number];
 
-  const company = useCurrentCompany();
   const formatMoney = useFormatMoney();
   const resolveCurrency = useResolveCurrency();
 
@@ -142,8 +140,8 @@ export function usePaymentColumns() {
       format: (value, payment) =>
         formatMoney(
           value,
-          payment.client?.country_id || company.settings.country_id,
-          payment.client?.settings.currency_id || company.settings.currency_id
+          payment.client?.country_id,
+          payment.client?.settings.currency_id
         ),
     },
     {
@@ -184,8 +182,8 @@ export function usePaymentColumns() {
       format: (value, payment) =>
         formatMoney(
           calculateConvertedAmount(payment),
-          payment.client?.country_id || company?.settings.country_id,
-          payment.client?.settings.currency_id || company?.settings.currency_id
+          payment.client?.country_id,
+          payment.client?.settings.currency_id
         ),
     },
     {
@@ -253,8 +251,8 @@ export function usePaymentColumns() {
       format: (value, payment) =>
         formatMoney(
           value,
-          payment.client?.country_id || company?.settings.country_id,
-          payment.client?.settings.currency_id || company?.settings.currency_id
+          payment.client?.country_id,
+          payment.client?.settings.currency_id
         ),
     },
     {

--- a/src/pages/payments/create/Create.tsx
+++ b/src/pages/payments/create/Create.tsx
@@ -339,8 +339,8 @@ export default function Create() {
                       'balance'
                     )} ${formatMoney(
                       invoice.balance,
-                      payment.client?.country_id ?? '1',
-                      payment.client?.settings.currency_id ?? '1'
+                      payment.client?.country_id,
+                      payment.client?.settings.currency_id
                     )}`,
                 }}
                 onChange={({ resource }) =>
@@ -382,8 +382,8 @@ export default function Create() {
                             'balance'
                           )} ${formatMoney(
                             credit.balance,
-                            payment.client?.country_id ?? '1',
-                            payment.client?.settings.currency_id ?? '1'
+                            payment.client?.country_id,
+                            payment.client?.settings.currency_id
                           )}`,
                       }}
                       onChange={(entry) =>
@@ -450,8 +450,8 @@ export default function Create() {
                       'balance'
                     )} ${formatMoney(
                       credit.balance,
-                      payment.client?.country_id ?? '1',
-                      payment.client?.settings.currency_id ?? '1'
+                      payment.client?.country_id,
+                      payment.client?.settings.currency_id
                     )}`,
                 }}
                 onChange={(entry) =>

--- a/src/pages/payments/edit/PaymentOverview.tsx
+++ b/src/pages/payments/edit/PaymentOverview.tsx
@@ -9,7 +9,6 @@
  */
 
 import { useFormatMoney } from '$app/common/hooks/money/useFormatMoney';
-import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { useTranslation } from 'react-i18next';
 import { Payment } from '$app/common/interfaces/payment';
 import { PaymentOverviewInvoice } from './PaymentOverviewInvoice';
@@ -22,7 +21,6 @@ interface Props {
 export function PaymentOverview(props: Props) {
   const [t] = useTranslation();
   const formatMoney = useFormatMoney();
-  const company = useCurrentCompany();
 
   return (
     <div>
@@ -31,7 +29,7 @@ export function PaymentOverview(props: Props) {
           <span className="text-gray-800">
             {`${t('amount')}: ${formatMoney(
               props?.payment?.amount || 0,
-              company.settings.country_id,
+              props.payment.client?.country_id,
               props.payment?.currency_id
             )}`}
           </span>
@@ -41,7 +39,7 @@ export function PaymentOverview(props: Props) {
           <span className="text-gray-800">
             {`${t('applied')}: ${formatMoney(
               props?.payment?.applied || 0,
-              company.settings.country_id,
+              props.payment.client?.country_id,
               props.payment?.currency_id
             )}`}
           </span>
@@ -55,7 +53,7 @@ export function PaymentOverview(props: Props) {
           <span className="text-gray-800">
             {`${t('refunded')}: ${formatMoney(
               props?.payment?.refunded || 0,
-              company.settings.country_id,
+              props.payment.client?.country_id,
               props.payment?.currency_id
             )}`}
           </span>

--- a/src/pages/payments/edit/PaymentOverview.tsx
+++ b/src/pages/payments/edit/PaymentOverview.tsx
@@ -31,8 +31,8 @@ export function PaymentOverview(props: Props) {
           <span className="text-gray-800">
             {`${t('amount')}: ${formatMoney(
               props?.payment?.amount || 0,
-              company.settings.country_id ?? '1',
-              props.payment?.currency_id ?? '1'
+              company.settings.country_id,
+              props.payment?.currency_id
             )}`}
           </span>
         </div>
@@ -41,8 +41,8 @@ export function PaymentOverview(props: Props) {
           <span className="text-gray-800">
             {`${t('applied')}: ${formatMoney(
               props?.payment?.applied || 0,
-              company.settings.country_id ?? '1',
-              props.payment?.currency_id ?? '1'
+              company.settings.country_id,
+              props.payment?.currency_id
             )}`}
           </span>
         </div>
@@ -55,8 +55,8 @@ export function PaymentOverview(props: Props) {
           <span className="text-gray-800">
             {`${t('refunded')}: ${formatMoney(
               props?.payment?.refunded || 0,
-              company.settings.country_id ?? '1',
-              props.payment?.currency_id ?? '1'
+              company.settings.country_id,
+              props.payment?.currency_id
             )}`}
           </span>
         </div>

--- a/src/pages/payments/edit/PaymentOverviewInvoice.tsx
+++ b/src/pages/payments/edit/PaymentOverviewInvoice.tsx
@@ -9,7 +9,6 @@
  */
 
 import { useFormatMoney } from '$app/common/hooks/money/useFormatMoney';
-import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { useTranslation } from 'react-i18next';
 import { Payment, Paymentable } from '$app/common/interfaces/payment';
 import { Invoice } from '$app/common/interfaces/invoice';
@@ -34,7 +33,6 @@ export function setLabel(payment: Payment, paymentable: Paymentable): string {
 export function PaymentOverviewInvoice(props: Props) {
   const [t] = useTranslation();
   const formatMoney = useFormatMoney();
-  const company = useCurrentCompany();
   const { dateFormat } = useCurrentCompanyDateFormats();
 
   return (
@@ -57,7 +55,7 @@ export function PaymentOverviewInvoice(props: Props) {
             <span className="text-gray-400">
               {formatMoney(
                 props?.paymentable?.amount || 0,
-                company.settings.country_id,
+                props.payment.client?.country_id,
                 props.payment?.currency_id
               )}
             </span>
@@ -88,7 +86,7 @@ export function PaymentOverviewInvoice(props: Props) {
             <span className="text-gray-400">
               {formatMoney(
                 props?.paymentable?.amount || 0,
-                company.settings.country_id,
+                props.payment.client?.country_id,
                 props.payment?.currency_id
               )}
             </span>

--- a/src/pages/products/common/hooks.tsx
+++ b/src/pages/products/common/hooks.tsx
@@ -14,7 +14,6 @@ import { date, getEntityState } from '$app/common/helpers';
 import { route } from '$app/common/helpers/route';
 import { toast } from '$app/common/helpers/toast/toast';
 import { useFormatMoney } from '$app/common/hooks/money/useFormatMoney';
-import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { useCurrentCompanyDateFormats } from '$app/common/hooks/useCurrentCompanyDateFormats';
 import { Product } from '$app/common/interfaces/product';
 import { ValidationBag } from '$app/common/interfaces/validation-bag';
@@ -92,7 +91,6 @@ export function useProductColumns() {
 
   const { dateFormat } = useCurrentCompanyDateFormats();
 
-  const company = useCurrentCompany();
   const formatMoney = useFormatMoney();
 
   const reactSettings = useReactSettings();
@@ -141,8 +139,8 @@ export function useProductColumns() {
       format: (value, product) =>
         formatMoney(
           value,
-          product.company?.settings.country_id || company.settings.country_id,
-          product.company?.settings.currency_id || company.settings.currency_id
+          product.company?.settings.country_id,
+          product.company?.settings.currency_id
         ),
     },
     {

--- a/src/pages/projects/common/hooks.tsx
+++ b/src/pages/projects/common/hooks.tsx
@@ -13,7 +13,6 @@ import { EntityState } from '$app/common/enums/entity-state';
 import { date, endpoint, getEntityState } from '$app/common/helpers';
 import { route } from '$app/common/helpers/route';
 import { useFormatMoney } from '$app/common/hooks/money/useFormatMoney';
-import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { useCurrentCompanyDateFormats } from '$app/common/hooks/useCurrentCompanyDateFormats';
 import { Project } from '$app/common/interfaces/project';
 import { Divider } from '$app/components/cards/Divider';
@@ -97,7 +96,6 @@ export function useProjectColumns() {
   const { t } = useTranslation();
   const { dateFormat } = useCurrentCompanyDateFormats();
 
-  const company = useCurrentCompany();
   const formatMoney = useFormatMoney();
 
   const reactSettings = useReactSettings();
@@ -123,11 +121,11 @@ export function useProjectColumns() {
       column: 'task_rate',
       id: 'task_rate',
       label: t('task_rate'),
-      format: (value) =>
+      format: (value, task) =>
         formatMoney(
           value,
-          company?.settings.country_id,
-          company?.settings.currency_id
+          task.client?.country_id,
+          task.client?.settings.currency_id
         ),
     },
     {

--- a/src/pages/projects/show/Show.tsx
+++ b/src/pages/projects/show/Show.tsx
@@ -137,7 +137,7 @@ export default function Show() {
             {t('task_rate')}:
             {formatMoney(
               project.task_rate,
-              project.client?.country_id || '',
+              project.client?.country_id,
               project.client?.settings.currency_id
             )}
           </p>

--- a/src/pages/purchase-orders/common/hooks.tsx
+++ b/src/pages/purchase-orders/common/hooks.tsx
@@ -16,7 +16,6 @@ import { request } from '$app/common/helpers/request';
 import { route } from '$app/common/helpers/route';
 import { toast } from '$app/common/helpers/toast/toast';
 import { useFormatMoney } from '$app/common/hooks/money/useFormatMoney';
-import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { useCurrentCompanyDateFormats } from '$app/common/hooks/useCurrentCompanyDateFormats';
 import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-api-response';
 import { PurchaseOrder } from '$app/common/interfaces/purchase-order';
@@ -145,7 +144,6 @@ export function usePurchaseOrderColumns() {
   const { t } = useTranslation();
   const { dateFormat } = useCurrentCompanyDateFormats();
 
-  const company = useCurrentCompany();
   const reactSettings = useReactSettings();
 
   const formatMoney = useFormatMoney();
@@ -217,11 +215,7 @@ export function usePurchaseOrderColumns() {
         id: 'amount',
         label: t('amount'),
         format: (amount, po) =>
-          formatMoney(
-            amount,
-            po.vendor?.country_id ?? company?.settings.country_id,
-            po.vendor?.currency_id ?? company?.settings.currency_id
-          ),
+          formatMoney(amount, po.vendor?.country_id, po.vendor?.currency_id),
       },
       {
         column: 'date',
@@ -296,8 +290,8 @@ export function usePurchaseOrderColumns() {
         format: (value, purchaseOrder) =>
           formatMoney(
             value,
-            purchaseOrder.vendor?.country_id || company?.settings.country_id,
-            purchaseOrder.vendor?.currency_id || company?.settings.currency_id
+            purchaseOrder.vendor?.country_id,
+            purchaseOrder.vendor?.currency_id
           ),
       },
       {

--- a/src/pages/quotes/common/hooks.tsx
+++ b/src/pages/quotes/common/hooks.tsx
@@ -604,7 +604,6 @@ export function useQuoteColumns() {
   const accentColor = useAccentColor();
   const navigate = useNavigate();
 
-  const company = useCurrentCompany();
   const formatMoney = useFormatMoney();
   const resolveCountry = useResolveCountry();
   const reactSettings = useReactSettings();
@@ -673,8 +672,8 @@ export function useQuoteColumns() {
       format: (value, quote) =>
         formatMoney(
           value,
-          quote.client?.country_id || company.settings.country_id,
-          quote.client?.settings.currency_id || company.settings.currency_id
+          quote.client?.country_id,
+          quote.client?.settings.currency_id
         ),
     },
     {
@@ -773,8 +772,8 @@ export function useQuoteColumns() {
       format: (value, quote) =>
         formatMoney(
           value,
-          quote.client?.country_id || company?.settings.country_id,
-          quote.client?.settings.currency_id || company?.settings.currency_id
+          quote.client?.country_id,
+          quote.client?.settings.currency_id
         ),
     },
     {
@@ -822,8 +821,8 @@ export function useQuoteColumns() {
       format: (value, quote) =>
         formatMoney(
           value,
-          quote.client?.country_id || company?.settings.country_id,
-          quote.client?.settings.currency_id || company?.settings.currency_id
+          quote.client?.country_id,
+          quote.client?.settings.currency_id
         ),
     },
     {
@@ -874,8 +873,8 @@ export function useQuoteColumns() {
       format: (value, quote) =>
         formatMoney(
           value,
-          quote.client?.country_id || company?.settings.country_id,
-          quote.client?.settings.currency_id || company?.settings.currency_id
+          quote.client?.country_id,
+          quote.client?.settings.currency_id
         ),
     },
     {

--- a/src/pages/recurring-expenses/common/hooks.tsx
+++ b/src/pages/recurring-expenses/common/hooks.tsx
@@ -15,7 +15,6 @@ import { useTranslation } from 'react-i18next';
 import { date, endpoint, getEntityState } from '$app/common/helpers';
 import { useCurrentCompanyDateFormats } from '$app/common/hooks/useCurrentCompanyDateFormats';
 import { EntityStatus } from '$app/components/EntityStatus';
-import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { useFormatMoney } from '$app/common/hooks/money/useFormatMoney';
 import { Link } from '$app/components/forms';
 import { route } from '$app/common/helpers/route';
@@ -123,8 +122,6 @@ export function useRecurringExpenseColumns() {
 
   const { dateFormat } = useCurrentCompanyDateFormats();
 
-  const company = useCurrentCompany();
-
   const formatMoney = useFormatMoney();
 
   const reactSettings = useReactSettings();
@@ -201,11 +198,11 @@ export function useRecurringExpenseColumns() {
       column: 'amount',
       id: 'amount',
       label: t('amount'),
-      format: (value) =>
+      format: (value, recurringExpense) =>
         formatMoney(
           value,
-          company?.settings.country_id,
-          company?.settings.currency_id
+          recurringExpense.client?.country_id,
+          recurringExpense.client?.settings.currency_id
         ),
     },
     {
@@ -283,11 +280,11 @@ export function useRecurringExpenseColumns() {
       column: 'net_amount',
       id: 'amount',
       label: t('net_amount'),
-      format: (value) =>
+      format: (value, recurringExpense) =>
         formatMoney(
           value,
-          company?.settings.country_id,
-          company?.settings.currency_id
+          recurringExpense.client?.country_id,
+          recurringExpense.client?.settings.currency_id
         ),
     },
     {

--- a/src/pages/recurring-expenses/common/hooks.tsx
+++ b/src/pages/recurring-expenses/common/hooks.tsx
@@ -202,7 +202,8 @@ export function useRecurringExpenseColumns() {
         formatMoney(
           value,
           recurringExpense.client?.country_id,
-          recurringExpense.client?.settings.currency_id
+          recurringExpense.currency_id ||
+            recurringExpense.client?.settings.currency_id
         ),
     },
     {
@@ -284,7 +285,8 @@ export function useRecurringExpenseColumns() {
         formatMoney(
           value,
           recurringExpense.client?.country_id,
-          recurringExpense.client?.settings.currency_id
+          recurringExpense.currency_id ||
+            recurringExpense.client?.settings.currency_id
         ),
     },
     {

--- a/src/pages/recurring-invoices/common/hooks.tsx
+++ b/src/pages/recurring-invoices/common/hooks.tsx
@@ -586,7 +586,6 @@ export function useRecurringInvoiceColumns() {
   const recurringInvoiceColumns = useAllRecurringInvoiceColumns();
   type RecurringInvoiceColumns = (typeof recurringInvoiceColumns)[number];
 
-  const company = useCurrentCompany();
   const formatMoney = useFormatMoney();
   const reactSettings = useReactSettings();
 
@@ -638,9 +637,8 @@ export function useRecurringInvoiceColumns() {
       format: (value, recurringInvoice) =>
         formatMoney(
           value,
-          recurringInvoice.client?.country_id || company.settings.country_id,
-          recurringInvoice.client?.settings.currency_id ||
-            company.settings.currency_id
+          recurringInvoice.client?.country_id,
+          recurringInvoice.client?.settings.currency_id
         ),
     },
     {
@@ -719,10 +717,8 @@ export function useRecurringInvoiceColumns() {
         recurringInvoice.is_amount_discount
           ? formatMoney(
               value,
-              recurringInvoice.client?.country_id ||
-                company?.settings.country_id,
-              recurringInvoice.client?.settings.currency_id ||
-                company?.settings.currency_id
+              recurringInvoice.client?.country_id,
+              recurringInvoice.client?.settings.currency_id
             )
           : `${recurringInvoice.discount}%`,
     },

--- a/src/pages/settings/schedules/common/components/EmailRecord.tsx
+++ b/src/pages/settings/schedules/common/components/EmailRecord.tsx
@@ -10,7 +10,6 @@
 
 import { endpoint } from '$app/common/helpers';
 import { useFormatMoney } from '$app/common/hooks/money/useFormatMoney';
-import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { Credit } from '$app/common/interfaces/credit';
 import { Invoice } from '$app/common/interfaces/invoice';
 import { PurchaseOrder } from '$app/common/interfaces/purchase-order';
@@ -35,15 +34,13 @@ export function EmailRecord(props: Props) {
   const [t] = useTranslation();
   const formatMoney = useFormatMoney();
 
-  const company = useCurrentCompany();
-
   const { schedule, handleChange, errors } = props;
 
   const formatEntityLabel = (entity: Invoice | Quote) => {
     return `${entity.number} (${formatMoney(
       entity.amount,
-      entity?.client?.country_id || company?.settings.country_id,
-      entity?.client?.settings.currency_id || company?.settings.currency_id
+      entity?.client?.country_id,
+      entity?.client?.settings.currency_id
     )})`;
   };
 
@@ -186,19 +183,15 @@ export function EmailRecord(props: Props) {
               dropdownLabelFn: (purchaseOrder) =>
                 `${purchaseOrder.number} (${formatMoney(
                   purchaseOrder.amount,
-                  purchaseOrder?.vendor?.country_id ||
-                    company?.settings.country_id,
-                  purchaseOrder?.vendor?.currency_id ||
-                    company?.settings.currency_id
+                  purchaseOrder?.vendor?.country_id,
+                  purchaseOrder?.vendor?.currency_id
                 )})`,
               inputLabelFn: (purchaseOrder) =>
                 purchaseOrder
                   ? `${purchaseOrder.number} (${formatMoney(
                       purchaseOrder.amount,
-                      purchaseOrder?.vendor?.country_id ||
-                        company?.settings.country_id,
-                      purchaseOrder?.vendor?.currency_id ||
-                        company?.settings.currency_id
+                      purchaseOrder?.vendor?.country_id,
+                      purchaseOrder?.vendor?.currency_id
                     )})`
                   : '',
             }}

--- a/src/pages/settings/subscriptions/common/components/MultipleProductSelector.tsx
+++ b/src/pages/settings/subscriptions/common/components/MultipleProductSelector.tsx
@@ -14,7 +14,6 @@ import { Link, SelectField } from '$app/components/forms';
 import { MdClose } from 'react-icons/md';
 import { useEffect, useState } from 'react';
 import { useFormatMoney } from '$app/common/hooks/money/useFormatMoney';
-import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { useAccentColor } from '$app/common/hooks/useAccentColor';
 import { route } from '$app/common/helpers/route';
 import { BsBox } from 'react-icons/bs';
@@ -36,8 +35,6 @@ interface Props {
 
 export function MultipleProductSelector(props: Props) {
   const accentColor = useAccentColor();
-
-  const company = useCurrentCompany();
 
   const navigate = useNavigate();
 
@@ -65,14 +62,14 @@ export function MultipleProductSelector(props: Props) {
     }
   };
 
-  const getOptionLabelText = (productKey: string, price: number) => {
+  const getOptionLabelText = (product: Product) => {
     return (
-      productKey +
+      product.product_key +
       ' ' +
       formatMoney(
-        price,
-        company?.settings.country_id,
-        company?.settings.currency_id
+        product.price,
+        product.company?.settings.country_id,
+        product.company?.settings.currency_id
       ).toString()
     );
   };
@@ -121,7 +118,7 @@ export function MultipleProductSelector(props: Props) {
         >
           {props.products.map((product, index) => (
             <option key={index} value={product.id}>
-              {getOptionLabelText(product.product_key, product.price)}
+              {getOptionLabelText(product)}
             </option>
           ))}
         </SelectField>
@@ -165,8 +162,8 @@ export function MultipleProductSelector(props: Props) {
                       <span>
                         {formatMoney(
                           product.price,
-                          company?.settings.country_id,
-                          company?.settings.currency_id
+                          product.company?.settings.country_id,
+                          product.company?.settings.currency_id
                         )}
                       </span>
                     </div>

--- a/src/pages/settings/subscriptions/create/Create.tsx
+++ b/src/pages/settings/subscriptions/create/Create.tsx
@@ -43,7 +43,7 @@ export function Create() {
 
   const { data } = useBlankSubscriptionQuery();
 
-  const { data: productsData } = useProductsQuery();
+  const { data: productsData } = useProductsQuery({ include: 'company' });
 
   const queryClient = useQueryClient();
 

--- a/src/pages/tasks/common/components/AddTasksOnInvoiceModal.tsx
+++ b/src/pages/tasks/common/components/AddTasksOnInvoiceModal.tsx
@@ -48,7 +48,7 @@ export function AddTasksOnInvoiceModal(props: Props) {
             <span>
               {formatMoney(
                 invoice.amount,
-                invoice.client?.country_id || '',
+                invoice.client?.country_id,
                 invoice.client?.settings.currency_id
               )}
             </span>

--- a/src/pages/tasks/common/hooks.tsx
+++ b/src/pages/tasks/common/hooks.tsx
@@ -192,8 +192,8 @@ export function useTaskColumns() {
       format: (value, task) =>
         formatMoney(
           task.rate || company.settings.default_task_rate,
-          task.client?.country_id || company?.settings.country_id,
-          task.client?.settings.currency_id || company?.settings.currency_id
+          task.client?.country_id,
+          task.client?.settings.currency_id
         ),
     },
     {
@@ -259,8 +259,8 @@ export function useTaskColumns() {
       format: (value, task) =>
         formatMoney(
           value,
-          task.client?.country_id || company?.settings.country_id,
-          task.client?.settings.currency_id || company?.settings.currency_id
+          task.client?.country_id,
+          task.client?.settings.currency_id
         ),
     },
     {

--- a/src/pages/tasks/kanban/components/ViewSlider.tsx
+++ b/src/pages/tasks/kanban/components/ViewSlider.tsx
@@ -67,9 +67,8 @@ export function ViewSlider() {
             <Element leftSide={t('rate')}>
               {formatMoney(
                 currentTask.rate || company.settings.default_task_rate,
-                currentTask.client?.country_id || company?.settings.country_id,
-                currentTask.client?.settings.currency_id ||
-                  company?.settings.currency_id
+                currentTask.client?.country_id,
+                currentTask.client?.settings.currency_id
               )}
             </Element>
 

--- a/src/pages/transactions/components/Details.tsx
+++ b/src/pages/transactions/components/Details.tsx
@@ -145,7 +145,7 @@ export function Details(props: Props) {
           {formatMoney(
             transaction?.amount || 0,
             company?.settings.country_id,
-            transaction?.currency_id || ''
+            transaction?.currency_id
           )}
         </Element>
 

--- a/src/pages/transactions/components/ListBox.tsx
+++ b/src/pages/transactions/components/ListBox.tsx
@@ -37,6 +37,8 @@ export interface ResourceItem {
   payment_type_id: string;
   archived_at: number;
   is_deleted: boolean;
+  country_id: string;
+  currency_id: string;
 }
 
 export interface SearchInput {
@@ -80,6 +82,7 @@ export function ListBox(props: Props) {
   });
 
   const { data: invoicesResponse } = useInvoicesQuery({
+    include: 'client',
     clientStatus: 'unpaid',
     filter: searchParams.searchTerm,
     clientId,
@@ -97,12 +100,14 @@ export function ListBox(props: Props) {
   });
 
   const { data: paymentsResponse } = usePaymentsQuery({
+    include: 'client',
     filter: searchParams.searchTerm,
     enabled: isPaymentsDataKey,
     matchTransactions: true,
   });
 
   const { data: expensesResponse } = useExpensesQuery({
+    include: 'client',
     filter: searchParams.searchTerm,
     enabled: isExpensesDataKey,
     matchTransactions: true,
@@ -154,6 +159,9 @@ export function ListBox(props: Props) {
       payment_date: resourceItem.payment_date,
       transaction_reference: resourceItem.transaction_reference,
       payment_type_id: resourceItem.payment_type_id,
+      country_id: resourceItem.country_id || resourceItem.client?.country_id,
+      currency_id:
+        resourceItem.currency_id || resourceItem.client?.settings.currency_id,
     }));
   };
 

--- a/src/pages/transactions/components/ListBoxItem.tsx
+++ b/src/pages/transactions/components/ListBoxItem.tsx
@@ -13,7 +13,6 @@ import { StatusBadge } from '$app/components/StatusBadge';
 import invoiceStatus from '$app/common/constants/invoice-status';
 import { ResourceItem } from './ListBox';
 import { useFormatMoney } from '$app/common/hooks/money/useFormatMoney';
-import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import paymentStatus from '$app/common/constants/payment-status';
 import { ExpenseStatus } from '$app/pages/expenses/common/components/ExpenseStatus';
 import { date as formatDate } from '$app/common/helpers';
@@ -27,8 +26,6 @@ interface Props {
 }
 
 export function ListBoxItem(props: Props) {
-  const company = useCurrentCompany();
-
   const formatMoney = useFormatMoney();
 
   const { dateFormat } = useCurrentCompanyDateFormats();
@@ -58,12 +55,12 @@ export function ListBoxItem(props: Props) {
             {formatDate(props.resourceItem.date || '', dateFormat)}
           </span>
         </div>
-        {props.resourceItem.amount && (
+        {typeof props.resourceItem.amount === 'number' && (
           <span className="text-sm">
             {formatMoney(
-              props.resourceItem.amount,
-              company.settings.country_id,
-              company.settings.currency_id
+              props.resourceItem.amount || 0,
+              props.resourceItem.country_id,
+              props.resourceItem.currency_id
             )}
           </span>
         )}


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes across the whole app regarding the formatting of money. We had some cases where we did not have a fallback to company settings, some cases where formatting was not correctly applied, and some other cases. So, currently, this PR should always provide the fallback to company settings and fix all the issues we had. 

Additionally, the PR includes improving the structure for falling back to company settings to avoid a lot of repetition.

Let me know your thoughts.