### PR TITLE
[Cleanup] Clickability On Rows | Improvement

### DIFF
--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -478,32 +478,44 @@ export function DataTable<T extends object>(props: Props<T>) {
                   'border-b border-gray-200': styleOptions?.addRowSeparator,
                   'last:border-b-0': hasVerticalOverflow,
                 })}
-                onClick={() =>
-                  props.onTableRowClick
-                    ? props.onTableRowClick(resource)
-                    : document.getElementById(resource.id)?.click()
-                }
               >
                 {!props.withoutActions && (
-                  <Td>
+                  <Td
+                    className="cursor-pointer"
+                    onClick={() =>
+                      selected.includes(resource.id)
+                        ? setSelected((current) =>
+                            current.filter((v) => v !== resource.id)
+                          )
+                        : setSelected((current) => [...current, resource.id])
+                    }
+                  >
                     <Checkbox
                       checked={selected.includes(resource.id)}
                       className="child-checkbox"
                       value={resource.id}
                       id={resource.id}
-                      onValueChange={(value) =>
-                        selected.includes(value)
-                          ? setSelected((current) =>
-                              current.filter((v) => v !== value)
-                            )
-                          : setSelected((current) => [...current, value])
-                      }
                     />
                   </Td>
                 )}
 
                 {props.columns.map((column, index) => (
-                  <Td key={index} className={styleOptions?.tdClassName}>
+                  <Td
+                    key={index}
+                    className={classNames(
+                      {
+                        'cursor-pointer': index < 3,
+                      },
+                      styleOptions?.tdClassName
+                    )}
+                    onClick={() => {
+                      if (index < 3) {
+                        props.onTableRowClick
+                          ? props.onTableRowClick(resource)
+                          : document.getElementById(resource.id)?.click();
+                      }
+                    }}
+                  >
                     {column.format
                       ? column.format(resource[column.id], resource)
                       : resource[column.id]}

--- a/src/components/tables/Td.tsx
+++ b/src/components/tables/Td.tsx
@@ -25,6 +25,7 @@ export function Td(props: Props) {
       width={props.width}
       colSpan={props.colSpan}
       rowSpan={props.rowSpan}
+      onClick={props.onClick}
       className={`px-2 lg:px-2.5 xl:px-4 py-2 whitespace-nowrap text-sm  ${props.className}`}
       style={{ color: colors.$3 }}
     >


### PR DESCRIPTION
@beganovich @turbo124 The PR includes an improvement in clickability for rows across all tables. Now, the entire `<td>` related to the Checkbox will be clickable for checking/unchecking the Checkbox. Additionally, sliders will now only open on the first three columns in a row after the Checkbox column. Let me know your thoughts.