### PR TITLE
[Bugfix] Opening Comboboxes After Closing Modal

### DIFF
--- a/src/components/forms/Combobox.tsx
+++ b/src/components/forms/Combobox.tsx
@@ -565,7 +565,7 @@ export function ComboboxStatic<T = any>({
                 entryOptions.inputLabelFn?.(entry?.resource) ??
                 (entry?.label || '')
               }
-              onFocus={() => setIsOpen(true)}
+              onClick={() => setIsOpen(true)}
               placeholder={inputOptions.placeholder}
               style={{
                 backgroundColor: colors.$1,


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixing the bug related to opening/focusing the comboboxes after closing the modal. It's important to pinpoint the source of this bug. In reality, the `Dialog` component from `@headlessui/react` focuses on the first focusable element in the `DOM` when we `close` it in any manner. The presence of an `onFocus` event on the `HeadlessCombobox.Input` component (`onFocus={() => setIsOpen(true)}`) caused the comboboxes to open when the modal was closed. David noticed this bug in the `Kanban` with `Project` combobox, but upon my examination of the rest of the application, I observed it occurring wherever the first focusable element is a combobox. I extensively researched the Dialog component, but I couldn't find any solutions provided for this bug. I might be mistaken, but it seems that their documentation primarily offers solutions for opening modals and elements within the modal, rather than addressing the behavior across the entire page or DOM.

Actually, I replaced the `onFocus` event with the `onClick` event, and we encountered the same behavior on the combobox component, effectively avoiding this bug. If we decide to implement dynamic focusing, we can explore additional solutions in the future, but for now, I believe this approach is suitable.

Let me know your thoughts.