### PR TITLE
[Bugfix] Ensuring 400 erros are shown in toaster

### DIFF
--- a/src/common/helpers/request.ts
+++ b/src/common/helpers/request.ts
@@ -31,10 +31,9 @@ client.interceptors.response.use(
 
     if (
       error.response?.status &&
-      error.response.status !== 401 &&
       error.response.status !== 412 &&
       error.response.status !== 422 &&
-      error.response.status !== 400 && // Temporary solution. If you see this in few months, please delete (live previews).
+      !error.request.url.includes('live_preview') && // Temporary solution. If you see this in few months, please delete (live previews).
       error.response.status > 399 &&
       error.response.status < 500
     ) {

--- a/src/common/helpers/request.ts
+++ b/src/common/helpers/request.ts
@@ -33,7 +33,6 @@ client.interceptors.response.use(
       error.response?.status &&
       error.response.status !== 412 &&
       error.response.status !== 422 &&
-      !error.request.url.includes('live_preview') && // Temporary solution. If you see this in few months, please delete (live previews).
       error.response.status > 399 &&
       error.response.status < 500
     ) {

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -53,8 +53,6 @@ import classNames from 'classnames';
 import { Guard } from '$app/common/guards/Guard';
 import { EntityState } from '$app/common/enums/entity-state';
 import collect from 'collect.js';
-import { AxiosError } from 'axios';
-import { ValidationBag } from '$app/common/interfaces/validation-bag';
 import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-api-response';
 
 export type DataTableColumns<T = any> = {
@@ -271,11 +269,6 @@ export function DataTable<T extends object>(props: Props<T>) {
             },
           })
         );
-      })
-      .catch((error: AxiosError<ValidationBag>) => {
-        if (error.response?.status === 401) {
-          toast.error(error.response?.data.message);
-        }
       })
       .finally(() => {
         queryClient.invalidateQueries([props.endpoint]);

--- a/src/pages/settings/company/edit/CompanyEdit.tsx
+++ b/src/pages/settings/company/edit/CompanyEdit.tsx
@@ -113,10 +113,7 @@ export function CompanyEdit(props: Props) {
           if (subdomain && isHosted()) {
             request('POST', endpoint('/api/v1/check_subdomain'), {
               subdomain: subdomain,
-            }).catch((error: AxiosError) => {
-              if (error?.response?.status === 401) {
-                toast.error('subdomain_is_not_available');
-              }
+            }).catch(() => {
               return;
             });
           }

--- a/src/pages/settings/users/edit/components/Actions.tsx
+++ b/src/pages/settings/users/edit/components/Actions.tsx
@@ -69,10 +69,6 @@ export function Actions(props: Props) {
         if (error.response?.status === 412) {
           toast.error('password_error_incorrect');
         }
-
-        if (error.response?.status === 401) {
-          toast.error(error.response?.data.message);
-        }
       });
   };
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for displaying a 401 error message in the toaster. To ensure that the entire logic is correct, here it is:

- If a user receives a 429 OR 403 error, they will be logged out of the app.
- If a user receives a 404 error, they will be navigated to the "not_found" page.
- If a user receives a 412 error, it will be displayed as a "wrong password" message in the toaster. It is catched throughout the entire app.
- If a user receives a 422 error, it will be displayed as a validation message under the field.
- If a user receives any error between 400 (including 400) and 500, the message will be displayed in the toaster.
- If a user receives a 500 error, we will display a "Something went wrong" message in the toaster.

Let me know your thoughts.