### PR TITLE
Fixes for TinyMCE z-index

### DIFF
--- a/src/components/forms/MarkdownEditor.tsx
+++ b/src/components/forms/MarkdownEditor.tsx
@@ -45,7 +45,7 @@ export function MarkdownEditor(props: Props) {
   const colors = useColorScheme();
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4" style={{ zIndex: 0 }}>
       {props.label && <InputLabel>{props.label}</InputLabel>}
 
       <Editor


### PR DESCRIPTION
This fixes an issue of TinyMCE header overlapping due to the wrong z-index (vendors edit page).