### PR TITLE
[Bugfix] Product Selector Clear Button Fix | Combobox Component Issue

### DIFF
--- a/src/components/forms/Combobox.tsx
+++ b/src/components/forms/Combobox.tsx
@@ -339,7 +339,9 @@ export function Combobox<T = any>({
               }}
               className="absolute inset-y-0 right-0 flex items-center rounded-r-md px-2 focus:outline-none"
             >
-              {onDismiss && selectedOption ? (
+              {onDismiss &&
+              selectedOption &&
+              selectedOption.eventType !== 'internal' ? (
                 <X
                   className="h-5 w-5"
                   aria-hidden="true"


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixing the issue with the Combobox component. When the component is nullable, there is no case where the Down arrow icon is displayed, even if no specific value is selected in the Product Combobox. Now, it is fixed, screenshot:

![Screenshot 2023-10-17 at 18 42 26](https://github.com/invoiceninja/ui/assets/51542191/747b3b72-b2d0-4202-9a6c-74a4a57b6213)

Let me know your thoughts.