### PR TITLE
[Cleanup] User Details Preferences Endpoint Adjusting

### DIFF
--- a/src/pages/settings/user/UserDetails.tsx
+++ b/src/pages/settings/user/UserDetails.tsx
@@ -69,27 +69,32 @@ export function UserDetails() {
     toast.processing();
     setErrors(undefined);
 
-    const requests = isAdmin
-      ? [
-          request(
-            'PUT',
-            endpoint('/api/v1/users/:id?include=company_user', {
+    const requests = [
+      request(
+        'PUT',
+        endpoint('/api/v1/users/:id?include=company_user', {
+          id: user!.id,
+        }),
+        userState.changes,
+        { headers: { 'X-Api-Password': password } }
+      ),
+    ];
+
+    if (!isAdmin) {
+      requests.push(
+        request(
+          'PUT',
+          endpoint(
+            '/api/v1/company_users/:id/preferences?include=company_user',
+            {
               id: user!.id,
-            }),
-            userState.changes,
-            { headers: { 'X-Api-Password': password } }
+            }
           ),
-        ]
-      : [
-          request(
-            'PUT',
-            endpoint('/api/v1/company_users/:id/preferences', {
-              id: user!.id,
-            }),
-            userState.changes,
-            { headers: { 'X-Api-Password': password } }
-          ),
-        ];
+          { react_settings: userState.changes.company_user?.react_settings },
+          { headers: { 'X-Api-Password': password } }
+        )
+      );
+    }
 
     if (isAdmin) {
       requests.push(

--- a/src/pages/settings/user/UserDetails.tsx
+++ b/src/pages/settings/user/UserDetails.tsx
@@ -69,14 +69,27 @@ export function UserDetails() {
     toast.processing();
     setErrors(undefined);
 
-    const requests = [
-      request(
-        'PUT',
-        endpoint('/api/v1/users/:id?include=company_user', { id: user!.id }),
-        userState.changes,
-        { headers: { 'X-Api-Password': password } }
-      ),
-    ];
+    const requests = isAdmin
+      ? [
+          request(
+            'PUT',
+            endpoint('/api/v1/users/:id?include=company_user', {
+              id: user!.id,
+            }),
+            userState.changes,
+            { headers: { 'X-Api-Password': password } }
+          ),
+        ]
+      : [
+          request(
+            'PUT',
+            endpoint('/api/v1/company_users/:id/preferences', {
+              id: user!.id,
+            }),
+            userState.changes,
+            { headers: { 'X-Api-Password': password } }
+          ),
+        ];
 
     if (isAdmin) {
       requests.push(


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adjustments to the endpoint on the User Details page regarding the user's permissions. So, if the user `IS an admin`, the endpoint will be standard: `'/api/v1/users/:id?include=company_user'`, but if he `IS NOT an admin`, the endpoint will be: `'/api/v1/company_users/:id/preferences'`. Let me know your thoughts.