### PR TITLE
[Bugfix] New Invoice Navigation | Client Action

### DIFF
--- a/src/pages/clients/common/hooks/useActions.tsx
+++ b/src/pages/clients/common/hooks/useActions.tsx
@@ -80,7 +80,7 @@ export function useActions(params: Params) {
     (client) =>
       !client.is_deleted && (
         <DropdownElement
-          onClick={route('/invoices/create?client=:id', { id: client.id })}
+          to={route('/invoices/create?client=:id', { id: client.id })}
           icon={<Icon element={BiPlusCircle} />}
         >
           {t('new_invoice')}


### PR DESCRIPTION
@beganovich @turbo124 The `new_invoice` action was not navigating to the `invoice` creation page at all. Therefore, this PR addresses and fixes this issue. Let me know your thoughts.