### PR TITLE
Set appropriate taxes depending on how many are configured

### DIFF
--- a/src/pages/invoices/common/hooks/useResolveInputField.tsx
+++ b/src/pages/invoices/common/hooks/useResolveInputField.tsx
@@ -164,6 +164,10 @@ export function useResolveInputField(props: Props) {
     await props.onLineItemPropertyChange(key, value, index);
   };
 
+  const company = useCurrentCompany();
+  const reactSettings = useReactSettings();
+  const resource = props.resource;
+
   const onProductChange = async (
     index: number,
     value: string,
@@ -171,12 +175,30 @@ export function useResolveInputField(props: Props) {
   ) => {
     setIsDeleteActionTriggered(false);
 
+    if (product && company && company.enabled_tax_rates === 0) {
+        product.tax_name1 = '';
+        product.tax_rate1 = 0;
+        product.tax_name2 = '';
+        product.tax_rate2 = 0;
+        product.tax_name3 = '';
+        product.tax_rate3 = 0;
+    }
+
+    if (product && company && company.enabled_tax_rates === 1) {
+        product.tax_name2 = '';
+        product.tax_rate2 = 0;
+        product.tax_name3 = '';
+        product.tax_rate3 = 0;
+    }
+
+    if (product && company && company.enabled_tax_rates === 2) {
+        product.tax_name3 = '';
+        product.tax_rate3 = 0;
+    }
+
     await handleProductChange(index, value, product);
   };
 
-  const company = useCurrentCompany();
-  const reactSettings = useReactSettings();
-  const resource = props.resource;
 
   const formatMoney = useFormatMoney({
     resource: props.resource,


### PR DESCRIPTION
@beganovich this PR helps to set the correct number of tax rates that may be configured on the product itself.

If a user later disables tax rates, we continue to set the tax rates which is unexpected. this PR checks when adding a product the configured number of tax rates, and cleans the product prior to adding.

I *think* this was the best place to add this?