### PR TITLE
[Bugfix] Combobox Invalidation/Caching && Additional Optional Chaining On Client Page

### DIFF
--- a/src/pages/clients/edit/components/AdditionalInfo.tsx
+++ b/src/pages/clients/edit/components/AdditionalInfo.tsx
@@ -103,7 +103,7 @@ export function AdditionalInfo({ client, errors, setClient }: Props) {
           {currencies.length > 1 && (
             <Element leftSide={t('currency')}>
               <CurrencySelector
-                value={client?.settings.currency_id || ''}
+                value={client?.settings?.currency_id || ''}
                 onChange={(v) => handleSettingsChange('currency_id', v)}
                 errorMessage={errors?.errors['settings.currency_id']}
                 dismissable

--- a/src/pages/payments/create/Create.tsx
+++ b/src/pages/payments/create/Create.tsx
@@ -173,7 +173,7 @@ export default function Create() {
       (current) =>
         current && {
           ...current,
-          currency_id: current.client?.settings.currency_id
+          currency_id: current.client?.settings.currency_id,
           // amount: collect(payment?.invoices).sum('amount') as number,
         }
     );
@@ -279,16 +279,27 @@ export default function Create() {
                         value: invoice.invoice_id,
                         label: t('invoice') ?? '',
                       }}
-                      endpoint={
-                          endpoint(
-                            `/api/v1/invoices?payable=${payment.client_id}&per_page=100`
-                          )
-                      }
+                      endpoint={endpoint(
+                        `/api/v1/invoices?payable=${payment.client_id}&per_page=100`
+                      )}
                       entryOptions={{
                         label: 'number',
                         id: 'id',
                         value: 'id',
                         searchable: 'number',
+                        dropdownLabelFn: (invoice) =>
+                          `${t('invoice_number_short')}${invoice.number} - ${t(
+                            'balance'
+                          )} ${formatMoney(
+                            invoice.balance,
+                            payment.client?.country_id,
+                            payment.client?.settings.currency_id
+                          )}`,
+                        inputLabelFn: (invoice) => {
+                          return invoice
+                            ? `${t('invoice_number_short')}${invoice?.number}`
+                            : '';
+                        },
                       }}
                       onChange={(entry) =>
                         entry.resource
@@ -346,9 +357,9 @@ export default function Create() {
           {payment?.client_id && (
             <Element leftSide={t('invoices')}>
               <ComboboxAsync<Invoice>
-                endpoint={
-                    endpoint(`/api/v1/invoices?payable=${payment?.client_id}&per_page=100`)
-                }
+                endpoint={endpoint(
+                  `/api/v1/invoices?payable=${payment?.client_id}&per_page=100`
+                )}
                 inputOptions={{
                   value: 'id',
                 }}
@@ -390,11 +401,9 @@ export default function Create() {
                         value: credit.credit_id,
                         label: t('credit') ?? '',
                       }}
-                      endpoint={
-                          endpoint(
-                            `/api/v1/credits?client_id=${payment.client_id}&per_page=100`
-                          )
-                      }
+                      endpoint={endpoint(
+                        `/api/v1/credits?client_id=${payment.client_id}&per_page=100`
+                      )}
                       entryOptions={{
                         id: 'id',
                         value: 'id',
@@ -465,9 +474,9 @@ export default function Create() {
           {payment?.client_id && (
             <Element leftSide={t('credits')}>
               <ComboboxAsync<Credit>
-                endpoint={
-                    endpoint(`/api/v1/credits?client_id=${payment.client_id}`)
-                }
+                endpoint={endpoint(
+                  `/api/v1/credits?client_id=${payment.client_id}`
+                )}
                 inputOptions={{
                   value: null,
                 }}
@@ -595,10 +604,8 @@ export default function Create() {
               onChange={(value) => {
                 setConvertCurrency(value);
 
-                if (!value)
-                  handleChange('exchange_currency_id', '');
-                else
-                  handleChange('exchange_currency_id', '1')
+                if (!value) handleChange('exchange_currency_id', '');
+                else handleChange('exchange_currency_id', '1');
 
                 handleChange('exchange_rate', 1);
               }}
@@ -610,7 +617,10 @@ export default function Create() {
               exchangeRate={payment.exchange_rate.toString() || '1'}
               exchangeCurrencyId={payment.exchange_currency_id}
               currencyId={payment.currency_id || '1'}
-              amount={collect(payment?.invoices).sum('amount') as number + payment?.amount ?? 0}
+              amount={
+                (collect(payment?.invoices).sum('amount') as number) +
+                  payment?.amount ?? 0
+              }
               onChange={(exchangeRate, exchangeCurrencyId) => {
                 handleChange('exchange_rate', exchangeRate);
                 handleChange('exchange_currency_id', exchangeCurrencyId);


### PR DESCRIPTION
@beganovich @turbo124 The PR includes finalizing the query key invalidation/caching for Combobox components and all adjustments related to it. The additional bug that I found, which actually caused the screen to go blank, is on the Client creation page. We had a case where the `client?.settings` object did not exist, and we were trying to read currency_id from it, which resulted in the page going blank. Let me know your thoughts.