### PR TITLE
[Bugfix] Single Payment Query Key Definition

### DIFF
--- a/src/common/queries/payments.ts
+++ b/src/common/queries/payments.ts
@@ -28,7 +28,7 @@ interface PaymentParams {
 
 export function usePaymentQuery(params: PaymentParams) {
   return useQuery(
-    ['/api/v1/payment_terms', params.id],
+    ['/api/v1/payments', params.id],
     () =>
       request(
         'GET',


### PR DESCRIPTION
@beganovich @turbo124 The PR includes changing the query key for the single Payment query from `['/api/v1/payment_terms', params.id]` to `['/api/v1/payments', params.id]`. We had correct invalidation, but instead of using 'payments' in the query key, we had 'payment_terms', which directly affected the update of the edit payment page. So, try changing something on the already created Payment, go back to the payments table, and then return to the Payment edit page. The changes will not be reflected there. Let me know your thoughts.