### PR TITLE
[Bugfix] Vendors Variable Typo | Generated Numbers

### DIFF
--- a/src/pages/settings/generated-numbers/vendors/Vendors.tsx
+++ b/src/pages/settings/generated-numbers/vendors/Vendors.tsx
@@ -68,9 +68,9 @@ export function Vendors() {
       <Element leftSide={t('number_counter')}>
         <InputField
           id="settings.vendor_number_counter"
-          value={companyChanges?.settings?.vendors_number_counter}
+          value={companyChanges?.settings?.vendor_number_counter}
           onChange={handleChange}
-          errorMessage={errors?.errors['settings.vendors_number_counter']}
+          errorMessage={errors?.errors['settings.vendor_number_counter']}
         />
       </Element>
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes resolving bug for not-updating `vendor_number_counter` field correctly. It was actually just typo for this variable. Let me know your thoughts.