### PR TITLE
[Bugfix] Product Fields Tab UI Fix && Additional Test To Check Correct Rendering

### DIFF
--- a/src/pages/products/routes.tsx
+++ b/src/pages/products/routes.tsx
@@ -79,10 +79,14 @@ export const productRoutes = (
       <Route path="" element={<Show />} />
       <Route path="documents" element={<Documents />} />
     </Route>
+
     <Route
-      path=":id/product_fields"
-      element={<Guard guards={[admin()]} component={<ProductFields />} />}
-    />
+      path=":id"
+      element={<Guard guards={[admin()]} component={<Product />} />}
+    >
+      <Route path="product_fields" element={<ProductFields />} />
+    </Route>
+
     <Route
       path=":id/edit"
       element={

--- a/tests/e2e/product.spec.ts
+++ b/tests/e2e/product.spec.ts
@@ -119,6 +119,17 @@ const checkEditPage = async (
         .locator('[data-cy="tabs"]')
         .getByRole('link', { name: 'Documents', exact: true })
     ).toBeVisible();
+
+    await page
+      .locator('[data-cy="tabs"]')
+      .getByRole('link', { name: 'Documents', exact: true })
+      .click();
+
+    await page.waitForURL('**/products/**/documents');
+
+    await expect(
+      page.getByRole('heading', { name: 'Upload', exact: true })
+    ).toBeVisible();
   } else {
     await expect(
       page
@@ -151,6 +162,28 @@ const checkEditPage = async (
         .locator('[data-cy="tabs"]')
         .getByRole('link', { name: 'Product Fields', exact: true })
     ).toBeVisible();
+
+    await page
+      .locator('[data-cy="tabs"]')
+      .getByRole('link', { name: 'Product Fields', exact: true })
+      .click();
+
+    await page.waitForURL('**/products/**/product_fields');
+
+    await expect(
+      page.getByRole('heading', { name: 'Custom Fields', exact: true })
+    ).toBeVisible();
+  }
+
+  const url = page.url();
+
+  if (url !== '**/products/**/edit') {
+    await page
+      .locator('[data-cy="tabs"]')
+      .getByRole('link', { name: 'Product Fields', exact: true })
+      .click();
+
+    await page.waitForURL('**/products/**/edit');
   }
 };
 

--- a/tests/e2e/product.spec.ts
+++ b/tests/e2e/product.spec.ts
@@ -119,17 +119,6 @@ const checkEditPage = async (
         .locator('[data-cy="tabs"]')
         .getByRole('link', { name: 'Documents', exact: true })
     ).toBeVisible();
-
-    await page
-      .locator('[data-cy="tabs"]')
-      .getByRole('link', { name: 'Documents', exact: true })
-      .click();
-
-    await page.waitForURL('**/products/**/documents');
-
-    await expect(
-      page.getByRole('heading', { name: 'Upload', exact: true })
-    ).toBeVisible();
   } else {
     await expect(
       page
@@ -162,30 +151,6 @@ const checkEditPage = async (
         .locator('[data-cy="tabs"]')
         .getByRole('link', { name: 'Product Fields', exact: true })
     ).toBeVisible();
-
-    await page
-      .locator('[data-cy="tabs"]')
-      .getByRole('link', { name: 'Product Fields', exact: true })
-      .click();
-
-    await page.waitForURL('**/products/**/product_fields');
-
-    await expect(
-      page.getByRole('heading', { name: 'Custom Fields', exact: true })
-    ).toBeVisible();
-  }
-
-  const url = page.url();
-
-  const pattern = /\/products\/.*\/edit/;
-
-  if (!pattern.test(url)) {
-    await page
-      .locator('[data-cy="tabs"]')
-      .getByRole('link', { name: 'Edit', exact: true })
-      .click();
-
-    await page.waitForURL('**/products/**/edit');
   }
 };
 
@@ -750,6 +715,46 @@ test('New Invoice and New Purchase Order displayed with creation permissions', a
     'bulkActionsDropdown',
     'dataTable'
   );
+
+  await logout(page);
+});
+
+test('rendering documents and product_fields tabs with admin permission', async ({
+  page,
+}) => {
+  await login(page);
+
+  await createProduct({ page, name: 'test product tabs' });
+
+  await page
+    .locator('[data-cy="tabs"]')
+    .getByRole('link', { name: 'Documents', exact: true })
+    .click();
+
+  await page.waitForURL('**/products/**/documents');
+
+  await expect(
+    page.getByRole('heading', { name: 'Upload', exact: true })
+  ).toBeVisible();
+
+  await page
+    .locator('[data-cy="tabs"]')
+    .getByRole('link', { name: 'Product Fields', exact: true })
+    .click();
+
+  await page.waitForURL('**/products/**/product_fields');
+
+  await expect(
+    page.getByRole('heading', { name: 'Custom Fields', exact: true })
+  ).toBeVisible();
+
+  await expect(
+    page.getByRole('link', { name: 'Edit', exact: true })
+  ).toBeVisible();
+
+  await expect(
+    page.getByRole('link', { name: 'Documents', exact: true })
+  ).toBeVisible();
 
   await logout(page);
 });

--- a/tests/e2e/product.spec.ts
+++ b/tests/e2e/product.spec.ts
@@ -177,10 +177,12 @@ const checkEditPage = async (
 
   const url = page.url();
 
-  if (url !== '**/products/**/edit') {
+  const pattern = /\/products\/.*\/edit/;
+
+  if (!pattern.test(url)) {
     await page
       .locator('[data-cy="tabs"]')
-      .getByRole('link', { name: 'Product Fields', exact: true })
+      .getByRole('link', { name: 'Edit', exact: true })
       .click();
 
     await page.waitForURL('**/products/**/edit');


### PR DESCRIPTION
@beganovich @turbo124 The PR includes a quick UI fix caused by defining the route for the "product_fields" tab and additional improvements to tests for Products. These changes cover the case and ensure that `documents` and the `product_fields` tabs are correctly rendered. Screenshot of bug:

<img width="1512" alt="Screenshot 2023-11-21 at 18 42 06" src="https://github.com/invoiceninja/ui/assets/51542191/71f691b5-d396-4686-9988-1ccf78d8d4c6">

 Let me know your thoughts.