### PR TITLE
[Cleanup] Implementation Of Notes On Client Overview Page && Little Refactoring Of Standing Component

### DIFF
--- a/src/components/cards/Element.tsx
+++ b/src/components/cards/Element.tsx
@@ -24,6 +24,7 @@ interface Props {
   withoutItemsCenter?: boolean;
   withoutWrappingLeftSide?: boolean;
   disabledLabels?: boolean;
+  noVerticalPadding?: boolean;
 }
 
 export function Element(props: Props) {
@@ -32,9 +33,10 @@ export function Element(props: Props) {
   return (
     <div
       className={classNames(
-        `py-4 sm:py-3 sm:grid sm:grid-cols-3 sm:gap-10 flex flex-col lg:flex-row ${props.className}`,
+        `sm:grid sm:grid-cols-3 sm:gap-10 flex flex-col lg:flex-row ${props.className}`,
         {
           'px-5 sm:px-6': !props.noExternalPadding,
+          'py-4 sm:py-3': !props.noVerticalPadding,
           'lg:items-center': !props.withoutItemsCenter,
         }
       )}

--- a/src/pages/clients/show/components/Address.tsx
+++ b/src/pages/clients/show/components/Address.tsx
@@ -45,6 +45,12 @@ export function Address(props: Props) {
                 </p>
 
                 <p>{resolveCountry(client.country_id)?.name}</p>
+
+                <span
+                  dangerouslySetInnerHTML={{
+                    __html: `${client.public_notes}`,
+                  }}
+                />
               </>
             }
             className="h-full"

--- a/src/pages/clients/show/components/Address.tsx
+++ b/src/pages/clients/show/components/Address.tsx
@@ -47,9 +47,8 @@ export function Address(props: Props) {
                 <p>{resolveCountry(client.country_id)?.name}</p>
 
                 <span
-                  dangerouslySetInnerHTML={{
-                    __html: `${client.public_notes}`,
-                  }}
+                  className="whitespace-normal"
+                  dangerouslySetInnerHTML={{ __html: client.public_notes }}
                 />
               </>
             }

--- a/src/pages/clients/show/components/Standing.tsx
+++ b/src/pages/clients/show/components/Standing.tsx
@@ -11,7 +11,10 @@
 import { useFormatMoney } from '$app/common/hooks/money/useFormatMoney';
 import { Client } from '$app/common/interfaces/client';
 import { InfoCard } from '$app/components/InfoCard';
+import { Element } from '$app/components/cards';
+import { Icon } from '$app/components/icons/Icon';
 import { useTranslation } from 'react-i18next';
+import { MdLockOutline } from 'react-icons/md';
 
 interface Props {
   client: Client;
@@ -31,17 +34,20 @@ export function Standing(props: Props) {
           <InfoCard
             title={t('standing')}
             value={
-              <div className="space-y-2">
-                <div className="flex items-center justify-between">
-                  <p className="font-semibold">{t('paid_to_date')}</p>
-                  <span>
-                    {formatMoney(
-                      client.paid_to_date,
-                      client.country_id,
-                      client.settings.currency_id
-                    )}
-                  </span>
-                </div>
+              <>
+                <Element
+                  leftSide={
+                    <span className="font-bold">{t('paid_to_date')}</span>
+                  }
+                  pushContentToRight
+                  noExternalPadding
+                >
+                  {formatMoney(
+                    client.paid_to_date,
+                    client.country_id,
+                    client.settings.currency_id
+                  )}
+                </Element>
 
                 <div className="flex items-center justify-between">
                   <p className="font-semibold">{t('outstanding')}</p>
@@ -77,7 +83,19 @@ export function Standing(props: Props) {
                     </span>
                   </div>
                 )}
-              </div>
+
+                <div className="flex items-center space-x-1">
+                  <div>
+                    <Icon element={MdLockOutline} size={24} />
+                  </div>
+
+                  <span
+                    dangerouslySetInnerHTML={{
+                      __html: `${client.private_notes}`,
+                    }}
+                  />
+                </div>
+              </>
             }
             className="h-full"
           />

--- a/src/pages/clients/show/components/Standing.tsx
+++ b/src/pages/clients/show/components/Standing.tsx
@@ -34,13 +34,14 @@ export function Standing(props: Props) {
           <InfoCard
             title={t('standing')}
             value={
-              <>
+              <div className="flex flex-col space-y-2">
                 <Element
                   leftSide={
                     <span className="font-bold">{t('paid_to_date')}</span>
                   }
                   pushContentToRight
                   noExternalPadding
+                  noVerticalPadding
                 >
                   {formatMoney(
                     client.paid_to_date,
@@ -49,39 +50,51 @@ export function Standing(props: Props) {
                   )}
                 </Element>
 
-                <div className="flex items-center justify-between">
-                  <p className="font-semibold">{t('outstanding')}</p>
-                  <span>
-                    {formatMoney(
-                      client.balance,
-                      client.country_id,
-                      client.settings.currency_id
-                    )}
-                  </span>
-                </div>
+                <Element
+                  leftSide={
+                    <span className="font-bold">{t('outstanding')}</span>
+                  }
+                  pushContentToRight
+                  noExternalPadding
+                  noVerticalPadding
+                >
+                  {formatMoney(
+                    client.balance,
+                    client.country_id,
+                    client.settings.currency_id
+                  )}
+                </Element>
 
-                <div className="flex items-center justify-between">
-                  <p className="font-semibold">{t('credit_balance')}</p>
-                  <span>
-                    {formatMoney(
-                      client.credit_balance,
-                      client.country_id,
-                      client.settings.currency_id
-                    )}
-                  </span>
-                </div>
+                <Element
+                  leftSide={
+                    <span className="font-bold">{t('credit_balance')}</span>
+                  }
+                  pushContentToRight
+                  noExternalPadding
+                  noVerticalPadding
+                >
+                  {formatMoney(
+                    client.credit_balance,
+                    client.country_id,
+                    client.settings.currency_id
+                  )}
+                </Element>
 
                 {client.payment_balance > 0 && (
-                  <div className="flex items-center justify-between">
-                    <p className="font-semibold">{t('payment_balance')}</p>
-                    <span>
-                      {formatMoney(
-                        client.payment_balance,
-                        client.country_id,
-                        client.settings.currency_id
-                      )}
-                    </span>
-                  </div>
+                  <Element
+                    leftSide={
+                      <span className="font-bold">{t('payment_balance')}</span>
+                    }
+                    pushContentToRight
+                    noExternalPadding
+                    noVerticalPadding
+                  >
+                    {formatMoney(
+                      client.payment_balance,
+                      client.country_id,
+                      client.settings.currency_id
+                    )}
+                  </Element>
                 )}
 
                 <div className="flex items-center space-x-1">
@@ -90,12 +103,11 @@ export function Standing(props: Props) {
                   </div>
 
                   <span
-                    dangerouslySetInnerHTML={{
-                      __html: `${client.private_notes}`,
-                    }}
+                    className="whitespace-normal"
+                    dangerouslySetInnerHTML={{ __html: client.private_notes }}
                   />
                 </div>
-              </>
+              </div>
             }
             className="h-full"
           />


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of private/public notes on the Client overview page. Public notes are placed on the `Address` card, while private notes are placed on the `Standing` card, just like we have in the Flutter app. Screenshot:

<img width="1512" alt="Screenshot 2023-10-16 at 10 23 31" src="https://github.com/invoiceninja/ui/assets/51542191/ba969fdf-b0ef-4da2-b393-62d06ce0c2aa">

@turbo124 I would like to explain a few things here. I noticed on the Flutter app that we have truncated text for notes on this page, which appears as a single line without wrapping and displays '...' at the end if it is too long. To display the text as it is entered, preserving all the formatting, we need to use the `dangerouslySetInnerHTML` property in the HTML. However, when using this property and wanting to display the text as a single line with '...' at the end if it's too long, this property does not add the '...'. I wasn't satisfied with how it looks without '...', and that's why I implemented the full notes on the page.

I found a solution for safely implementing '...' at the end with truncated text using the `DOMPurify` package. However, this approach results in the loss of all formatting in the text, such as bolding and font size. Therefore, I decided to proceed with this recommended solution.

Let me know your thoughts.