### PR TITLE
Fixes for vendors double query

### DIFF
--- a/src/common/hooks/clients/useClientResolver.ts
+++ b/src/common/hooks/clients/useClientResolver.ts
@@ -8,10 +8,24 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
-import { ClientResolver } from '$app/common/helpers/clients/client-resolver';
-
-const clientResolver = new ClientResolver();
+import { endpoint } from '$app/common/helpers';
+import { request } from '$app/common/helpers/request';
+import { Client } from '$app/common/interfaces/client';
+import { useQueryClient } from 'react-query';
 
 export function useClientResolver() {
-  return clientResolver;
+  const queryClient = useQueryClient();
+
+  const find = (id: string) => {
+    return queryClient.fetchQuery<Client>({
+      queryKey: ['client', id],
+      queryFn: () =>
+        request('GET', endpoint('/api/v1/clients/:id', { id })).then(
+          (response) => response.data.data
+        ),
+      staleTime: Infinity,
+    });
+  };
+
+  return { find };
 }

--- a/src/components/forms/Combobox.tsx
+++ b/src/components/forms/Combobox.tsx
@@ -790,6 +790,9 @@ export function ComboboxAsync<T = any>({
     },
     {
       staleTime: staleTime ?? Infinity,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      refetchOnMount: false 
     }
   );
 

--- a/src/components/forms/Combobox.tsx
+++ b/src/components/forms/Combobox.tsx
@@ -804,6 +804,12 @@ export function ComboboxAsync<T = any>({
   }, []);
 
   const onEmptyValues = (query: string) => {
+    const $url = new URL(url);
+
+    if (query === '' && !$url.searchParams.has('filter')) {
+      return;
+    }
+
     setUrl((c) => {
       const url = new URL(c);
 

--- a/src/pages/credits/edit/Edit.tsx
+++ b/src/pages/credits/edit/Edit.tsx
@@ -9,7 +9,6 @@
  */
 
 import { route } from '$app/common/helpers/route';
-import { useClientResolver } from '$app/common/hooks/clients/useClientResolver';
 import { useReactSettings } from '$app/common/hooks/useReactSettings';
 import { useTitle } from '$app/common/hooks/useTitle';
 import { Client } from '$app/common/interfaces/client';
@@ -62,7 +61,6 @@ export default function Edit() {
   const [errors, setErrors] = useState<ValidationBag>();
 
   const productColumns = useProductColumns();
-  const clientResolver = useClientResolver();
 
   const {
     handleChange,
@@ -84,8 +82,6 @@ export default function Edit() {
 
       if (_credit && _credit.client) {
         setClient(_credit.client);
-
-        clientResolver.cache(_credit.client);
       }
     }
   }, [data]);

--- a/src/pages/invoices/edit/Edit.tsx
+++ b/src/pages/invoices/edit/Edit.tsx
@@ -10,7 +10,6 @@
 
 import { InvoiceStatus } from '$app/common/enums/invoice-status';
 import { route } from '$app/common/helpers/route';
-import { useClientResolver } from '$app/common/hooks/clients/useClientResolver';
 import { useReactSettings } from '$app/common/hooks/useReactSettings';
 import { useTitle } from '$app/common/hooks/useTitle';
 import { Client } from '$app/common/interfaces/client';
@@ -71,8 +70,6 @@ export default function Edit() {
   const [client, setClient] = useState<Client | undefined>();
   const [errors, setErrors] = useState<ValidationBag>();
 
-  const clientResolver = useClientResolver();
-
   const {
     handleChange,
     handleInvitationChange,
@@ -97,8 +94,6 @@ export default function Edit() {
 
       if (_invoice?.client) {
         setClient(_invoice.client);
-
-        clientResolver.cache(_invoice.client);
       }
     }
   }, [data]);

--- a/src/pages/quotes/edit/Edit.tsx
+++ b/src/pages/quotes/edit/Edit.tsx
@@ -9,7 +9,6 @@
  */
 
 import { route } from '$app/common/helpers/route';
-import { useClientResolver } from '$app/common/hooks/clients/useClientResolver';
 import { useReactSettings } from '$app/common/hooks/useReactSettings';
 import { useTitle } from '$app/common/hooks/useTitle';
 import { Client } from '$app/common/interfaces/client';
@@ -64,7 +63,6 @@ export default function Edit() {
   const [errors, setErrors] = useState<ValidationBag>();
 
   const productColumns = useProductColumns();
-  const clientResolver = useClientResolver();
 
   const {
     handleChange,
@@ -86,8 +84,6 @@ export default function Edit() {
 
       if (_quote && _quote.client) {
         setClient(_quote.client);
-
-        clientResolver.cache(_quote.client);
       }
     }
   }, [data]);

--- a/src/pages/recurring-invoices/edit/Edit.tsx
+++ b/src/pages/recurring-invoices/edit/Edit.tsx
@@ -9,7 +9,6 @@
  */
 
 import { route } from '$app/common/helpers/route';
-import { useClientResolver } from '$app/common/hooks/clients/useClientResolver';
 import { useReactSettings } from '$app/common/hooks/useReactSettings';
 import { useTitle } from '$app/common/hooks/useTitle';
 import { Client } from '$app/common/interfaces/client';
@@ -72,8 +71,6 @@ export default function Edit() {
   const [client, setClient] = useState<Client>();
   const [errors, setErrors] = useState<ValidationBag>();
 
-  const clientResolver = useClientResolver();
-
   const {
     handleChange,
     handleInvitationChange,
@@ -96,8 +93,6 @@ export default function Edit() {
 
       if (ri && ri.client) {
         setClient(ri.client);
-
-        clientResolver.cache(ri.client);
       }
     }
   }, [data]);


### PR DESCRIPTION
This fixes and reduces double query for vendors (and all other comboboxes) on the expenses edit page.