### PR TITLE
[Bugfix] Overflow Issue On The Company Edit Modal && Showing Missing Toaster Error Message

### DIFF
--- a/src/pages/settings/company/create/CompanyCreate.tsx
+++ b/src/pages/settings/company/create/CompanyCreate.tsx
@@ -9,7 +9,7 @@
  */
 
 import { Button } from '$app/components/forms';
-import { AxiosResponse } from 'axios';
+import { AxiosError, AxiosResponse } from 'axios';
 import { AuthenticationTypes } from '$app/common/dtos/authentication';
 import { endpoint } from '$app/common/helpers';
 import { request } from '$app/common/helpers/request';
@@ -22,6 +22,7 @@ import { useState, SetStateAction, Dispatch } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from 'react-query';
 import { useDispatch } from 'react-redux';
+import { ValidationBag } from '$app/common/interfaces/validation-bag';
 
 interface Props {
   isModalOpen: boolean;
@@ -88,6 +89,14 @@ export function CompanyCreate(props: Props) {
             .finally(() =>
               localStorage.setItem('COMPANY-EDIT-OPENED', 'false')
             );
+        })
+        .catch((error: AxiosError<ValidationBag>) => {
+          if (
+            error.response?.status === 422 &&
+            error.response.data.errors.name
+          ) {
+            toast.error(error.response.data.errors.name[0]);
+          }
         })
         .finally(() => setIsFormBusy(false));
     }

--- a/src/pages/settings/company/edit/CompanyEdit.tsx
+++ b/src/pages/settings/company/edit/CompanyEdit.tsx
@@ -162,6 +162,7 @@ export function CompanyEdit(props: Props) {
         setErrors(undefined);
       }}
       backgroundColor="white"
+      overflowVisible
     >
       <InputField
         label={t('company_name')}


### PR DESCRIPTION
@beganovich @turbo124 The PR fixes this bug:

![Screenshot 2023-11-17 at 02 12 30](https://github.com/invoiceninja/ui/assets/51542191/fcc2b177-1acc-49bc-9f11-8af938b8747a)

Additionally, we did not display the message in the toaster regarding the number of companies that the user is able to create. The reason for that is because it is a 422 error, and we needed to show it in the toaster instead of displaying it under the field. Now, it is shown to the user in the toaster. Screenshot:

![Screenshot 2023-11-17 at 02 14 20](https://github.com/invoiceninja/ui/assets/51542191/7ed4133c-91fe-4b6f-9479-f57763602d91)

Let me know your thoughts.