### PR TITLE
[Bugfix] Client Selector Not Showing For Some Permissions

### DIFF
--- a/src/components/clients/ClientSelector.tsx
+++ b/src/components/clients/ClientSelector.tsx
@@ -17,6 +17,11 @@ import { useTranslation } from 'react-i18next';
 import { ComboboxAsync } from '../forms/Combobox';
 import { Alert } from '../Alert';
 import { endpoint } from '$app/common/helpers';
+import {
+  Permissions,
+  useHasPermission,
+} from '$app/common/hooks/permissions/useHasPermission';
+import { useLocation } from 'react-router-dom';
 
 export interface ClientSelectorProps extends GenericSelectorProps<Client> {
   initiallyVisible?: boolean;
@@ -27,9 +32,59 @@ export interface ClientSelectorProps extends GenericSelectorProps<Client> {
   clearInputAfterSelection?: boolean;
 }
 
+export const REQUIRED_PERMISSIONS = [
+  {
+    page: 'invoices',
+    permission: 'create_invoice',
+  },
+  {
+    page: 'payments',
+    permission: 'create_payment',
+  },
+  {
+    page: 'recurring_invoices',
+    permission: 'create_recurring_invoice',
+  },
+  {
+    page: 'quotes',
+    permission: 'create_quote',
+  },
+  {
+    page: 'credits',
+    permission: 'create_credit',
+  },
+  {
+    page: 'projects',
+    permission: 'create_project',
+  },
+  {
+    page: 'tasks',
+    permission: 'create_task',
+  },
+  {
+    page: 'expenses',
+    permission: 'create_expense',
+  },
+  {
+    page: 'recurring_expenses',
+    permission: 'create_recurring_expense',
+  },
+];
+
 export function ClientSelector(props: ClientSelectorProps) {
   const [t] = useTranslation();
+  const location = useLocation();
   const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const hasPermission = useHasPermission();
+
+  const disableByPermission = () => {
+    const permission = REQUIRED_PERMISSIONS.find(({ page }) =>
+      location.pathname.startsWith(`/${page}`)
+    )?.permission;
+
+    return Boolean(permission) && !hasPermission(permission as Permissions);
+  };
 
   return (
     <>
@@ -45,7 +100,7 @@ export function ClientSelector(props: ClientSelectorProps) {
           value: props.value || null,
         }}
         endpoint={endpoint('/api/v1/clients')}
-        readonly={props.readonly}
+        readonly={props.readonly || disableByPermission()}
         onDismiss={props.onClearButtonClick}
         querySpecificEntry="/api/v1/clients/:id"
         initiallyVisible={props.initiallyVisible}
@@ -56,7 +111,10 @@ export function ClientSelector(props: ClientSelectorProps) {
         exclude={props.exclude}
         action={{
           label: t('new_client'),
-          visible: props.withoutAction ? false : true,
+          visible:
+            props.withoutAction || !hasPermission('create_client')
+              ? false
+              : true,
           onClick: () => setIsModalOpen(true),
         }}
         key="client_selector"

--- a/src/components/clients/ClientSelector.tsx
+++ b/src/components/clients/ClientSelector.tsx
@@ -17,11 +17,7 @@ import { useTranslation } from 'react-i18next';
 import { ComboboxAsync } from '../forms/Combobox';
 import { Alert } from '../Alert';
 import { endpoint } from '$app/common/helpers';
-import {
-  Permissions,
-  useHasPermission,
-} from '$app/common/hooks/permissions/useHasPermission';
-import { useLocation } from 'react-router-dom';
+import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 
 export interface ClientSelectorProps extends GenericSelectorProps<Client> {
   initiallyVisible?: boolean;
@@ -32,59 +28,11 @@ export interface ClientSelectorProps extends GenericSelectorProps<Client> {
   clearInputAfterSelection?: boolean;
 }
 
-export const REQUIRED_PERMISSIONS = [
-  {
-    page: 'invoices',
-    permission: 'create_invoice',
-  },
-  {
-    page: 'payments',
-    permission: 'create_payment',
-  },
-  {
-    page: 'recurring_invoices',
-    permission: 'create_recurring_invoice',
-  },
-  {
-    page: 'quotes',
-    permission: 'create_quote',
-  },
-  {
-    page: 'credits',
-    permission: 'create_credit',
-  },
-  {
-    page: 'projects',
-    permission: 'create_project',
-  },
-  {
-    page: 'tasks',
-    permission: 'create_task',
-  },
-  {
-    page: 'expenses',
-    permission: 'create_expense',
-  },
-  {
-    page: 'recurring_expenses',
-    permission: 'create_recurring_expense',
-  },
-];
-
 export function ClientSelector(props: ClientSelectorProps) {
   const [t] = useTranslation();
-  const location = useLocation();
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const hasPermission = useHasPermission();
-
-  const disableByPermission = () => {
-    const permission = REQUIRED_PERMISSIONS.find(({ page }) =>
-      location.pathname.startsWith(`/${page}`)
-    )?.permission;
-
-    return Boolean(permission) && !hasPermission(permission as Permissions);
-  };
 
   return (
     <>
@@ -100,7 +48,7 @@ export function ClientSelector(props: ClientSelectorProps) {
           value: props.value || null,
         }}
         endpoint={endpoint('/api/v1/clients')}
-        readonly={props.readonly || disableByPermission()}
+        readonly={props.readonly}
         onDismiss={props.onClearButtonClick}
         querySpecificEntry="/api/v1/clients/:id"
         initiallyVisible={props.initiallyVisible}

--- a/src/pages/invoices/common/components/ClientSelector.tsx
+++ b/src/pages/invoices/common/components/ClientSelector.tsx
@@ -15,15 +15,9 @@ import { Invoice } from '$app/common/interfaces/invoice';
 import { RecurringInvoice } from '$app/common/interfaces/recurring-invoice';
 import { ChangeEvent, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  REQUIRED_PERMISSIONS,
-  ClientSelector as Selector,
-} from '$app/components/clients/ClientSelector';
+import { ClientSelector as Selector } from '$app/components/clients/ClientSelector';
 import { route } from '$app/common/helpers/route';
-import {
-  Permissions,
-  useHasPermission,
-} from '$app/common/hooks/permissions/useHasPermission';
+import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 import { CopyToClipboardIconOnly } from '$app/components/CopyToClipBoardIconOnly';
 import { useColorScheme } from '$app/common/colors';
 
@@ -61,14 +55,6 @@ export function ClientSelector(props: Props) {
         .then((client) => setClient(client));
   }, [resource?.client_id]);
 
-  const disableByPermission = () => {
-    const permission = REQUIRED_PERMISSIONS.find(({ page }) =>
-      location.pathname.startsWith(`/${page}`)
-    )?.permission;
-
-    return Boolean(permission) && !hasPermission(permission as Permissions);
-  };
-
   const hasPermission = useHasPermission();
   const colors = useColorScheme();
 
@@ -85,7 +71,7 @@ export function ClientSelector(props: Props) {
             inputLabel={t('client')}
             onChange={(client) => props.onChange(client.id)}
             value={resource?.client_id}
-            readonly={props.readonly || !resource || disableByPermission()}
+            readonly={props.readonly || !resource}
             clearButton={Boolean(resource?.client_id)}
             onClearButtonClick={props.onClearButtonClick}
             initiallyVisible={!resource?.client_id}


### PR DESCRIPTION
@beganovich @turbo124 The PR includes bug fixes for not showing the Client selector when a user has appropriate permissions. Additionally, I noticed that if a user does not have the "create_client" permission, we still show the "new_client" action in the combo list, which allows us to open the client slider for client creation. I believe there is no need to show this action without having the necessary permission. So, if a user has the "create_client" permissions, the "new_client" action will be shown, otherwise, it will not. Let me know your thoughts.