### PR TITLE
[Cleanup] Sorting Lists In Alphabetical Order

### DIFF
--- a/src/common/generic/DesignSelector.tsx
+++ b/src/common/generic/DesignSelector.tsx
@@ -106,6 +106,7 @@ export function DesignSelector(props: Props) {
               typeof props.actionVisibility === 'undefined' ||
               props.actionVisibility,
           }}
+          sortBy="name|asc"
           onDismiss={() => setDesign(null)}
           disableWithQueryParameter={props.disableWithQueryParameter}
           errorMessage={
@@ -140,6 +141,7 @@ export function DesignSelector(props: Props) {
             typeof props.actionVisibility === 'undefined' ||
             props.actionVisibility,
         }}
+        sortBy="name|asc"
         onDismiss={props.onClearButtonClick}
         disableWithQueryParameter={props.disableWithQueryParameter}
         errorMessage={props.errorMessage}

--- a/src/common/queries/designs.ts
+++ b/src/common/queries/designs.ts
@@ -22,7 +22,10 @@ export function useDesignsQuery() {
   return useQuery<Design[]>(
     ['/api/v1/designs'],
     () =>
-      request('GET', endpoint('/api/v1/designs?status=active')).then(
+      request(
+        'GET',
+        endpoint('/api/v1/designs?status=active&sort=name|asc')
+      ).then(
         (response: AxiosResponse<GenericManyResponse<Design>>) =>
           response.data.data
       ),

--- a/src/common/queries/expense-categories.ts
+++ b/src/common/queries/expense-categories.ts
@@ -33,7 +33,7 @@ export function useExpenseCategoriesQuery(params: ExpenseCategoriesParams) {
           {
             perPage: params.perPage ?? '100',
             currentPage: params.currentPage ?? '1',
-            sort: params.sort ?? 'id|asc',
+            sort: params.sort ?? 'name|asc',
             filter: params.filter ?? '',
             status: params.status?.join(',') ?? '',
           }

--- a/src/components/payment-types/PaymentTypeSelector.tsx
+++ b/src/components/payment-types/PaymentTypeSelector.tsx
@@ -22,11 +22,13 @@ export function PaymentTypeSelector(props: GenericSelectorProps) {
       withBlank
       errorMessage={props.errorMessage}
     >
-      {statics.data?.payment_types.map((type, index) => (
-        <option key={index} value={type.id}>
-          {type.name}
-        </option>
-      ))}
+      {statics.data?.payment_types
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .map((type, index) => (
+          <option key={index} value={type.id}>
+            {type.name}
+          </option>
+        ))}
     </SelectField>
   );
 }

--- a/src/components/tax-rates/TaxRateSelector.tsx
+++ b/src/components/tax-rates/TaxRateSelector.tsx
@@ -49,6 +49,7 @@ export function TaxRateSelector(props: Props) {
             taxRate ? `${taxRate.name} ${taxRate.rate}%` : '',
           dropdownLabelFn: (taxRate) => `${taxRate.name} ${taxRate.rate}%`,
         }}
+        sortBy="name|asc"
         onDismiss={props.onClearButtonClick}
       />
 

--- a/src/pages/expenses/common/hooks/useCustomBulkActions.tsx
+++ b/src/pages/expenses/common/hooks/useCustomBulkActions.tsx
@@ -89,6 +89,7 @@ function ChangeCategory({
           label: 'name',
           value: 'id',
         }}
+        sortBy="name|asc"
         onChange={(e) => (e.resource ? setCategory(e.resource.id) : null)}
       />
 
@@ -142,7 +143,7 @@ export const useCustomBulkActions = () => {
         {t('documents')}
       </DropdownElement>
     ),
-    ({selectedResources, setSelected}) => (
+    ({ selectedResources, setSelected }) => (
       <>
         {selectedResources ? (
           <ChangeCategory

--- a/src/pages/settings/localization/components/Settings.tsx
+++ b/src/pages/settings/localization/components/Settings.tsx
@@ -165,11 +165,13 @@ export function Settings() {
               handlePropertyChange('settings.timezone_id', v)
             }
           >
-            {statics?.timezones.map((timezone: Timezone) => (
-              <option value={timezone.id} key={timezone.id}>
-                {timezone.name}
-              </option>
-            ))}
+            {statics?.timezones
+              .sort((a, b) => a.name.localeCompare(b.name))
+              .map((timezone: Timezone) => (
+                <option value={timezone.id} key={timezone.id}>
+                  {timezone.name}
+                </option>
+              ))}
           </SearchableSelect>
         </Element>
 


### PR DESCRIPTION
@turbo124 @beganovich The PR includes changes that order lists for `expense_categories`, `designs`, `tax_rates`, `payment_types`, and `timezones`. These changes involve ordering them in `ascending` order by the `name` of the entity `(A -> Z)`. This adjustment applies to comboboxes or selectors. Let me know your thoughts.