### PR TITLE
[Bugfix] Custom Design Preview Endpoint | Null Design Object Value

### DIFF
--- a/src/pages/settings/invoice-design/pages/custom-designs/pages/edit/Edit.tsx
+++ b/src/pages/settings/invoice-design/pages/custom-designs/pages/edit/Edit.tsx
@@ -100,12 +100,14 @@ export default function Edit() {
       </div>
 
       <div className="w-full lg:w-1/2 max-h-[80vh] overflow-y-scroll">
-        <InvoiceViewer
-          link={endpoint('/api/v1/preview')}
-          resource={payload}
-          method="POST"
-          withToast
-        />
+        {payload.design && (
+          <InvoiceViewer
+            link={endpoint('/api/v1/preview')}
+            resource={payload}
+            method="POST"
+            withToast
+          />
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixing a bug with Custom Designs and the preview endpoint, where we sent the `design` object as a `null` value to show the custom invoice design. On my end, it looks fixed. Let me know your thoughts.