### PR TITLE
[Cleanup] Product Selector | Clear Value Functionality

### DIFF
--- a/src/pages/invoices/common/hooks/useHandleProductChange.ts
+++ b/src/pages/invoices/common/hooks/useHandleProductChange.ts
@@ -9,9 +9,13 @@
  */
 
 import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
-import { InvoiceItem } from '$app/common/interfaces/invoice-item';
+import {
+  InvoiceItem,
+  InvoiceItemType,
+} from '$app/common/interfaces/invoice-item';
 import { Product } from '$app/common/interfaces/product';
 import { ProductTableResource } from '../components/ProductsTable';
+import { blankLineItem } from '$app/common/constants/blank-line-item';
 
 interface Props {
   resource: ProductTableResource;
@@ -33,7 +37,13 @@ export function useHandleProductChange(props: Props) {
       // When we deal with inline product key
       // keep everything but the name.
 
-      return props.onChange(index, lineItem);
+      return props.onChange(index, {
+        ...blankLineItem(),
+        type_id:
+          props.type === 'product'
+            ? InvoiceItemType.Product
+            : InvoiceItemType.Task,
+      });
     }
 
     lineItem.quantity = company?.default_quantity ? 1 : product?.quantity ?? 0;

--- a/src/pages/invoices/common/hooks/useHandleProductChange.ts
+++ b/src/pages/invoices/common/hooks/useHandleProductChange.ts
@@ -29,14 +29,7 @@ export function useHandleProductChange(props: Props) {
   const resource = props.resource;
 
   return (index: number, product_key: string, product: Product | null) => {
-    const lineItem = { ...resource.line_items[index] };
-
-    lineItem.product_key = product?.product_key || product_key;
-
     if (!product) {
-      // When we deal with inline product key
-      // keep everything but the name.
-
       return props.onChange(index, {
         ...blankLineItem(),
         type_id:
@@ -45,6 +38,10 @@ export function useHandleProductChange(props: Props) {
             : InvoiceItemType.Task,
       });
     }
+
+    const lineItem = { ...resource.line_items[index] };
+
+    lineItem.product_key = product?.product_key || product_key;
 
     lineItem.quantity = company?.default_quantity ? 1 : product?.quantity ?? 0;
 


### PR DESCRIPTION
@beganovich @turbo124 The PR involves changing the logic for clearing the Product selector on the Products table. Instead of just removing the value for the Product, we will reset all values in the line item to the blank line item. Let me know your thoughts.