### PR TITLE
[Bugfix] Missing Validation For Design Selectors | Custom Designs

### DIFF
--- a/src/pages/settings/invoice-design/pages/custom-designs/pages/create/Create.tsx
+++ b/src/pages/settings/invoice-design/pages/custom-designs/pages/create/Create.tsx
@@ -94,6 +94,12 @@ export default function Create() {
           <DesignSelector
             onChange={(design) => handleChange('design', design.design)}
             actionVisibility={false}
+            errorMessage={
+              errors?.errors['design.header'] ||
+              errors?.errors['design.body'] ||
+              errors?.errors['design.footer'] ||
+              errors?.errors['design.includes']
+            }
           />
         </Element>
       </Card>

--- a/src/pages/settings/invoice-design/pages/custom-designs/pages/edit/components/Settings.tsx
+++ b/src/pages/settings/invoice-design/pages/custom-designs/pages/edit/components/Settings.tsx
@@ -65,6 +65,12 @@ export function Settings(props: Props) {
           <DesignSelector
             onChange={(design) => handlePropertyChange('design', design.design)}
             actionVisibility={false}
+            errorMessage={
+              errors?.errors['design.header'] ||
+              errors?.errors['design.body'] ||
+              errors?.errors['design.footer'] ||
+              errors?.errors['design.includes']
+            }
           />
         </Element>
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the addition of missing validation for Design Selectors on Custom Designs pages. Screenshot:

<img width="1261" alt="Screenshot 2023-08-09 at 16 28 26" src="https://github.com/invoiceninja/ui/assets/51542191/d0b7e2ab-1510-457f-aa90-dfae5ff5951b">

Let me know your thoughts.