### PR TITLE
[Feature] Products Selection On Reports | Products Sales & Invoice Item

### DIFF
--- a/src/pages/reports/common/components/ProductItemsSelector.tsx
+++ b/src/pages/reports/common/components/ProductItemsSelector.tsx
@@ -1,0 +1,91 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { useProductsQuery } from '$app/common/queries/products';
+import { Element } from '$app/components/cards';
+import { SelectOption } from '$app/components/datatables/Actions';
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import Select, { MultiValue, StylesConfig } from 'react-select';
+import { Report } from '../../index/Reports';
+
+interface Props {
+  setReport: Dispatch<SetStateAction<Report>>;
+}
+export function ProductItemsSelector(props: Props) {
+  const [t] = useTranslation();
+
+  const { setReport } = props;
+
+  const [productItems, setProductItems] = useState<SelectOption[]>([]);
+
+  const { data: products } = useProductsQuery();
+
+  useEffect(() => {
+    if (products) {
+      setProductItems(
+        products.map((product) => ({
+          value: product.product_key,
+          label: product.product_key,
+          color: 'black',
+          backgroundColor: '#e4e4e4',
+        }))
+      );
+    }
+  }, [products]);
+
+  const handleChange = (
+    products: MultiValue<{ value: string; label: string }>
+  ) => {
+    const values: Array<string> = (products as SelectOption[]).map(
+      (option: { value: string; label: string }) => option.value
+    );
+
+    setReport((current) => ({
+      ...current,
+      payload: { ...current.payload, product_key: values.join(',') },
+    }));
+  };
+
+  const customStyles: StylesConfig<SelectOption, true> = {
+    multiValue: (styles, { data }) => {
+      return {
+        ...styles,
+        backgroundColor: data.backgroundColor,
+        color: data.color,
+        borderRadius: '3px',
+      };
+    },
+    multiValueLabel: (styles, { data }) => ({
+      ...styles,
+      color: data.color,
+    }),
+    multiValueRemove: (styles) => ({
+      ...styles,
+      ':hover': {
+        color: 'white',
+      },
+      color: '#999999',
+    }),
+  };
+
+  return (
+    <Element leftSide={t('products')}>
+      <Select
+        styles={customStyles}
+        defaultValue={null}
+        onChange={(options) => handleChange(options)}
+        placeholder={t('products')}
+        options={productItems}
+        isMulti={true}
+      />
+    </Element>
+  );
+}

--- a/src/pages/reports/index/Reports.tsx
+++ b/src/pages/reports/index/Reports.tsx
@@ -32,6 +32,7 @@ import {
 import { useReports } from '../common/useReports';
 import { usePreferences } from '$app/common/hooks/usePreferences';
 import collect from 'collect.js';
+import { ProductItemsSelector } from '../common/components/ProductItemsSelector';
 
 export type Identifier =
   | 'activity'
@@ -77,7 +78,7 @@ const ranges: Range[] = [
   { identifier: 'custom', label: 'custom' },
 ];
 
-interface Report {
+export interface Report {
   identifier: Identifier;
   label: string;
   endpoint: string;
@@ -98,6 +99,7 @@ interface Payload {
   is_expense_billed?: boolean;
   include_tax?: boolean;
   status?: string;
+  product_key?: string;
 }
 
 export default function Reports() {
@@ -344,6 +346,11 @@ export default function Reports() {
                 isMulti={true}
               />
             </Element>
+          )}
+
+          {(report.identifier === 'product_sales' ||
+            report.identifier === 'invoice_item') && (
+            <ProductItemsSelector setReport={setReport} />
           )}
         </Card>
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of a selector for Products on the Report page for Invoice Item and Product Sales reports. Screenshot:

![Screenshot 2023-10-31 at 00 54 15](https://github.com/invoiceninja/ui/assets/51542191/34937eb6-a8ab-45ef-a91b-9090b8a65f16)

@turbo124 Can you please confirm just two things to ensure I understood you correctly from the video. Do we need to send `product keys` in a comma-separated list within the `payload` object under the `property_key` property?

Let me know your thoughts.