### PR TITLE
[Cleanup] Task Status Action Implementation Along With Modal

### DIFF
--- a/src/common/queries/task-statuses.ts
+++ b/src/common/queries/task-statuses.ts
@@ -17,8 +17,9 @@ import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-ap
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 import { toast } from '$app/common/helpers/toast/toast';
 import { $refetch } from '../hooks/useRefetch';
+import { GenericQueryOptions } from './invoices';
 
-export function useBlankTaskStatusQuery() {
+export function useBlankTaskStatusQuery(options?: GenericQueryOptions) {
   const hasPermission = useHasPermission();
 
   return useQuery<TaskStatus>(
@@ -28,7 +29,10 @@ export function useBlankTaskStatusQuery() {
         (response: GenericSingleResourceResponse<TaskStatus>) =>
           response.data.data
       ),
-    { staleTime: Infinity, enabled: hasPermission('create_task') }
+    {
+      staleTime: Infinity,
+      enabled: hasPermission('create_task') ? options?.enabled ?? true : false,
+    }
   );
 }
 

--- a/src/components/task-statuses/TaskStatusSelector.tsx
+++ b/src/components/task-statuses/TaskStatusSelector.tsx
@@ -11,27 +11,133 @@
 import { endpoint } from '$app/common/helpers';
 import { GenericSelectorProps } from '$app/common/interfaces/generic-selector-props';
 import { TaskStatus } from '$app/common/interfaces/task-status';
+import { useTranslation } from 'react-i18next';
+import { Modal } from '../Modal';
+import { Button, InputField, InputLabel } from '../forms';
+import { ColorPicker } from '../forms/ColorPicker';
 import { ComboboxAsync, Entry } from '../forms/Combobox';
+import { useEffect, useState } from 'react';
+import { ValidationBag } from '$app/common/interfaces/validation-bag';
+import { useBlankTaskStatusQuery } from '$app/common/queries/task-statuses';
+import { useAccentColor } from '$app/common/hooks/useAccentColor';
+import { toast } from '$app/common/helpers/toast/toast';
+import { AxiosError } from 'axios';
+import { $refetch } from '$app/common/hooks/useRefetch';
+import { request } from '$app/common/helpers/request';
+import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-api-response';
 
 export function TaskStatusSelector(props: GenericSelectorProps<TaskStatus>) {
+  const [t] = useTranslation();
+
+  const accentColor = useAccentColor();
+
+  const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
+
+  const [isFormBusy, setIsFormBusy] = useState<boolean>(false);
+
+  const [taskStatus, setTaskStatus] = useState<TaskStatus>();
+  const [errors, setErrors] = useState<ValidationBag>();
+
+  const { data: taskStatusResponse } = useBlankTaskStatusQuery({
+    enabled: isModalVisible,
+  });
+
+  const handleCreateTaskStatus = () => {
+    if (!isFormBusy) {
+      toast.processing();
+
+      setErrors(undefined);
+
+      setIsFormBusy(true);
+
+      request('POST', endpoint('/api/v1/task_statuses'), taskStatus)
+        .then((response: GenericSingleResourceResponse<TaskStatus>) => {
+          toast.success('created_task_status');
+
+          $refetch(['task_statuses']);
+
+          setTaskStatus(taskStatusResponse);
+
+          props.onChange(response.data.data);
+
+          setIsModalVisible(false);
+        })
+        .catch((error: AxiosError<ValidationBag>) => {
+          if (error.response?.status === 422) {
+            setErrors(error.response.data);
+            toast.dismiss();
+          }
+        })
+        .finally(() => setIsFormBusy(false));
+    }
+  };
+
+  useEffect(() => {
+    if (taskStatusResponse) {
+      setTaskStatus(taskStatusResponse);
+    }
+  }, [taskStatusResponse]);
+
   return (
-    <ComboboxAsync<TaskStatus>
-      endpoint={endpoint('/api/v1/task_statuses?status=active')}
-      onChange={(taskStatus: Entry<TaskStatus>) =>
-        taskStatus.resource && props.onChange(taskStatus.resource)
-      }
-      inputOptions={{
-        label: props.inputLabel?.toString(),
-        value: props.value || null,
-      }}
-      entryOptions={{
-        id: 'id',
-        label: 'name',
-        value: 'id',
-      }}
-      onDismiss={props.onClearButtonClick}
-      readonly={props.readonly}
-      errorMessage={props.errorMessage}
-    />
+    <>
+      <Modal
+        title={t('new_task_status')}
+        visible={isModalVisible}
+        onClose={() => {
+          setIsModalVisible(false);
+          setTaskStatus(taskStatusResponse);
+        }}
+      >
+        <InputField
+          required
+          label={t('name')}
+          value={taskStatus?.name}
+          onValueChange={(value) =>
+            setTaskStatus((current) => current && { ...current, name: value })
+          }
+          errorMessage={errors?.errors.name}
+        />
+
+        <InputLabel>{t('color')}</InputLabel>
+        <ColorPicker
+          value={taskStatus?.color || accentColor}
+          onValueChange={(value) =>
+            setTaskStatus((current) => current && { ...current, color: value })
+          }
+        />
+
+        <Button
+          className="self-end"
+          behavior="button"
+          onClick={handleCreateTaskStatus}
+        >
+          {t('save')}
+        </Button>
+      </Modal>
+
+      <ComboboxAsync<TaskStatus>
+        endpoint={endpoint('/api/v1/task_statuses?status=active')}
+        onChange={(taskStatus: Entry<TaskStatus>) =>
+          taskStatus.resource && props.onChange(taskStatus.resource)
+        }
+        inputOptions={{
+          label: props.inputLabel?.toString(),
+          value: props.value || null,
+        }}
+        entryOptions={{
+          id: 'id',
+          label: 'name',
+          value: 'id',
+        }}
+        action={{
+          label: t('new_task_status'),
+          onClick: () => setIsModalVisible(true),
+          visible: true,
+        }}
+        onDismiss={props.onClearButtonClick}
+        readonly={props.readonly}
+        errorMessage={props.errorMessage}
+      />
+    </>
   );
 }

--- a/src/pages/tasks/create/Create.tsx
+++ b/src/pages/tasks/create/Create.tsx
@@ -44,6 +44,9 @@ export default function Create() {
   const [searchParams] = useSearchParams();
   const [errors, setErrors] = useState<ValidationBag>();
 
+  const [isInitialConfiguration, setIsInitialConfiguration] =
+    useState<boolean>(true);
+
   const { data: taskStatuses } = useTaskStatusesQuery();
   const { data } = useBlankTaskQuery({ enabled: typeof task === 'undefined' });
 
@@ -68,9 +71,6 @@ export default function Create() {
       ) {
         const _task = cloneDeep(data);
 
-        _task.status_id =
-          taskStatuses.data.length > 0 ? taskStatuses.data[0].id : '';
-
         if (searchParams.get('client')) {
           _task.client_id = searchParams.get('client')!;
         }
@@ -90,7 +90,22 @@ export default function Create() {
 
       return value;
     });
-  }, [data, taskStatuses]);
+  }, [data]);
+
+  useEffect(() => {
+    if (task && taskStatuses && isInitialConfiguration) {
+      setTask(
+        (current) =>
+          current && {
+            ...current,
+            status_id:
+              taskStatuses.data.length > 0 ? taskStatuses.data[0].id : '',
+          }
+      );
+
+      setIsInitialConfiguration(false);
+    }
+  }, [task, taskStatuses]);
 
   const handleChange = (property: keyof Task, value: unknown) => {
     setTask((current) => current && { ...current, [property]: value });


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of the "new_task_status" action on the Task Status selector and creation modal for creating this entity. Screenshot:

![Screenshot 2023-12-07 at 01 20 27](https://github.com/invoiceninja/ui/assets/51542191/cc8f172f-1144-488f-85fc-e07b07356cb8)

Let me know your thoughts.