### PR TITLE
[Cleanup] Increase Prices Action | Percent Field Changing Type To Number

### DIFF
--- a/src/pages/recurring-invoices/common/components/IncreasePricesAction.tsx
+++ b/src/pages/recurring-invoices/common/components/IncreasePricesAction.tsx
@@ -63,6 +63,7 @@ export const IncreasePricesAction = (props: Props) => {
       >
         <InputField
           label={t('percent')}
+          type="number"
           value={increasingPercent}
           onValueChange={(value) => {
             setIncreasingPercent(Number(value));


### PR DESCRIPTION
@beganovich @turbo124 The PR includes changing the type for the `percent` field on the "Increase Prices" action for recurring invoices. This will require the user to enter a numeric value instead of allowing the possibility of a string value. Screenshot:

![Screenshot 2023-09-13 at 19 24 06](https://github.com/invoiceninja/ui/assets/51542191/5d83b3b3-c7d9-43ff-8d34-7a4e5cb48603)

Let me know your thoughts.