### PR TITLE
[Cleanup] Payment Creation Page && Combobox Selector Improvements

### DIFF
--- a/src/components/forms/Combobox.tsx
+++ b/src/components/forms/Combobox.tsx
@@ -112,6 +112,7 @@ export function ComboboxStatic({
   );
 
   const comboboxRef = useRef<HTMLDivElement>(null);
+  const comboboxInputRef = useRef<HTMLInputElement>(null);
 
   useClickAway(comboboxRef, () => {
     setIsOpen(false);
@@ -149,6 +150,12 @@ export function ComboboxStatic({
     if (clearInputAfterSelection) {
       setSelectedValue(null);
       setQuery('');
+    }
+
+    setIsOpen(false);
+
+    if (comboboxInputRef.current) {
+      comboboxInputRef.current.blur();
     }
   }, [selectedValue]);
 
@@ -209,6 +216,7 @@ export function ComboboxStatic({
           >
             <HeadlessCombobox.Input
               data-testid="combobox-input-field"
+              ref={comboboxInputRef}
               className="w-full border-0 rounded py-1.5 pl-3 pr-10 shadow-sm sm:text-sm sm:leading-6"
               onChange={(event) => setQuery(event.target.value)}
               displayValue={(entry: Nullable<Entry>) =>
@@ -288,7 +296,7 @@ export function ComboboxStatic({
                   value={entry}
                   className={() =>
                     classNames(
-                      'min-w-[19rem] relative cursor-default select-none py-2 pl-3 pr-9'
+                      ' min-w-[19rem] relative cursor-default select-none py-2 pl-3 pr-9 '
                       // active ? 'bg-gray-100 text-gray-900' : 'text-gray-900'
                     )
                   }

--- a/src/components/forms/Combobox.tsx
+++ b/src/components/forms/Combobox.tsx
@@ -154,7 +154,7 @@ export function ComboboxStatic({
 
     setIsOpen(false);
 
-    if (comboboxInputRef.current) {
+    if (comboboxInputRef?.current) {
       comboboxInputRef.current.blur();
     }
   }, [selectedValue]);

--- a/src/components/forms/Combobox.tsx
+++ b/src/components/forms/Combobox.tsx
@@ -294,12 +294,8 @@ export function ComboboxStatic({
                   }}
                   key={entry.id}
                   value={entry}
-                  className={() =>
-                    classNames(
-                      ' min-w-[19rem] relative cursor-default select-none py-2 pl-3 pr-9 '
-                      // active ? 'bg-gray-100 text-gray-900' : 'text-gray-900'
-                    )
-                  }
+                  className="min-w-[19rem] relative cursor-default select-none py-2 pl-3 pr-9"
+                  // active ? 'bg-gray-100 text-gray-900' : 'text-gray-900'
                   style={{ color: colors.$3 }}
                 >
                   {({ selected }) => (

--- a/src/components/forms/InputField.tsx
+++ b/src/components/forms/InputField.tsx
@@ -36,6 +36,7 @@ interface Props extends CommonProps {
   step?: string;
   maxLength?: number;
   autoComplete?: string;
+  withoutLabelWrapping?: boolean;
 }
 
 export function InputField(props: Props) {
@@ -60,7 +61,12 @@ export function InputField(props: Props) {
   return (
     <section>
       {props.label && (
-        <InputLabel className="mb-2" for={props.id}>
+        <InputLabel
+          className={classNames('mb-2', {
+            'whitespace-nowrap': props.withoutLabelWrapping,
+          })}
+          for={props.id}
+        >
           {props.label}
           {props.required && <span className="ml-1 text-red-600">*</span>}
         </InputLabel>
@@ -68,7 +74,12 @@ export function InputField(props: Props) {
 
       <div className="relative">
         <DebounceInput
-          style={{ backgroundColor: colors.$1, borderColor: colors.$5, color: colors.$3, ...props.style }}
+          style={{
+            backgroundColor: colors.$1,
+            borderColor: colors.$5,
+            color: colors.$3,
+            ...props.style,
+          }}
           min={props.min}
           maxLength={props.maxLength}
           autoComplete={props.autoComplete || 'new-password'}

--- a/src/pages/payments/create/Create.tsx
+++ b/src/pages/payments/create/Create.tsx
@@ -227,6 +227,8 @@ export default function Create() {
               onClearButtonClick={() => {
                 handleChange('client_id', '');
                 handleChange('currency_id', '');
+                handleChange('invoices', []);
+                handleChange('credits', []);
               }}
               errorMessage={errors?.errors.client_id}
               defaultValue={payment?.client_id}
@@ -264,7 +266,7 @@ export default function Create() {
             payment.invoices.map((invoice, index) => (
               <Element key={index}>
                 <div className="flex flex-col">
-                  <div className="flex items-center space-x-2">
+                  <div className="flex items-end space-x-2">
                     <ComboboxAsync<Invoice>
                       inputOptions={{
                         value: invoice.invoice_id,
@@ -287,6 +289,13 @@ export default function Create() {
                           ? handleExistingInvoiceChange(entry.resource, index)
                           : null
                       }
+                      exclude={collect(
+                        payment.invoices.filter(
+                          ({ invoice_id }) => invoice_id !== invoice.invoice_id
+                        )
+                      )
+                        .pluck('invoice_id')
+                        .toArray()}
                     />
 
                     <InputField
@@ -299,12 +308,13 @@ export default function Create() {
                       }
                       className="w-full"
                       value={invoice.amount}
+                      withoutLabelWrapping
                     />
 
                     <Button
                       behavior="button"
                       type="minimal"
-                      className="mt-6"
+                      className="self-center mt-6"
                       onClick={() => handleDeletingInvoice(invoice._id)}
                     >
                       <X />
@@ -356,6 +366,7 @@ export default function Create() {
                 exclude={collect(payment.invoices)
                   .pluck('invoice_id')
                   .toArray()}
+                clearInputAfterSelection
               />
             </Element>
           )}
@@ -367,7 +378,7 @@ export default function Create() {
             payment.credits.map((credit, index) => (
               <Element key={index}>
                 <div className="flex flex-col">
-                  <div className="flex items-center space-x-2">
+                  <div className="flex items-end space-x-2">
                     <ComboboxAsync<Credit>
                       inputOptions={{
                         value: credit.credit_id,
@@ -398,6 +409,13 @@ export default function Create() {
                           ? handleExistingCreditChange(entry.resource, index)
                           : null
                       }
+                      exclude={collect(
+                        payment.credits.filter(
+                          ({ credit_id }) => credit_id !== credit.credit_id
+                        )
+                      )
+                        .pluck('credit_id')
+                        .toArray()}
                     />
 
                     <InputField
@@ -410,12 +428,13 @@ export default function Create() {
                       }
                       className="w-full"
                       value={credit.amount}
+                      withoutLabelWrapping
                     />
 
                     <Button
                       behavior="button"
                       type="minimal"
-                      className="mt-6"
+                      className="self-center mt-6"
                       onClick={() => handleDeletingCredit(credit._id)}
                     >
                       <X />
@@ -465,6 +484,7 @@ export default function Create() {
                   entry.resource ? handleCreditChange(entry.resource) : null
                 }
                 exclude={collect(payment.credits).pluck('credit_id').toArray()}
+                clearInputAfterSelection
               />
             </Element>
           )}

--- a/src/pages/payments/create/Create.tsx
+++ b/src/pages/payments/create/Create.tsx
@@ -223,6 +223,8 @@ export default function Create() {
               onChange={(client) => {
                 handleChange('client_id', client?.id as string);
                 handleChange('currency_id', client?.settings.currency_id);
+                handleChange('invoices', []);
+                handleChange('credits', []);
               }}
               onClearButtonClick={() => {
                 handleChange('client_id', '');


### PR DESCRIPTION
@beganovich @turbo124 The PR includes a couple of improvements:

- The dropdown of the combobox component closes after selecting a value
- Unable to select the same invoice/credit twice from the dropdown menus on the payment creation page
- Setting the `invoices` and `credits` properties in the Payment object to an empty array after clearing the value from the Client combobox
- Resolving a bug with classes in the Combobox Component (as explained in the comment)

Let me know your thoughts.