### PR TITLE
[Bugfix] Upload Certificate Validation Message

### DIFF
--- a/src/pages/settings/email-settings/EmailSettings.tsx
+++ b/src/pages/settings/email-settings/EmailSettings.tsx
@@ -26,14 +26,14 @@ import { useHandleCurrentCompanyChangeProperty } from '../common/hooks/useHandle
 import { useDiscardChanges } from '../common/hooks/useDiscardChanges';
 import { useDropzone } from 'react-dropzone';
 import { updateRecord } from '$app/common/stores/slices/company-users';
-import { AxiosResponse } from 'axios';
+import { AxiosError, AxiosResponse } from 'axios';
 import { useFormik } from 'formik';
 import { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { request } from '$app/common/helpers/request';
 import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { Image } from 'react-feather';
-import { useAtomValue } from 'jotai';
+import { useAtom } from 'jotai';
 import { companySettingsErrorsAtom } from '../common/atoms';
 import { UserSelector } from '$app/components/users/UserSelector';
 import { toast } from '$app/common/helpers/toast/toast';
@@ -41,6 +41,8 @@ import { useCurrentSettingsLevel } from '$app/common/hooks/useCurrentSettingsLev
 import { PropertyCheckbox } from '$app/components/PropertyCheckbox';
 import { useDisableSettingsField } from '$app/common/hooks/useDisableSettingsField';
 import { SettingsLabel } from '$app/components/SettingsLabel';
+import { Alert } from '$app/components/Alert';
+import { ValidationBag } from '$app/common/interfaces/validation-bag';
 
 export function EmailSettings() {
   useTitle('email_settings');
@@ -59,7 +61,9 @@ export function EmailSettings() {
 
   const disableSettingsField = useDisableSettingsField();
 
-  const errors = useAtomValue(companySettingsErrorsAtom);
+  const [errors, setErrors] = useAtom(companySettingsErrorsAtom);
+
+  console.log(errors);
 
   const handleChange = useHandleCurrentCompanyChangeProperty();
 
@@ -76,6 +80,8 @@ export function EmailSettings() {
     onSubmit: () => {
       toast.processing();
 
+      setErrors(undefined);
+
       request(
         'POST',
         endpoint('/api/v1/companies/:id', { id: currentCompany.id }),
@@ -89,7 +95,12 @@ export function EmailSettings() {
 
           toast.success('uploaded_document');
         })
-
+        .catch((error: AxiosError<ValidationBag>) => {
+          if (error.response?.status === 422) {
+            setErrors(error.response.data);
+            toast.dismiss();
+          }
+        })
         .finally(() => setFormData(new FormData()));
     },
   });
@@ -253,6 +264,12 @@ export function EmailSettings() {
                     </span>
                   </div>
                 </div>
+
+                {errors?.errors.e_invoice_certificate && (
+                  <Alert className="mt-2" type="danger">
+                    {errors?.errors.e_invoice_certificate}
+                  </Alert>
+                )}
               </Element>
             )}
 

--- a/src/pages/settings/email-settings/EmailSettings.tsx
+++ b/src/pages/settings/email-settings/EmailSettings.tsx
@@ -41,7 +41,6 @@ import { useCurrentSettingsLevel } from '$app/common/hooks/useCurrentSettingsLev
 import { PropertyCheckbox } from '$app/components/PropertyCheckbox';
 import { useDisableSettingsField } from '$app/common/hooks/useDisableSettingsField';
 import { SettingsLabel } from '$app/components/SettingsLabel';
-import { Alert } from '$app/components/Alert';
 import { ValidationBag } from '$app/common/interfaces/validation-bag';
 
 export function EmailSettings() {
@@ -62,8 +61,6 @@ export function EmailSettings() {
   const disableSettingsField = useDisableSettingsField();
 
   const [errors, setErrors] = useAtom(companySettingsErrorsAtom);
-
-  console.log(errors);
 
   const handleChange = useHandleCurrentCompanyChangeProperty();
 
@@ -264,12 +261,6 @@ export function EmailSettings() {
                     </span>
                   </div>
                 </div>
-
-                {errors?.errors.e_invoice_certificate && (
-                  <Alert className="mt-2" type="danger">
-                    {errors?.errors.e_invoice_certificate}
-                  </Alert>
-                )}
               </Element>
             )}
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adding part of the logic that we missed for catching the 422 error when uploading a certificate. Screenshot:
 
![Screenshot 2023-10-17 at 17 13 45](https://github.com/invoiceninja/ui/assets/51542191/6084f5da-39c1-407c-bec5-7cfa87f7b2dd)

@turbo124 As we discussed on Slack, we would like to align the settings pages with the rest of the app by displaying validation messages under the fields, as we have done on other pages. For this purpose and to make adjustments to the settings pages, I will create a specific ticket for it. I hope that you will agree.

Let me know your thoughts.