### PR TITLE
[Bugfix] Activate Company Link Breaks App

### DIFF
--- a/src/pages/settings/account-management/component/Overview.tsx
+++ b/src/pages/settings/account-management/component/Overview.tsx
@@ -90,7 +90,7 @@ export function Overview() {
         />
       </Element>
 
-      {account.default_company_id !== company.id && defaultCompany && (
+      {account.default_company_id !== company?.id && defaultCompany && (
         <>
           <Divider />
           <Element leftSide={t('set_default_company')}>
@@ -99,7 +99,7 @@ export function Overview() {
               behavior="button"
               onClick={handleSetDefaultCompany}
             >
-              {company.settings.name}
+              {company?.settings.name}
             </Button>
           </Element>
         </>


### PR DESCRIPTION
@beganovich @turbo124 The reason we had a broken app when the user clicked the "activate_company" button on the banner is that we did not have optional chaining in the "set_default_company" logic. So, there was a moment when the "company" object was undefined, and we tried to read "id" and "settings.name" from that undefined value (`company.id` and `company.settings.name`).

The reason you, David, were not able to see the "activate_company" banner locally is that we show the banner only for the `HOSTED` platform. Please let me know if I should remove this constraint and display the banner for both types of platforms.

Let me know your thoughts.