### PR TITLE
[Cleanup] Adding API Tokens Guards

### DIFF
--- a/src/pages/settings/account-management/component/Integrations.tsx
+++ b/src/pages/settings/account-management/component/Integrations.tsx
@@ -11,19 +11,24 @@
 import { Divider } from '$app/components/cards/Divider';
 import { useTranslation } from 'react-i18next';
 import { Card, ClickableElement } from '../../../../components/cards';
-import { freePlan } from '$app/common/guards/guards/free-plan';
 import { isHosted, isSelfHosted } from '$app/common/helpers';
+import { useAdmin } from '$app/common/hooks/permissions/useHasPermission';
+import { proPlan } from '$app/common/guards/guards/pro-plan';
+import { enterprisePlan } from '$app/common/guards/guards/enterprise-plan';
 
 export function Integrations() {
   const [t] = useTranslation();
 
+  const { isAdmin } = useAdmin();
+
   return (
     <Card title={t('integrations')}>
-      {((!freePlan() && isHosted()) || isSelfHosted()) && (
-        <ClickableElement to="/settings/integrations/api_tokens">
-          {t('api_tokens')}
-        </ClickableElement>
-      )}
+      {(((proPlan() || enterprisePlan()) && isHosted()) || isSelfHosted()) &&
+        isAdmin && (
+          <ClickableElement to="/settings/integrations/api_tokens">
+            {t('api_tokens')}
+          </ClickableElement>
+        )}
 
       <ClickableElement to="/settings/integrations/api_webhooks">
         {t('api_webhooks')}

--- a/src/pages/settings/account-management/component/Integrations.tsx
+++ b/src/pages/settings/account-management/component/Integrations.tsx
@@ -11,15 +11,19 @@
 import { Divider } from '$app/components/cards/Divider';
 import { useTranslation } from 'react-i18next';
 import { Card, ClickableElement } from '../../../../components/cards';
+import { freePlan } from '$app/common/guards/guards/free-plan';
+import { isHosted, isSelfHosted } from '$app/common/helpers';
 
 export function Integrations() {
   const [t] = useTranslation();
 
   return (
     <Card title={t('integrations')}>
-      <ClickableElement to="/settings/integrations/api_tokens">
-        {t('api_tokens')}
-      </ClickableElement>
+      {((!freePlan() && isHosted()) || isSelfHosted()) && (
+        <ClickableElement to="/settings/integrations/api_tokens">
+          {t('api_tokens')}
+        </ClickableElement>
+      )}
 
       <ClickableElement to="/settings/integrations/api_webhooks">
         {t('api_webhooks')}

--- a/src/pages/settings/routes.tsx
+++ b/src/pages/settings/routes.tsx
@@ -15,6 +15,7 @@ import { plan } from '$app/common/guards/guards/plan';
 import * as Settings from './index';
 import { isDemo } from '$app/common/helpers';
 import { invoiceDesignRoutes } from '$app/pages/settings/invoice-design/routes';
+import { or } from '$app/common/guards/guards/or';
 
 export const settingsRoutes = (
   <Route path="/settings">
@@ -184,9 +185,33 @@ export const settingsRoutes = (
       </Route>
       <Route path="integrations">
         <Route path="api_tokens">
-          <Route path="" element={<Settings.ApiTokens />} />
-          <Route path="create" element={<Settings.CreateApiToken />} />
-          <Route path=":id/edit" element={<Settings.EditApiToken />} />
+          <Route
+            path=""
+            element={
+              <Guard
+                guards={[or(plan('enterprise'), plan('pro'))]}
+                component={<Settings.ApiTokens />}
+              />
+            }
+          />
+          <Route
+            path="create"
+            element={
+              <Guard
+                guards={[or(plan('enterprise'), plan('pro'))]}
+                component={<Settings.CreateApiToken />}
+              />
+            }
+          />
+          <Route
+            path=":id/edit"
+            element={
+              <Guard
+                guards={[or(plan('enterprise'), plan('pro'))]}
+                component={<Settings.EditApiToken />}
+              />
+            }
+          />
         </Route>
         <Route path="api_webhooks">
           <Route path="" element={<Settings.ApiWebhooks />} />

--- a/src/pages/settings/routes.tsx
+++ b/src/pages/settings/routes.tsx
@@ -189,7 +189,7 @@ export const settingsRoutes = (
             path=""
             element={
               <Guard
-                guards={[or(plan('enterprise'), plan('pro'))]}
+                guards={[or(plan('enterprise'), plan('pro')), admin()]}
                 component={<Settings.ApiTokens />}
               />
             }
@@ -198,7 +198,7 @@ export const settingsRoutes = (
             path="create"
             element={
               <Guard
-                guards={[or(plan('enterprise'), plan('pro'))]}
+                guards={[or(plan('enterprise'), plan('pro')), admin()]}
                 component={<Settings.CreateApiToken />}
               />
             }
@@ -207,7 +207,7 @@ export const settingsRoutes = (
             path=":id/edit"
             element={
               <Guard
-                guards={[or(plan('enterprise'), plan('pro'))]}
+                guards={[or(plan('enterprise'), plan('pro')), admin()]}
                 component={<Settings.EditApiToken />}
               />
             }


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the addition of guards and conditions for accessing API Tokens routes. As a result, only SELF-HOSTED users or users with a PRO/ENTERPRISE plan will be able to access these routes. Free plan users will NOT have access to this section of the app. Below is a screenshot of the hidden button to access these routes:

<img width="1261" alt="Screenshot 2023-08-10 at 15 37 00" src="https://github.com/invoiceninja/ui/assets/51542191/c4ceb1f4-6d1b-4229-a407-2530314198f7">

Let me know your thoughts.