### PR TITLE
[Feature] Additional Custom Filters | Upcoming & Converted | Quotes

### DIFF
--- a/src/pages/quotes/common/hooks.tsx
+++ b/src/pages/quotes/common/hooks.tsx
@@ -937,7 +937,19 @@ export function useQuoteFilters() {
       label: t('expired'),
       value: 'expired',
       color: 'white',
+      backgroundColor: '#DC2626',
+    },
+    {
+      label: t('upcoming'),
+      value: 'upcoming',
+      color: 'white',
       backgroundColor: '#e6b05c',
+    },
+    {
+      label: t('converted'),
+      value: 'converted',
+      color: 'white',
+      backgroundColor: '#22C55E',
     },
   ];
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the addition of additional filters for quotes (`upcoming` and `converted`). We already had `expired` added to those filters, so I simply added these two. Screenshot:

<img width="1262" alt="Screenshot 2023-10-06 at 09 58 06" src="https://github.com/invoiceninja/ui/assets/51542191/2bb1a527-cdb4-4c00-a845-1891301bf5f7">

@turbo124 We are missing the `upcoming` translation keyword in the files. Please add it there.

Let me know your thoughts.