### PR TITLE
Fixes for combo box logic

### DIFF
--- a/src/components/forms/Combobox.tsx
+++ b/src/components/forms/Combobox.tsx
@@ -107,7 +107,7 @@ export function ComboboxStatic({
         return onEmptyValues(query);
       }
 
-      if (filteredValues.length === 0) {
+      if (filteredValues.length <= 3) {
         return onEmptyValues(query);
       }
     },


### PR DESCRIPTION

instead of searching when the result list hits 0, we increment this to 3, so that we preempt the search results, improves user experience when the string partially matching existing records, but the exact record is not shown.