### PR TITLE
[Bugfix] Property Value '0' When All Gateways Are Removed | Group & Client Settings

### DIFF
--- a/src/pages/settings/gateways/common/components/GatewaysTable.tsx
+++ b/src/pages/settings/gateways/common/components/GatewaysTable.tsx
@@ -46,6 +46,7 @@ import Select, { StylesConfig } from 'react-select';
 import { useColorScheme } from '$app/common/colors';
 import { Settings } from '$app/common/interfaces/company.interface';
 import { useHandleCurrentCompanyChangeProperty } from '$app/pages/settings/common/hooks/useHandleCurrentCompanyChange';
+import { useCurrentSettingsLevel } from '$app/common/hooks/useCurrentSettingsLevel';
 
 interface Params {
   includeRemoveAction: boolean;
@@ -55,6 +56,8 @@ export function GatewaysTable(params: Params) {
   const [t] = useTranslation();
 
   const colors = useColorScheme();
+
+  const { isCompanySettingsActive } = useCurrentSettingsLevel();
 
   const handleChange = useHandleCurrentCompanyChangeProperty();
 
@@ -118,13 +121,13 @@ export function GatewaysTable(params: Params) {
     return STRIPE_CONNECT === gateway.gateway_key && !gatewayConfig.account_id;
   };
 
-  const handleSaveBulkActionsChanges = async (ids: string[]) => {
+  const handleSaveBulkActionsChanges = (ids: string[]) => {
     if (companyChanges?.settings.company_gateway_ids) {
       const numberOfGateways: number = (
         companyChanges?.settings as Settings
       ).company_gateway_ids.split(',').length;
 
-      if (numberOfGateways > 1) {
+      if (numberOfGateways > 1 || isCompanySettingsActive) {
         handleChange(
           'settings.company_gateway_ids',
           currentGateways

--- a/src/pages/settings/gateways/common/components/GatewaysTable.tsx
+++ b/src/pages/settings/gateways/common/components/GatewaysTable.tsx
@@ -238,9 +238,9 @@ export function GatewaysTable(params: Params) {
           <Dropdown label={t('more_actions')} disabled={!selected.length}>
             <DropdownElement
               onClick={() => {
-                bulk(selected, 'archive').then(() => {
-                  handleSaveBulkActionsChanges(selected);
-                });
+                bulk(selected, 'archive').then(() =>
+                  handleSaveBulkActionsChanges(selected)
+                );
 
                 handleDeselect();
               }}

--- a/src/pages/settings/gateways/common/hooks/useGatewayUtilities.ts
+++ b/src/pages/settings/gateways/common/hooks/useGatewayUtilities.ts
@@ -12,10 +12,9 @@ import { useCompanyChanges } from '$app/common/hooks/useCompanyChanges';
 import { useCurrentSettingsLevel } from '$app/common/hooks/useCurrentSettingsLevel';
 import { CompanyGateway } from '$app/common/interfaces/company-gateway';
 import { useCompanyGatewaysQuery } from '$app/common/queries/company-gateways';
-import { updateChanges } from '$app/common/stores/slices/company-users';
 import { SelectOption } from '$app/components/datatables/Actions';
+import { useHandleCurrentCompanyChangeProperty } from '$app/pages/settings/common/hooks/useHandleCurrentCompanyChange';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
-import { useDispatch } from 'react-redux';
 import { MultiValue, SingleValue } from 'react-select';
 
 interface Params {
@@ -23,13 +22,13 @@ interface Params {
   setCurrentGateways: Dispatch<SetStateAction<CompanyGateway[]>>;
 }
 export function useGatewayUtilities(params: Params) {
-  const dispatch = useDispatch();
-
   const { isCompanySettingsActive } = useCurrentSettingsLevel();
 
   const { currentGateways, setCurrentGateways } = params;
 
   const companyChanges = useCompanyChanges();
+
+  const handleChange = useHandleCurrentCompanyChangeProperty();
 
   const [currentSettingGateways, setCurrentSettingGateways] = useState<
     CompanyGateway[]
@@ -49,16 +48,6 @@ export function useGatewayUtilities(params: Params) {
     const values = (options as SelectOption[]).map((option) => option.value);
 
     setStatus(values.join(','));
-  };
-
-  const handleChange = (property: string, value: string) => {
-    dispatch(
-      updateChanges({
-        object: 'company',
-        property,
-        value,
-      })
-    );
   };
 
   const handleRemoveGateway = (gatewayId: string) => {
@@ -94,44 +83,47 @@ export function useGatewayUtilities(params: Params) {
 
   useEffect(() => {
     if (companyGatewaysResponse) {
-      if (companyChanges?.settings.company_gateway_ids) {
-        let filteredCompanyGateways =
-          companyChanges.settings.company_gateway_ids
-            .split(',')
-            .map((id: string) =>
-              companyGatewaysResponse.data.data.find(
-                (gateway: CompanyGateway) => gateway.id === id
-              )
-            );
-
-        filteredCompanyGateways = filteredCompanyGateways.filter(
-          (companyGateway: CompanyGateway) => companyGateway
-        );
-
-        if (isCompanySettingsActive) {
-          (companyGatewaysResponse.data.data as CompanyGateway[]).forEach(
-            (companyGateway) => {
-              const isAlreadyAdded = filteredCompanyGateways.some(
-                (gateway: CompanyGateway) => gateway.id === companyGateway.id
+      if (companyChanges?.settings.company_gateway_ids !== '0') {
+        if (companyChanges?.settings.company_gateway_ids) {
+          let filteredCompanyGateways =
+            companyChanges.settings.company_gateway_ids
+              .split(',')
+              .map((id: string) =>
+                companyGatewaysResponse.data.data.find(
+                  (gateway: CompanyGateway) => gateway.id === id
+                )
               );
 
-              if (!isAlreadyAdded) {
-                filteredCompanyGateways.push(companyGateway);
-              }
-            }
+          filteredCompanyGateways = filteredCompanyGateways.filter(
+            (companyGateway: CompanyGateway) => companyGateway
           );
-        }
 
-        setCurrentSettingGateways(filteredCompanyGateways);
+          if (isCompanySettingsActive) {
+            (companyGatewaysResponse.data.data as CompanyGateway[]).forEach(
+              (companyGateway) => {
+                const isAlreadyAdded = filteredCompanyGateways.some(
+                  (gateway: CompanyGateway) => gateway.id === companyGateway.id
+                );
+
+                if (!isAlreadyAdded) {
+                  filteredCompanyGateways.push(companyGateway);
+                }
+              }
+            );
+          }
+
+          setCurrentSettingGateways(filteredCompanyGateways);
+        } else {
+          setCurrentSettingGateways(companyGatewaysResponse.data.data);
+        }
       } else {
-        setCurrentSettingGateways(companyGatewaysResponse.data.data);
+        setCurrentSettingGateways([]);
       }
     }
   }, [companyGatewaysResponse]);
 
   return {
     gateways: currentSettingGateways,
-    handleChange,
     handleRemoveGateway,
     handleReset,
     onStatusChange,

--- a/src/pages/settings/gateways/common/hooks/useGatewayUtilities.ts
+++ b/src/pages/settings/gateways/common/hooks/useGatewayUtilities.ts
@@ -68,10 +68,14 @@ export function useGatewayUtilities(params: Params) {
 
     setCurrentGateways(filteredGateways);
 
-    handleChange(
-      'settings.company_gateway_ids',
-      filteredGateways.map(({ id }) => id).join(',')
-    );
+    if (filteredGateways.length) {
+      handleChange(
+        'settings.company_gateway_ids',
+        filteredGateways.map(({ id }) => id).join(',')
+      );
+    } else {
+      handleChange('settings.company_gateway_ids', '0');
+    }
   };
 
   const handleReset = () => {


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adding logic to cover the edge case of setting the `company_gateway_ids` property to '0' when all gateways are removed from group/client settings. Let me know your thoughts.