### PR TITLE
[Bugfix] Default Tax Rates Parsing To Number

### DIFF
--- a/src/pages/settings/tax-settings/components/Selector.tsx
+++ b/src/pages/settings/tax-settings/components/Selector.tsx
@@ -14,16 +14,16 @@ import { endpoint } from '$app/common/helpers';
 import { request } from '$app/common/helpers/request';
 import { useCompanyChanges } from '$app/common/hooks/useCompanyChanges';
 import { TaxRate } from '$app/common/interfaces/tax-rate';
-import { updateChanges } from '$app/common/stores/slices/company-users';
 import { ChangeEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQuery } from 'react-query';
-import { useDispatch } from 'react-redux';
 import { useAtomValue } from 'jotai';
 import { companySettingsErrorsAtom } from '../../common/atoms';
 import { useDisableSettingsField } from '$app/common/hooks/useDisableSettingsField';
 import { PropertyCheckbox } from '$app/components/PropertyCheckbox';
 import { SettingsLabel } from '$app/components/SettingsLabel';
+import { useHandleCurrentCompanyChangeProperty } from '../../common/hooks/useHandleCurrentCompanyChange';
+import { cloneDeep } from 'lodash';
 
 interface Props {
   title?: string;
@@ -31,7 +31,8 @@ interface Props {
 export function Selector(props: Props) {
   const [t] = useTranslation();
   const companyChanges = useCompanyChanges();
-  const dispatch = useDispatch();
+
+  const handlePropertyChange = useHandleCurrentCompanyChangeProperty();
 
   const disableSettingsField = useDisableSettingsField();
 
@@ -46,21 +47,20 @@ export function Selector(props: Props) {
   const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
     const option = event.target.options[event.target.selectedIndex];
 
-    dispatch(
-      updateChanges({
-        object: 'company',
-        property: event.target.id,
-        value: parseFloat(option.dataset.rate || '0'),
-      })
+    handlePropertyChange(
+      event.target.id,
+      parseFloat(option.dataset.rate || '0')
     );
 
-    dispatch(
-      updateChanges({
-        object: 'company',
-        property: option.dataset.rateName as string,
-        value: event.target.value,
-      })
-    );
+    handlePropertyChange(option.dataset.rateName as string, event.target.value);
+  };
+
+  const handleRemoveProperty = (propertyKey: string) => {
+    const updatedCompanySettings = cloneDeep(companyChanges?.settings);
+
+    delete updatedCompanySettings[propertyKey];
+
+    handlePropertyChange('settings', updatedCompanySettings);
   };
 
   return (
@@ -73,14 +73,22 @@ export function Selector(props: Props) {
                 <PropertyCheckbox
                   propertyKey="tax_name1"
                   labelElement={<SettingsLabel label={t('default_tax_rate')} />}
-                  defaultValue="0"
+                  onCheckboxChange={(value) => {
+                    if (value) {
+                      handlePropertyChange('settings.tax_rate1', 0);
+                    }
+
+                    if (!value) {
+                      handleRemoveProperty('tax_rate1');
+                    }
+                  }}
                 />
               }
             >
               <SelectField
                 id="settings.tax_rate1"
                 onChange={handleChange}
-                value={companyChanges?.settings?.tax_name1 || '0'}
+                value={companyChanges?.settings?.tax_name1 || 0}
                 disabled={disableSettingsField('tax_name1')}
                 errorMessage={errors?.errors['settings.tax_rate1']}
               >
@@ -110,14 +118,22 @@ export function Selector(props: Props) {
                 <PropertyCheckbox
                   propertyKey="tax_name2"
                   labelElement={<SettingsLabel label={t('default_tax_rate')} />}
-                  defaultValue="0"
+                  onCheckboxChange={(value) => {
+                    if (value) {
+                      handlePropertyChange('settings.tax_rate2', 0);
+                    }
+
+                    if (!value) {
+                      handleRemoveProperty('tax_rate2');
+                    }
+                  }}
                 />
               }
             >
               <SelectField
                 id="settings.tax_rate2"
                 onChange={handleChange}
-                value={companyChanges?.settings?.tax_name2 || '0'}
+                value={companyChanges?.settings?.tax_name2 || 0}
                 disabled={disableSettingsField('tax_name2')}
                 errorMessage={errors?.errors['settings.tax_rate2']}
               >
@@ -147,14 +163,22 @@ export function Selector(props: Props) {
                 <PropertyCheckbox
                   propertyKey="tax_name3"
                   labelElement={<SettingsLabel label={t('default_tax_rate')} />}
-                  defaultValue="0"
+                  onCheckboxChange={(value) => {
+                    if (value) {
+                      handlePropertyChange('settings.tax_rate3', 0);
+                    }
+
+                    if (!value) {
+                      handleRemoveProperty('tax_rate3');
+                    }
+                  }}
                 />
               }
             >
               <SelectField
                 id="settings.tax_rate3"
                 onChange={handleChange}
-                value={companyChanges?.settings?.tax_name3 || '0'}
+                value={companyChanges?.settings?.tax_name3 || 0}
                 disabled={disableSettingsField('tax_name3')}
                 errorMessage={errors?.errors['settings.tax_rate3']}
               >

--- a/src/pages/settings/tax-settings/components/Selector.tsx
+++ b/src/pages/settings/tax-settings/components/Selector.tsx
@@ -76,9 +76,7 @@ export function Selector(props: Props) {
                   onCheckboxChange={(value) => {
                     if (value) {
                       handlePropertyChange('settings.tax_rate1', 0);
-                    }
-
-                    if (!value) {
+                    } else {
                       handleRemoveProperty('tax_rate1');
                     }
                   }}
@@ -121,9 +119,7 @@ export function Selector(props: Props) {
                   onCheckboxChange={(value) => {
                     if (value) {
                       handlePropertyChange('settings.tax_rate2', 0);
-                    }
-
-                    if (!value) {
+                    } else {
                       handleRemoveProperty('tax_rate2');
                     }
                   }}
@@ -166,9 +162,7 @@ export function Selector(props: Props) {
                   onCheckboxChange={(value) => {
                     if (value) {
                       handlePropertyChange('settings.tax_rate3', 0);
-                    }
-
-                    if (!value) {
+                    } else {
                       handleRemoveProperty('tax_rate3');
                     }
                   }}

--- a/src/pages/settings/tax-settings/components/Selector.tsx
+++ b/src/pages/settings/tax-settings/components/Selector.tsx
@@ -50,7 +50,7 @@ export function Selector(props: Props) {
       updateChanges({
         object: 'company',
         property: event.target.id,
-        value: option.dataset.rate,
+        value: parseFloat(option.dataset.rate || '0'),
       })
     );
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixing the type for the properties tax_rate1, tax_rate2, and tax_rate3 across all settings levels that we send to the payload. We sent them as strings, but they need to be numbers. Let me know your thoughts.