### PR TITLE
[Bugfix] Print PDF | Firefox

### DIFF
--- a/src/pages/invoices/common/hooks/usePrintPdf.ts
+++ b/src/pages/invoices/common/hooks/usePrintPdf.ts
@@ -17,8 +17,20 @@ interface Props {
   entity: 'invoice' | 'quote' | 'credit' | 'purchase_order';
 }
 
-export function usePrintPdf({ entity }: Props) {
+export const usePrintPdf = ({ entity }: Props) => {
   const queryClient = useQueryClient();
+
+  const appendIframe = (element: HTMLElement) => {
+    return new Promise<void>((resolve) => {
+      const onLoad = () => {
+        element.removeEventListener('load', onLoad);
+        resolve();
+      };
+
+      document.body.appendChild(element);
+      element.addEventListener('load', onLoad);
+    });
+  };
 
   return (resourceIds: string[]) => {
     if (!resourceIds.length) {
@@ -33,7 +45,7 @@ export function usePrintPdf({ entity }: Props) {
         endpoint(`/api/v1/${entity}s/bulk`),
         { action: 'bulk_print', ids: resourceIds },
         { responseType: 'arraybuffer' }
-      ).then((response) => {
+      ).then(async (response) => {
         const blob = new Blob([response.data], { type: 'application/pdf' });
         const url = URL.createObjectURL(blob);
 
@@ -42,7 +54,7 @@ export function usePrintPdf({ entity }: Props) {
         iframeElement.style.display = 'none';
         iframeElement.src = url;
 
-        document.body.appendChild(iframeElement);
+        await appendIframe(iframeElement);
 
         if (iframeElement && iframeElement.contentWindow) {
           iframeElement.contentWindow.focus();
@@ -53,4 +65,4 @@ export function usePrintPdf({ entity }: Props) {
       })
     );
   };
-}
+};


### PR DESCRIPTION
@beganovich @turbo124 The PR addresses a bug related to printing PDFs in the Firefox browser. The reason for encountering blank PDFs during printing was the inconsistent behavior of `document.body.appendChild` across various browsers. Particularly in the case of `Firefox`, there was a slight delay when appending the `iframe` element into the `body` of the `document`, leading to the issue of blank PDFs. The problem has been resolved by utilizing an asynchronous approach to ensure the proper appending of this element within the document's body. Here is the screenshot:

![Screenshot 2023-08-15 at 18 53 53](https://github.com/invoiceninja/ui/assets/51542191/aceb1f12-ae28-486c-a72c-28c67434dc98)

Let me know your thoughts. 