### PR TITLE
[Bugfix] Add Tasks To Invoice Bulk Action | Tasks

### DIFF
--- a/src/pages/tasks/common/components/AddTasksOnInvoiceAction.tsx
+++ b/src/pages/tasks/common/components/AddTasksOnInvoiceAction.tsx
@@ -12,7 +12,7 @@ import { endpoint, trans } from '$app/common/helpers';
 import { Task } from '$app/common/interfaces/task';
 import { DropdownElement } from '$app/components/dropdown/DropdownElement';
 import { Icon } from '$app/components/icons/Icon';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { MdAddCircleOutline } from 'react-icons/md';
 import { AddTasksOnInvoiceModal } from './AddTasksOnInvoiceModal';
 import { toast } from '$app/common/helpers/toast/toast';
@@ -28,7 +28,7 @@ interface Props {
 }
 
 export function AddTasksOnInvoiceAction(props: Props) {
-  const { tasks, isBulkAction } = props;
+  const { tasks, isBulkAction, setSelected } = props;
 
   const queryClient = useQueryClient();
 
@@ -84,11 +84,13 @@ export function AddTasksOnInvoiceAction(props: Props) {
           setInvoices(response.data.data);
 
           setIsModalVisible(true);
-
-          props.setSelected?.([]);
         })
     );
   };
+
+  useEffect(() => {
+    !isModalVisible && setSelected?.([]);
+  }, [isModalVisible]);
 
   return (tasks.length && tasks[0].client_id && !tasks[0].invoice_id) ||
     isBulkAction ? (


### PR DESCRIPTION
@beganovich @turbo124 The PR addresses the bug with the "Add Tasks To Invoice Bulk Action." The bug was related to setting selected resources as an empty string at the wrong time, which is why we did not have any new task line items on the invoice page. Let me know your thoughts.