### PR TITLE
[Cleanup] Client Does Not Have Contact Email | Email Invoice Action

### DIFF
--- a/src/pages/invoices/common/components/EmailInvoiceAction.tsx
+++ b/src/pages/invoices/common/components/EmailInvoiceAction.tsx
@@ -22,7 +22,7 @@ import { Modal } from '$app/components/Modal';
 
 interface Props {
   invoice: Invoice;
-  commonActionSection?: boolean;
+  dropdown?: boolean;
 }
 export function EmailInvoiceAction(props: Props) {
   const [t] = useTranslation();
@@ -30,7 +30,7 @@ export function EmailInvoiceAction(props: Props) {
 
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
-  const { invoice, commonActionSection = false } = props;
+  const { invoice, dropdown = false } = props;
 
   const hasClientEmailContacts = (client?: Client) => {
     return client?.contacts.some(({ email }) => email);
@@ -44,17 +44,14 @@ export function EmailInvoiceAction(props: Props) {
         }
       >
         <DropdownElement
-          {...(commonActionSection && { behavior: 'button' })}
+          {...(!dropdown && { behavior: 'button' })}
           {...(hasClientEmailContacts(invoice.client) && {
             to: route('/invoices/:id/email', {
               id: invoice.id,
             }),
           })}
           icon={
-            <Icon
-              element={MdSend}
-              {...(commonActionSection && { color: 'white' })}
-            />
+            <Icon element={MdSend} {...(!dropdown && { color: 'white' })} />
           }
         >
           {t('email_invoice')}

--- a/src/pages/invoices/common/components/EmailInvoiceAction.tsx
+++ b/src/pages/invoices/common/components/EmailInvoiceAction.tsx
@@ -18,7 +18,6 @@ import { useTranslation } from 'react-i18next';
 import { MdSend } from 'react-icons/md';
 import { Button } from '$app/components/forms';
 import { useNavigate } from 'react-router-dom';
-import { useColorScheme } from '$app/common/colors';
 import { Modal } from '$app/components/Modal';
 
 interface Props {
@@ -29,11 +28,9 @@ export function EmailInvoiceAction(props: Props) {
   const [t] = useTranslation();
   const navigate = useNavigate();
 
-  const colors = useColorScheme();
-
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
-  const { invoice, commonActionSection } = props;
+  const { invoice, commonActionSection = false } = props;
 
   const hasClientEmailContacts = (client?: Client) => {
     return client?.contacts.some(({ email }) => email);
@@ -46,30 +43,22 @@ export function EmailInvoiceAction(props: Props) {
           !hasClientEmailContacts(invoice.client) && setIsModalOpen(true)
         }
       >
-        {!commonActionSection ? (
-          <DropdownElement
-            {...(hasClientEmailContacts(invoice.client) && {
-              to: route('/invoices/:id/email', {
-                id: invoice.id,
-              }),
-            })}
-            icon={<Icon element={MdSend} />}
-          >
-            {t('email_invoice')}
-          </DropdownElement>
-        ) : (
-          <Button
-            className="flex space-x-2"
-            behavior="button"
-            onClick={() =>
-              hasClientEmailContacts(invoice.client) &&
-              navigate(route('/invoices/:id/email', { id: invoice.id }))
-            }
-          >
-            <Icon element={MdSend} color={colors.$1} />
-            <span>{t('email_invoice')}</span>
-          </Button>
-        )}
+        <DropdownElement
+          {...(commonActionSection && { behavior: 'button' })}
+          {...(hasClientEmailContacts(invoice.client) && {
+            to: route('/invoices/:id/email', {
+              id: invoice.id,
+            }),
+          })}
+          icon={
+            <Icon
+              element={MdSend}
+              {...(commonActionSection && { color: 'white' })}
+            />
+          }
+        >
+          {t('email_invoice')}
+        </DropdownElement>
       </div>
 
       <Modal

--- a/src/pages/invoices/common/components/EmailInvoiceAction.tsx
+++ b/src/pages/invoices/common/components/EmailInvoiceAction.tsx
@@ -11,29 +11,34 @@
 import { route } from '$app/common/helpers/route';
 import { Client } from '$app/common/interfaces/client';
 import { Invoice } from '$app/common/interfaces/invoice';
-import { Modal } from '$app/components/Modal';
 import { DropdownElement } from '$app/components/dropdown/DropdownElement';
-import { Button } from '$app/components/forms';
 import { Icon } from '$app/components/icons/Icon';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MdSend } from 'react-icons/md';
+import { Button } from '$app/components/forms';
 import { useNavigate } from 'react-router-dom';
+import { useColorScheme } from '$app/common/colors';
+import { Modal } from '$app/components/Modal';
 
 interface Props {
   invoice: Invoice;
+  commonActionSection?: boolean;
 }
 export function EmailInvoiceAction(props: Props) {
   const [t] = useTranslation();
   const navigate = useNavigate();
 
+  const colors = useColorScheme();
+
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
-  const { invoice } = props;
+  const { invoice, commonActionSection } = props;
 
   const hasClientEmailContacts = (client?: Client) => {
     return client?.contacts.some(({ email }) => email);
   };
+
   return (
     <>
       <div
@@ -41,18 +46,32 @@ export function EmailInvoiceAction(props: Props) {
           !hasClientEmailContacts(invoice.client) && setIsModalOpen(true)
         }
       >
-        <DropdownElement
-          to={
-            hasClientEmailContacts(invoice.client)
-              ? route('/invoices/:id/email', {
-                  id: invoice.id,
-                })
-              : ''
-          }
-          icon={<Icon element={MdSend} />}
-        >
-          {t('email_invoice')}
-        </DropdownElement>
+        {!commonActionSection ? (
+          <DropdownElement
+            to={
+              hasClientEmailContacts(invoice.client)
+                ? route('/invoices/:id/email', {
+                    id: invoice.id,
+                  })
+                : ''
+            }
+            icon={<Icon element={MdSend} />}
+          >
+            {t('email_invoice')}
+          </DropdownElement>
+        ) : (
+          <Button
+            className="flex space-x-2"
+            behavior="button"
+            onClick={() =>
+              hasClientEmailContacts(invoice.client) &&
+              navigate(route('/invoices/:id/email', { id: invoice.id }))
+            }
+          >
+            <Icon element={MdSend} color={colors.$1} />
+            <span>{t('email_invoice')}</span>
+          </Button>
+        )}
       </div>
 
       <Modal
@@ -68,7 +87,7 @@ export function EmailInvoiceAction(props: Props) {
           <Button
             className="self-end"
             onClick={() => {
-              navigate(route('/clients/:id/edit', { id: invoice.client?.id }));
+              navigate(route('/clients/:id/edit', { id: invoice.client_id }));
               setIsModalOpen(false);
             }}
           >

--- a/src/pages/invoices/common/components/EmailInvoiceAction.tsx
+++ b/src/pages/invoices/common/components/EmailInvoiceAction.tsx
@@ -48,13 +48,11 @@ export function EmailInvoiceAction(props: Props) {
       >
         {!commonActionSection ? (
           <DropdownElement
-            to={
-              hasClientEmailContacts(invoice.client)
-                ? route('/invoices/:id/email', {
-                    id: invoice.id,
-                  })
-                : ''
-            }
+            {...(hasClientEmailContacts(invoice.client) && {
+              to: route('/invoices/:id/email', {
+                id: invoice.id,
+              }),
+            })}
             icon={<Icon element={MdSend} />}
           >
             {t('email_invoice')}

--- a/src/pages/invoices/common/components/EmailInvoiceAction.tsx
+++ b/src/pages/invoices/common/components/EmailInvoiceAction.tsx
@@ -1,0 +1,81 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { route } from '$app/common/helpers/route';
+import { Client } from '$app/common/interfaces/client';
+import { Invoice } from '$app/common/interfaces/invoice';
+import { Modal } from '$app/components/Modal';
+import { DropdownElement } from '$app/components/dropdown/DropdownElement';
+import { Button } from '$app/components/forms';
+import { Icon } from '$app/components/icons/Icon';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { MdSend } from 'react-icons/md';
+import { useNavigate } from 'react-router-dom';
+
+interface Props {
+  invoice: Invoice;
+}
+export function EmailInvoiceAction(props: Props) {
+  const [t] = useTranslation();
+  const navigate = useNavigate();
+
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+
+  const { invoice } = props;
+
+  const hasClientEmailContacts = (client?: Client) => {
+    return client?.contacts.some(({ email }) => email);
+  };
+  return (
+    <>
+      <div
+        onClick={() =>
+          !hasClientEmailContacts(invoice.client) && setIsModalOpen(true)
+        }
+      >
+        <DropdownElement
+          to={
+            hasClientEmailContacts(invoice.client)
+              ? route('/invoices/:id/email', {
+                  id: invoice.id,
+                })
+              : ''
+          }
+          icon={<Icon element={MdSend} />}
+        >
+          {t('email_invoice')}
+        </DropdownElement>
+      </div>
+
+      <Modal
+        title={t('contact_email')}
+        visible={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+      >
+        <div className="flex flex-col items-center space-y-4">
+          <span className="text-base font-medium">
+            {t('client_email_not_set')}.
+          </span>
+
+          <Button
+            className="self-end"
+            onClick={() => {
+              navigate(route('/clients/:id/edit', { id: invoice.client?.id }));
+              setIsModalOpen(false);
+            }}
+          >
+            {t('edit_client')}
+          </Button>
+        </div>
+      </Modal>
+    </>
+  );
+}

--- a/src/pages/invoices/common/components/SendEmailBulkAction.tsx
+++ b/src/pages/invoices/common/components/SendEmailBulkAction.tsx
@@ -14,32 +14,82 @@ import { DropdownElement } from '$app/components/dropdown/DropdownElement';
 import { Icon } from '$app/components/icons/Icon';
 import { useTranslation } from 'react-i18next';
 import { MdSend } from 'react-icons/md';
+import { Invoice } from '$app/common/interfaces/invoice';
+import { Button } from '$app/components/forms';
+import { Modal } from '$app/components/Modal';
+import { useNavigate } from 'react-router-dom';
+import { route } from '$app/common/helpers/route';
 
 interface Props {
-  invoiceIds: string[];
+  invoices: Invoice[];
 }
 
 export function SendEmailBulkAction(props: Props) {
-  const { invoiceIds } = props;
+  const { invoices } = props;
 
   const [t] = useTranslation();
+  const navigate = useNavigate();
 
   const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
+
+  const [isContactEmailOpen, setContactEmailOpen] = useState<boolean>(false);
+
+  const haveClientsEmailContacts = () => {
+    return invoices.every(({ client }) =>
+      client?.contacts.some(({ email }) => email)
+    );
+  };
+
+  const getInvoiceWithoutClientContacts = () => {
+    return invoices.find(
+      ({ client }) => !client?.contacts.some(({ email }) => email)
+    );
+  };
 
   return (
     <>
       <SendEmailModal
         visible={isModalVisible}
         setVisible={setIsModalVisible}
-        invoiceIds={invoiceIds}
+        invoiceIds={invoices.map(({ id }) => id)}
       />
 
       <DropdownElement
-        onClick={() => setIsModalVisible(true)}
+        onClick={() =>
+          haveClientsEmailContacts()
+            ? setIsModalVisible(true)
+            : setContactEmailOpen(true)
+        }
         icon={<Icon element={MdSend} />}
       >
         {t('send_email')}
       </DropdownElement>
+
+      <Modal
+        title={t('contact_email')}
+        visible={isContactEmailOpen}
+        onClose={() => setContactEmailOpen(false)}
+      >
+        <div className="flex flex-col items-center space-y-4">
+          <span className="text-base font-medium">
+            {t('client_email_not_set')}.
+          </span>
+
+          <Button
+            className="self-end"
+            onClick={() => {
+              navigate(
+                route('/clients/:id/edit', {
+                  id: getInvoiceWithoutClientContacts()?.client_id,
+                })
+              );
+              setContactEmailOpen(false);
+            }}
+          >
+            {t('edit_client')}
+          </Button>
+        </div>
+      </Modal>
     </>
   );
 }

--- a/src/pages/invoices/common/hooks/useCustomBulkActions.tsx
+++ b/src/pages/invoices/common/hooks/useCustomBulkActions.tsx
@@ -122,7 +122,8 @@ export const useCustomBulkActions = () => {
   };
 
   const customBulkActions: CustomBulkAction<Invoice>[] = [
-    (selectedIds) => <SendEmailBulkAction invoiceIds={selectedIds} />,
+    (_, selectedInvoices) =>
+      selectedInvoices && <SendEmailBulkAction invoices={selectedInvoices} />,
     (selectedIds) => (
       <DropdownElement
         onClick={() => printPdf(selectedIds)}

--- a/src/pages/invoices/edit/components/Actions.tsx
+++ b/src/pages/invoices/edit/components/Actions.tsx
@@ -217,7 +217,7 @@ export function useActions(params?: Params) {
     () => Boolean(showEditAction) && dropdown && <Divider withoutPadding />,
     (invoice: Invoice) =>
       showActionByPreferences('invoice', 'email_invoice') && (
-        <EmailInvoiceAction invoice={invoice} />
+        <EmailInvoiceAction invoice={invoice} dropdown={dropdown} />
       ),
     (invoice: Invoice) =>
       showActionByPreferences('invoice', 'view_pdf') && (

--- a/src/pages/invoices/edit/components/Actions.tsx
+++ b/src/pages/invoices/edit/components/Actions.tsx
@@ -43,7 +43,6 @@ import {
   MdRefresh,
   MdRestore,
   MdSchedule,
-  MdSend,
 } from 'react-icons/md';
 import { useNavigate } from 'react-router-dom';
 import { useScheduleEmailRecord } from '$app/pages/invoices/common/hooks/useScheduleEmailRecord';
@@ -54,6 +53,7 @@ import dayjs from 'dayjs';
 import { useEntityPageIdentifier } from '$app/common/hooks/useEntityPageIdentifier';
 import { useBulk } from '$app/common/queries/invoices';
 import { useReverseInvoice } from '../../common/hooks/useReverseInvoice';
+import { EmailInvoiceAction } from '../../common/components/EmailInvoiceAction';
 
 export const isInvoiceAutoBillable = (invoice: Invoice) => {
   return (
@@ -207,14 +207,7 @@ export function useActions(params?: Params) {
       ),
     () => Boolean(showEditAction) && <Divider withoutPadding />,
     (invoice: Invoice) =>
-      !excludeCommonActions && (
-        <DropdownElement
-          to={route('/invoices/:id/email', { id: invoice.id })}
-          icon={<Icon element={MdSend} />}
-        >
-          {t('email_invoice')}
-        </DropdownElement>
-      ),
+      !excludeCommonActions && <EmailInvoiceAction invoice={invoice} />,
     (invoice: Invoice) => (
       <DropdownElement
         to={route('/invoices/:id/pdf', { id: invoice.id })}

--- a/src/pages/invoices/edit/components/CommonActions.tsx
+++ b/src/pages/invoices/edit/components/CommonActions.tsx
@@ -10,21 +10,19 @@
 
 import { useColorScheme } from '$app/common/colors';
 import { InvoiceStatus } from '$app/common/enums/invoice-status';
-import { route } from '$app/common/helpers/route';
 import { Invoice } from '$app/common/interfaces/invoice';
 import { useBulk } from '$app/common/queries/invoices';
 import { Button } from '$app/components/forms';
 import { Icon } from '$app/components/icons/Icon';
 import { useTranslation } from 'react-i18next';
-import { MdMarkEmailRead, MdSend } from 'react-icons/md';
-import { useNavigate } from 'react-router-dom';
+import { MdMarkEmailRead } from 'react-icons/md';
+import { EmailInvoiceAction } from '../../common/components/EmailInvoiceAction';
 
 interface Props {
   invoice: Invoice;
 }
 export function CommonActions(props: Props) {
   const [t] = useTranslation();
-  const navigate = useNavigate();
 
   const colors = useColorScheme();
 
@@ -45,16 +43,7 @@ export function CommonActions(props: Props) {
         </Button>
       )}
 
-      <Button
-        className="flex space-x-2"
-        behavior="button"
-        onClick={() =>
-          navigate(route('/invoices/:id/email', { id: invoice.id }))
-        }
-      >
-        <Icon element={MdSend} color={colors.$1} />
-        <span>{t('email_invoice')}</span>
-      </Button>
+      <EmailInvoiceAction invoice={invoice} commonActionSection />
     </div>
   );
 }

--- a/src/pages/invoices/edit/components/CommonActions.tsx
+++ b/src/pages/invoices/edit/components/CommonActions.tsx
@@ -11,8 +11,8 @@
 import { Invoice } from '$app/common/interfaces/invoice';
 import { CommonActionsPreferenceModal } from '$app/components/CommonActionsPreferenceModal';
 import { Icon } from '$app/components/icons/Icon';
-import { MdSettings } from 'react-icons/md';
 import { useState } from 'react';
+import { MdSettings } from 'react-icons/md';
 import { useActions } from './Actions';
 
 interface Props {


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of a modal to inform the user that the client does not have any email contacts to email an invoice. The modal also provides an additional CTA to navigate to the client's edit page and add some contacts. Screenshot:

![Screenshot 2023-10-23 at 22 27 14](https://github.com/invoiceninja/ui/assets/51542191/d55f3c51-6cdd-497a-b605-84464c7624c1)

Let me know your thoughts.