### PR TITLE
[Cleanup] Removing Client And Contact Fields Tabs From Edit Client Page && Quick UI Fix With Spacing

### DIFF
--- a/src/pages/clients/edit/Edit.tsx
+++ b/src/pages/clients/edit/Edit.tsx
@@ -142,8 +142,8 @@ export default function Edit() {
       {isLoading && <Spinner />}
 
       {client && (
-        <div className="flex flex-col xl:flex-row xl:gap-4">
-          <div className="w-full xl:w-1/2">
+        <div className="flex flex-col xl:flex-row xl:space-x-4">
+          <div className="flex flex-col w-full xl:w-1/2 space-y-4">
             <Details
               client={client}
               setClient={setClient}
@@ -159,7 +159,7 @@ export default function Edit() {
             />
           </div>
 
-          <div className="w-full xl:w-1/2">
+          <div className="flex flex-col w-full xl:w-1/2 space-y-4">
             <Contacts
               contacts={contacts}
               setContacts={setContacts}

--- a/src/pages/clients/edit/components/AdditionalInfo.tsx
+++ b/src/pages/clients/edit/components/AdditionalInfo.tsx
@@ -9,7 +9,7 @@
  */
 
 import { Card, Element } from '$app/components/cards';
-import { InputField, Link, SelectField } from '$app/components/forms';
+import { InputField, SelectField } from '$app/components/forms';
 import { endpoint } from '$app/common/helpers';
 import { useCurrencies } from '$app/common/hooks/useCurrencies';
 import { useLanguages } from '$app/common/hooks/useLanguages';
@@ -80,8 +80,6 @@ export function AdditionalInfo({ client, errors, setClient }: Props) {
     t('settings'),
     t('notes'),
     t('classify'),
-    t('client_fields'),
-    t('contact_fields'),
     t('documents'),
   ]);
 
@@ -261,20 +259,6 @@ export function AdditionalInfo({ client, errors, setClient }: Props) {
               </SelectField>
             </Element>
           )}
-        </div>
-
-        <div>
-          <span className="text-sm">{t('custom_fields')} &nbsp;</span>
-          <Link to="/settings/custom_fields/clients" className="capitalize">
-            {t('click_here')}
-          </Link>
-        </div>
-
-        <div>
-          <span className="text-sm">{t('custom_fields')} &nbsp;</span>
-          <Link to="/settings/custom_fields/clients" className="capitalize">
-            {t('click_here')}
-          </Link>
         </div>
 
         {id ? (


### PR DESCRIPTION
@beganovich @turbo124 The PR involves removing the tabs for Client and Contact fields from the Edit Client page. Screenshot:

![Screenshot 2023-11-20 at 20 01 38](https://github.com/invoiceninja/ui/assets/51542191/d4e06baa-1bcd-4515-b6c7-f3ab1e12bfd4)

Additionally, I have addressed the spacing issue between cards on this page. The screenshot of issue:

![Screenshot 2023-11-20 at 20 02 54](https://github.com/invoiceninja/ui/assets/51542191/a4bfc562-e9a3-4869-a170-7c3048c98fef)

Let me know your thoughts.