### PR TITLE
[Feature] Custom Bulk Actions Implementation | Recurring Expense

### DIFF
--- a/src/common/queries/documents.ts
+++ b/src/common/queries/documents.ts
@@ -34,7 +34,7 @@ export const useDocumentsBulk = () => {
   return (ids: string[], action: 'download') => {
     toast.processing();
 
-    request('POST', endpoint('/api/v1/documents?per_page=100'), {
+    request('POST', endpoint('/api/v1/documents/bulk?per_page=100'), {
       action,
       ids,
     }).then(() => toast.success('exported_data'));

--- a/src/pages/recurring-expenses/common/hooks.tsx
+++ b/src/pages/recurring-expenses/common/hooks.tsx
@@ -515,7 +515,7 @@ export function useActions() {
       isEditPage &&
       getEntityState(recurringExpense) === EntityState.Active && (
         <DropdownElement
-          onClick={() => bulk(recurringExpense.id, 'archive')}
+          onClick={() => bulk([recurringExpense.id], 'archive')}
           icon={<Icon element={MdArchive} />}
         >
           {t('archive')}
@@ -526,7 +526,7 @@ export function useActions() {
       (getEntityState(recurringExpense) === EntityState.Archived ||
         getEntityState(recurringExpense) === EntityState.Deleted) && (
         <DropdownElement
-          onClick={() => bulk(recurringExpense.id, 'restore')}
+          onClick={() => bulk([recurringExpense.id], 'restore')}
           icon={<Icon element={MdRestore} />}
         >
           {t('restore')}
@@ -537,7 +537,7 @@ export function useActions() {
       (getEntityState(recurringExpense) === EntityState.Active ||
         getEntityState(recurringExpense) === EntityState.Archived) && (
         <DropdownElement
-          onClick={() => bulk(recurringExpense.id, 'delete')}
+          onClick={() => bulk([recurringExpense.id], 'delete')}
           icon={<Icon element={MdDelete} />}
         >
           {t('delete')}

--- a/src/pages/recurring-expenses/common/hooks/useCustomBulkActions.tsx
+++ b/src/pages/recurring-expenses/common/hooks/useCustomBulkActions.tsx
@@ -1,0 +1,109 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { RecurringExpenseStatus } from '$app/common/enums/recurring-expense-status';
+import { toast } from '$app/common/helpers/toast/toast';
+import { RecurringExpense } from '$app/common/interfaces/recurring-expense';
+import { useDocumentsBulk } from '$app/common/queries/documents';
+import { useBulk } from '$app/common/queries/recurring-expense';
+import { CustomBulkAction } from '$app/components/DataTable';
+import { DropdownElement } from '$app/components/dropdown/DropdownElement';
+import { Icon } from '$app/components/icons/Icon';
+import { Dispatch, SetStateAction } from 'react';
+import { useTranslation } from 'react-i18next';
+import { MdDownload, MdNotStarted, MdStopCircle } from 'react-icons/md';
+
+export const useCustomBulkActions = () => {
+  const [t] = useTranslation();
+
+  const bulk = useBulk();
+
+  const documentsBulk = useDocumentsBulk();
+
+  const shouldDownloadDocuments = (recurringExpenses: RecurringExpense[]) => {
+    return recurringExpenses.some(({ documents }) => documents.length);
+  };
+
+  const getDocumentsIds = (recurringExpenses: RecurringExpense[]) => {
+    return recurringExpenses.flatMap(({ documents }) =>
+      documents.map(({ id }) => id)
+    );
+  };
+
+  const handleDownloadDocuments = (
+    selectedRecurringExpenses: RecurringExpense[],
+    setSelected?: Dispatch<SetStateAction<string[]>>
+  ) => {
+    const recurringExpenseIds = getDocumentsIds(selectedRecurringExpenses);
+
+    documentsBulk(recurringExpenseIds, 'download');
+    setSelected?.([]);
+  };
+
+  const shouldShowStartAction = (recurringExpenses: RecurringExpense[]) => {
+    return recurringExpenses.every(
+      ({ status_id }) =>
+        status_id === RecurringExpenseStatus.Draft ||
+        status_id === RecurringExpenseStatus.Paused
+    );
+  };
+
+  const shouldShowStopAction = (recurringExpenses: RecurringExpense[]) => {
+    return recurringExpenses.every(
+      ({ status_id }) => status_id === RecurringExpenseStatus.Active
+    );
+  };
+
+  const customBulkActions: CustomBulkAction<RecurringExpense>[] = [
+    (selectedIds, selectedRecurringExpenses, setSelected) =>
+      selectedRecurringExpenses &&
+      shouldShowStartAction(selectedRecurringExpenses) && (
+        <DropdownElement
+          onClick={() => {
+            bulk(selectedIds, 'start');
+
+            setSelected?.([]);
+          }}
+          icon={<Icon element={MdNotStarted} />}
+        >
+          {t('start')}
+        </DropdownElement>
+      ),
+    (selectedIds, selectedRecurringExpenses, setSelected) =>
+      selectedRecurringExpenses &&
+      shouldShowStopAction(selectedRecurringExpenses) && (
+        <DropdownElement
+          onClick={() => {
+            bulk(selectedIds, 'stop');
+
+            setSelected?.([]);
+          }}
+          icon={<Icon element={MdStopCircle} />}
+        >
+          {t('stop')}
+        </DropdownElement>
+      ),
+    (_, selectedRecurringExpenses, setSelected) => (
+      <DropdownElement
+        onClick={() =>
+          selectedRecurringExpenses &&
+          shouldDownloadDocuments(selectedRecurringExpenses)
+            ? handleDownloadDocuments(selectedRecurringExpenses, setSelected)
+            : toast.error('no_documents_to_download')
+        }
+        icon={<Icon element={MdDownload} />}
+      >
+        {t('documents')}
+      </DropdownElement>
+    ),
+  ];
+
+  return customBulkActions;
+};

--- a/src/pages/recurring-expenses/index/RecurringExpenses.tsx
+++ b/src/pages/recurring-expenses/index/RecurringExpenses.tsx
@@ -19,6 +19,7 @@ import {
   useRecurringExpenseColumns,
 } from '../common/hooks';
 import { permission } from '$app/common/guards/guards/permission';
+import { useCustomBulkActions } from '../common/hooks/useCustomBulkActions';
 
 export default function RecurringExpenses() {
   useTitle('recurring_expenses');
@@ -35,6 +36,8 @@ export default function RecurringExpenses() {
 
   const recurringExpenseColumns = useAllRecurringExpenseColumns();
 
+  const customBulkActions = useCustomBulkActions();
+
   return (
     <Default
       title={t('recurring_expenses')}
@@ -50,6 +53,7 @@ export default function RecurringExpenses() {
         linkToCreate="/recurring_expenses/create"
         linkToEdit="/recurring_expenses/:id/edit"
         customActions={actions}
+        customBulkActions={customBulkActions}
         withResourcefulActions
         leftSideChevrons={
           <DataTableColumnsPicker


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of custom bulk actions for the `Recurring Expense` entity.

I noticed a small bug in the Flutter app while comparing. When stopping and starting a recurring expense, there is actually a message for a recurring invoice.

Note: We are missing two keywords in the translation files: `started_recurring_expense` and `stopped_recurring_expense`. If you agree with me, please just add them.

Let me know your thoughts.