### PR TITLE
[Bugfix] Default Quantity Functionality

### DIFF
--- a/src/common/interfaces/company.interface.ts
+++ b/src/common/interfaces/company.interface.ts
@@ -48,6 +48,7 @@ export interface Company {
   has_e_invoice_certificate: boolean;
   has_e_invoice_certificate_passphrase: boolean;
   default_password_timeout: number;
+  default_quantity: boolean;
   subdomain: string;
   client_can_register: boolean;
   invoice_task_item_description: boolean;

--- a/src/pages/invoices/common/hooks/useHandleProductChange.ts
+++ b/src/pages/invoices/common/hooks/useHandleProductChange.ts
@@ -28,7 +28,7 @@ export function useHandleProductChange(props: Props) {
     const lineItem = { ...resource.line_items[index] };
 
     lineItem.product_key = product?.product_key || product_key;
-    lineItem.quantity = product?.quantity || 0;
+    lineItem.quantity = company?.default_quantity ? 1 : product?.quantity ?? 0;
 
     if (company.fill_products) {
       lineItem.cost = product?.price || 0;


### PR DESCRIPTION
@beganovich @turbo124 The PR includes implementing functionality for the `default_quantity` property in company settings. I believe that we have now replicated the behavior of the Flutter app in the React app.

One note regarding the video in the Jira ticket, David. I believe the product you selected in the video had a quantity of `1`, which is why you ended up choosing a quantity of `1`, even though the `default_quantity` was set to `false`.

Of course, we now have the entire functionality implemented, but for that specific reason, I believe that was the case.

Let me know your thoughts.