### PR TITLE
[Bugfix] Missing Wepay Logo

### DIFF
--- a/src/pages/settings/gateways/create/Create.tsx
+++ b/src/pages/settings/gateways/create/Create.tsx
@@ -55,6 +55,7 @@ export const gatewaysDetails = [
   { name: 'checkoutcom', key: '3758e7f7c6f4cecf0f4f348b9a00f456' },
   { name: 'payfast', key: 'd6814fc83f45d2935e7777071e629ef9' },
   { name: 'eway', key: '944c20175bbe6b9972c05bcfe294c2c7' },
+  { name: 'wepay', key: '8fdeed552015b3c7b44ed6c8ebd9e992' },
 ];
 
 export function Create() {


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adding the missing part of the logic for displaying the `WePay` logo in the quick creation section. Screenshot:

![Screenshot 2023-09-03 at 18 18 15](https://github.com/invoiceninja/ui/assets/51542191/913220bb-de9b-4c1f-aea9-066ff3d873ac)

Let me know your thoughts.