### PR TITLE
[Bugfix] Quote | Credit Custom Fields

### DIFF
--- a/src/common/hooks/useEntityCustomFields.ts
+++ b/src/common/hooks/useEntityCustomFields.ts
@@ -22,9 +22,7 @@ export type Entity =
   | 'project'
   | 'task'
   | 'vendor'
-  | 'expense'
-  | 'quote'
-  | 'credit';
+  | 'expense';
 
 interface Params {
   entity: Entity;

--- a/src/pages/credits/common/components/CreditDetails.tsx
+++ b/src/pages/credits/common/components/CreditDetails.tsx
@@ -75,22 +75,22 @@ export function CreditDetails(props: Props) {
           </Element>
         )}
 
-        {credit && company?.custom_fields?.credit1 && (
+        {credit && company?.custom_fields?.invoice1 && (
           <CustomField
             field="credit1"
             defaultValue={credit?.custom_value1 || ''}
-            value={company.custom_fields.credit1}
+            value={company.custom_fields.invoice1}
             onValueChange={(value) =>
               handleChange('custom_value1', String(value))
             }
           />
         )}
 
-        {credit && company?.custom_fields?.credit2 && (
+        {credit && company?.custom_fields?.invoice2 && (
           <CustomField
             field="credit2"
             defaultValue={credit?.custom_value2 || ''}
-            value={company.custom_fields.credit2}
+            value={company.custom_fields.invoice2}
             onValueChange={(value) =>
               handleChange('custom_value2', String(value))
             }
@@ -145,22 +145,22 @@ export function CreditDetails(props: Props) {
           </div>
         </Element>
 
-        {credit && company?.custom_fields?.credit3 && (
+        {credit && company?.custom_fields?.invoice3 && (
           <CustomField
             field="credit3"
             defaultValue={credit?.custom_value3 || ''}
-            value={company.custom_fields.credit3}
+            value={company.custom_fields.invoice3}
             onValueChange={(value) =>
               handleChange('custom_value3', String(value))
             }
           />
         )}
 
-        {credit && company?.custom_fields?.credit4 && (
+        {credit && company?.custom_fields?.invoice4 && (
           <CustomField
             field="credit4"
             defaultValue={credit?.custom_value4 || ''}
-            value={company.custom_fields.credit4}
+            value={company.custom_fields.invoice4}
             onValueChange={(value) =>
               handleChange('custom_value4', String(value))
             }

--- a/src/pages/credits/common/hooks.tsx
+++ b/src/pages/credits/common/hooks.tsx
@@ -577,7 +577,7 @@ export const defaultColumns: string[] = [
 export function useAllCreditColumns() {
   const [firstCustom, secondCustom, thirdCustom, fourthCustom] =
     useEntityCustomFields({
-      entity: 'credit',
+      entity: 'invoice',
     });
 
   const creditColumns = [
@@ -637,7 +637,7 @@ export function useCreditColumns() {
 
   const [firstCustom, secondCustom, thirdCustom, fourthCustom] =
     useEntityCustomFields({
-      entity: 'credit',
+      entity: 'invoice',
     });
 
   const columns: DataTableColumnsExtended<Credit, CreditColumns> = [

--- a/src/pages/quotes/common/components/QuoteDetails.tsx
+++ b/src/pages/quotes/common/components/QuoteDetails.tsx
@@ -74,22 +74,22 @@ export function QuoteDetails(props: Props) {
           </Element>
         )}
 
-        {quote && company?.custom_fields?.quote1 && (
+        {quote && company?.custom_fields?.invoice1 && (
           <CustomField
             field="quote1"
             defaultValue={quote?.custom_value1 || ''}
-            value={company.custom_fields.quote1}
+            value={company.custom_fields.invoice1}
             onValueChange={(value) =>
               handleChange('custom_value1', String(value))
             }
           />
         )}
 
-        {quote && company?.custom_fields?.quote2 && (
+        {quote && company?.custom_fields?.invoice2 && (
           <CustomField
             field="quote2"
             defaultValue={quote?.custom_value2 || ''}
-            value={company.custom_fields.quote2}
+            value={company.custom_fields.invoice2}
             onValueChange={(value) =>
               handleChange('custom_value2', String(value))
             }
@@ -144,22 +144,22 @@ export function QuoteDetails(props: Props) {
           </div>
         </Element>
 
-        {quote && company?.custom_fields?.quote3 && (
+        {quote && company?.custom_fields?.invoice3 && (
           <CustomField
             field="quote3"
             defaultValue={quote?.custom_value3 || ''}
-            value={company.custom_fields.quote3}
+            value={company.custom_fields.invoice3}
             onValueChange={(value) =>
               handleChange('custom_value3', String(value))
             }
           />
         )}
 
-        {quote && company?.custom_fields?.quote4 && (
+        {quote && company?.custom_fields?.invoice4 && (
           <CustomField
             field="quote4"
             defaultValue={quote?.custom_value4 || ''}
-            value={company.custom_fields.quote4}
+            value={company.custom_fields.invoice4}
             onValueChange={(value) =>
               handleChange('custom_value4', String(value))
             }

--- a/src/pages/quotes/common/hooks.tsx
+++ b/src/pages/quotes/common/hooks.tsx
@@ -552,7 +552,7 @@ export const defaultColumns: string[] = [
 export function useAllQuoteColumns() {
   const [firstCustom, secondCustom, thirdCustom, fourthCustom] =
     useEntityCustomFields({
-      entity: 'quote',
+      entity: 'invoice',
     });
 
   const quoteColumns = [
@@ -625,7 +625,7 @@ export function useQuoteColumns() {
 
   const [firstCustom, secondCustom, thirdCustom, fourthCustom] =
     useEntityCustomFields({
-      entity: 'quote',
+      entity: 'invoice',
     });
 
   const columns: DataTableColumnsExtended<Quote, QuoteColumns> = [

--- a/src/pages/settings/invoice-design/pages/general-settings/components/CreditDetails.tsx
+++ b/src/pages/settings/invoice-design/pages/general-settings/components/CreditDetails.tsx
@@ -25,19 +25,19 @@ export function CreditDetails() {
     { value: '$credit.total', label: t('credit_total') },
     {
       value: '$credit.custom1',
-      label: customField('credit1').label() || t('custom1'),
+      label: customField('invoice1').label() || t('custom1'),
     },
     {
       value: '$credit.custom2',
-      label: customField('credit2').label() || t('custom2'),
+      label: customField('invoice2').label() || t('custom2'),
     },
     {
       value: '$credit.custom3',
-      label: customField('credit3').label() || t('custom3'),
+      label: customField('invoice3').label() || t('custom3'),
     },
     {
       value: '$credit.custom4',
-      label: customField('credit4').label() || t('custom4'),
+      label: customField('invoice4').label() || t('custom4'),
     },
     { value: '$client.balance', label: t('client_balance') },
   ];

--- a/src/pages/settings/invoice-design/pages/general-settings/components/QuoteDetails.tsx
+++ b/src/pages/settings/invoice-design/pages/general-settings/components/QuoteDetails.tsx
@@ -25,19 +25,19 @@ export function QuoteDetails() {
     { value: '$quote.total', label: t('quote_total') },
     {
       value: '$quote.custom1',
-      label: customField('quote1').label() || t('custom1'),
+      label: customField('invoice1').label() || t('custom1'),
     },
     {
       value: '$quote.custom2',
-      label: customField('quote2').label() || t('custom2'),
+      label: customField('invoice2').label() || t('custom2'),
     },
     {
       value: '$quote.custom3',
-      label: customField('quote3').label() || t('custom3'),
+      label: customField('invoice3').label() || t('custom3'),
     },
     {
       value: '$quote.custom4',
-      label: customField('quote4').label() || t('custom4'),
+      label: customField('invoice4').label() || t('custom4'),
     },
     { value: '$client.balance', label: t('client_balance') },
   ];


### PR DESCRIPTION
@beganovich @turbo124 The PR includes bug fixes for `custom_fields` related to the Credit and Quote entities. This encompasses table pages, create/edit pages. Additionally, I identified another bug on the `invoice_design` page under the `general_settings` tab, where incorrect `custom_fields` were also being applied. Let me know your thoughts.