### PR TITLE
Fixes for recurring invoices next send date

### DIFF
--- a/src/pages/recurring-invoices/common/components/InvoiceDetails.tsx
+++ b/src/pages/recurring-invoices/common/components/InvoiceDetails.tsx
@@ -56,11 +56,7 @@ export function InvoiceDetails(props: Props) {
           <InputField
             type="date"
             onValueChange={(value) => handleChange('next_send_date', value)}
-            value={
-              recurringInvoice?.next_send_date
-                ? dayjs(recurringInvoice?.next_send_date).format('YYYY-MM-DD')
-                : dayjs().format('YYYY-MM-DD')
-            }
+            value={recurringInvoice?.next_send_date}
             min={dayjs().format('YYYY-MM-DD')}
             errorMessage={props.errors?.errors.next_send_date}
           />

--- a/src/pages/recurring-invoices/common/components/InvoiceDetails.tsx
+++ b/src/pages/recurring-invoices/common/components/InvoiceDetails.tsx
@@ -56,7 +56,7 @@ export function InvoiceDetails(props: Props) {
           <InputField
             type="date"
             onValueChange={(value) => handleChange('next_send_date', value)}
-            value={recurringInvoice?.next_send_date}
+            value={dayjs(recurringInvoice?.next_send_date).format('YYYY-MM-DD')}
             min={dayjs().format('YYYY-MM-DD')}
             errorMessage={props.errors?.errors.next_send_date}
           />

--- a/src/pages/recurring-invoices/create/Create.tsx
+++ b/src/pages/recurring-invoices/create/Create.tsx
@@ -36,6 +36,7 @@ import { useCreate, useRecurringInvoiceUtilities } from '../common/hooks';
 import { useBlankRecurringInvoiceQuery } from '../common/queries';
 import { Icon } from '$app/components/icons/Icon';
 import { MdNotStarted, MdSend } from 'react-icons/md';
+import dayjs from 'dayjs';
 
 export default function Create() {
   const { documentTitle } = useTitle('new_recurring_invoice');
@@ -112,6 +113,10 @@ export default function Create() {
 
         if (searchParams.get('client')) {
           _recurringInvoice.client_id = searchParams.get('client')!;
+        }
+
+        if (_recurringInvoice.next_send_date === '') {
+          _recurringInvoice.next_send_date = dayjs().format('YYYY-MM-DD');
         }
 
         _recurringInvoice.uses_inclusive_taxes =


### PR DESCRIPTION
This prefills the next_send_date of the recurring invoices if it's empty (on create page).