### PR TITLE
[Bugfix] Hex Color Edge Case | Task Statuses

### DIFF
--- a/src/common/hooks/useAdjustColorDarkness.ts
+++ b/src/common/hooks/useAdjustColorDarkness.ts
@@ -11,11 +11,18 @@
 export const hexToRGB = (hex: string) => {
   hex = hex.replace('#', '');
 
+  if (hex.length === 3) {
+    hex = hex
+      .split('')
+      .map((char) => char + char)
+      .join('');
+  }
+
   const red = parseInt(hex.substring(0, 2), 16);
   const green = parseInt(hex.substring(2, 4), 16);
   const blue = parseInt(hex.substring(4, 6), 16);
 
-  return { red, green, blue };
+  return { red, green, blue, hex: `#${hex}` };
 };
 
 export const isColorLight = (red: number, green: number, blue: number) => {

--- a/src/pages/tasks/common/components/TaskStatus.tsx
+++ b/src/pages/tasks/common/components/TaskStatus.tsx
@@ -51,7 +51,7 @@ export function TaskStatus(props: Props) {
   if (isRunning()) return <Badge variant="light-blue">{t('running')}</Badge>;
 
   if (status) {
-    const { red, green, blue } = hexToRGB(status.color);
+    const { red, green, blue, hex } = hexToRGB(status.color);
 
     const darknessAmount = isColorLight(red, green, blue) ? -220 : 220;
 
@@ -60,7 +60,7 @@ export function TaskStatus(props: Props) {
         for={{}}
         code={status.name}
         style={{
-          color: adjustColorDarkness(status.color, darknessAmount),
+          color: adjustColorDarkness(hex, darknessAmount),
           backgroundColor: status.color,
         }}
       />

--- a/src/pages/tasks/common/hooks.tsx
+++ b/src/pages/tasks/common/hooks.tsx
@@ -338,14 +338,14 @@ export function useTaskFilters() {
   ];
 
   taskStatuses?.data.forEach((taskStatus) => {
-    const { red, green, blue } = hexToRGB(taskStatus.color);
+    const { red, green, blue, hex } = hexToRGB(taskStatus.color);
 
     const darknessAmount = isColorLight(red, green, blue) ? -220 : 220;
 
     filters.push({
       label: taskStatus.name,
       value: taskStatus.id,
-      color: adjustColorDarkness(taskStatus.color, darknessAmount),
+      color: adjustColorDarkness(hex, darknessAmount),
       backgroundColor: taskStatus.color,
       queryKey: 'task_status',
     });


### PR DESCRIPTION
@beganovich @turbo124 We encountered a non-covered case where the default color was `#fff`. As a result, the text color adjustment was incorrect, and the text appeared white, making it invisible in this edge case. However, I have fixed the issue, and now it looks good on my end. Let me know your thoughts.