### PR TITLE
[Bugfix] Displaying Only 'Active' Task Statuses In The Kanban

### DIFF
--- a/src/pages/tasks/kanban/Kanban.tsx
+++ b/src/pages/tasks/kanban/Kanban.tsx
@@ -99,7 +99,7 @@ export default function Kanban() {
 
   const [isTaskModalOpened, setIsTaskModalOpened] = useState<boolean>(false);
 
-  const { data: taskStatuses } = useTaskStatusesQuery();
+  const { data: taskStatuses } = useTaskStatusesQuery({ status: 'active' });
 
   const { data: tasks } = useTasksQuery({
     endpoint: apiEndpoint,


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixing a bug to display only tasks with the 'Active' status in the Kanban. Let me know your thoughts.