### PR TITLE
[Bugfix] New Invoice | Products

### DIFF
--- a/src/pages/products/common/hooks/useInvoiceProducts.ts
+++ b/src/pages/products/common/hooks/useInvoiceProducts.ts
@@ -31,7 +31,7 @@ export const useInvoiceProducts = () => {
         cost: product.price,
         quantity: product.quantity,
         line_total: Number((product.price * product.quantity).toFixed(2)),
-        product_key: product.id,
+        product_key: product.product_key,
         notes: product.notes,
         tax_name1: product.tax_name1,
         tax_rate1: product.tax_rate1,


### PR DESCRIPTION
@beganovich @turbo124 The PR addresses a bug related to incorrect mapping of the invoice object when created from the products. Instead of matching the `product_key` to the `product_key` property, we inadvertently set the ID of the product to the product_key property. This issue has now been fixed. Let me know your thoughts.