### PR TITLE
[Bugfix] Comobox Query Invalidation Across Whole App

### DIFF
--- a/src/components/forms/Combobox.tsx
+++ b/src/components/forms/Combobox.tsx
@@ -755,7 +755,7 @@ export function ComboboxAsync<T = any>({
   const [url, setUrl] = useState(endpoint);
 
   const { data } = useQuery(
-    [url],
+    [new URL(url).pathname, new URL(url).searchParams.toString()],
     () => {
       const $url = new URL(url);
 


### PR DESCRIPTION
@beganovich @turbo124 The PR addresses the bug related to query invalidation for comboboxes across the entire app. In the old component, `Debounced Combobox`, we had a query key specified to the `pathname of the URL`. This was the method for invalidating queries throughout the application. However, when we changed it in the newly created comboboxes, query invalidation broke. I've simply added the `queryKey` definition under the new combobox component, which should resolve the bug throughout the app. Let me know your thoughts.