### PR TITLE
Allow both onChange and onBlur selectively

### DIFF
--- a/src/components/datatables/Actions.tsx
+++ b/src/components/datatables/Actions.tsx
@@ -153,6 +153,7 @@ export function Actions(props: Props) {
 
         <InputField
           id="filter"
+          changeOverride={true}
           placeholder={t('filter')}
           value={props.filter}
           onValueChange={(value) =>

--- a/src/components/forms/InputField.tsx
+++ b/src/components/forms/InputField.tsx
@@ -37,6 +37,7 @@ interface Props extends CommonProps {
   maxLength?: number;
   autoComplete?: string;
   withoutLabelWrapping?: boolean;
+  changeOverride?: boolean;
 }
 
 export function InputField(props: Props) {
@@ -100,12 +101,15 @@ export function InputField(props: Props) {
           onBlur={(event) => {
             props.onValueChange && props.onValueChange(event.target.value);
             props.onChange && props.onChange(event);
+            console.log(event.target.value);
           }}
-          // onChange={(event) => {
-          //   props.onValueChange && props.onValueChange(event.target.value);
-          //   props.onChange && props.onChange(event);
-          // }}
-          onChange={() => {}}
+          onChange={(event) => {
+            if (props.changeOverride && props.changeOverride === true) {
+                props.onValueChange && props.onValueChange(event.target.value);
+                props.onChange && props.onChange(event);
+              console.log(event.target.value + 'override');
+            }
+          }}
           value={props.value}
           list={props.list}
           rows={props.textareaRows || 5}

--- a/src/components/forms/InputField.tsx
+++ b/src/components/forms/InputField.tsx
@@ -101,13 +101,11 @@ export function InputField(props: Props) {
           onBlur={(event) => {
             props.onValueChange && props.onValueChange(event.target.value);
             props.onChange && props.onChange(event);
-            console.log(event.target.value);
           }}
           onChange={(event) => {
             if (props.changeOverride && props.changeOverride === true) {
                 props.onValueChange && props.onValueChange(event.target.value);
                 props.onChange && props.onChange(event);
-              console.log(event.target.value + 'override');
             }
           }}
           value={props.value}

--- a/src/pages/credits/common/components/CreditDetails.tsx
+++ b/src/pages/credits/common/components/CreditDetails.tsx
@@ -56,6 +56,7 @@ export function CreditDetails(props: Props) {
           <InputField
             id="partial"
             type="number"
+            changeOverride={true}
             onValueChange={(value) =>
               handleChange('partial', parseFloat(value))
             }

--- a/src/pages/invoices/common/components/InvoiceDetails.tsx
+++ b/src/pages/invoices/common/components/InvoiceDetails.tsx
@@ -54,6 +54,7 @@ export function InvoiceDetails(props: Props) {
           <InputField
             id="partial"
             type="number"
+            changeOverride={true}
             onValueChange={(value) =>
               handleChange('partial', parseFloat(value) || 0)
             }

--- a/src/pages/invoices/common/hooks/useHandleProductChange.ts
+++ b/src/pages/invoices/common/hooks/useHandleProductChange.ts
@@ -9,13 +9,9 @@
  */
 
 import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
-import {
-  InvoiceItem,
-  InvoiceItemType,
-} from '$app/common/interfaces/invoice-item';
+import { InvoiceItem } from '$app/common/interfaces/invoice-item';
 import { Product } from '$app/common/interfaces/product';
 import { ProductTableResource } from '../components/ProductsTable';
-import { blankLineItem } from '$app/common/constants/blank-line-item';
 
 interface Props {
   resource: ProductTableResource;
@@ -29,19 +25,16 @@ export function useHandleProductChange(props: Props) {
   const resource = props.resource;
 
   return (index: number, product_key: string, product: Product | null) => {
-    if (!product) {
-      return props.onChange(index, {
-        ...blankLineItem(),
-        type_id:
-          props.type === 'product'
-            ? InvoiceItemType.Product
-            : InvoiceItemType.Task,
-      });
-    }
-
     const lineItem = { ...resource.line_items[index] };
 
     lineItem.product_key = product?.product_key || product_key;
+
+    if (!product) {
+      // When we deal with inline product key
+      // keep everything but the name.
+
+      return props.onChange(index, lineItem);
+    }
 
     lineItem.quantity = company?.default_quantity ? 1 : product?.quantity ?? 0;
 

--- a/src/pages/purchase-orders/edit/components/Details.tsx
+++ b/src/pages/purchase-orders/edit/components/Details.tsx
@@ -57,6 +57,7 @@ export function Details(props: PurchaseOrderCardProps) {
         <Element leftSide={t('partial')}>
           <InputField
             type="number"
+            changeOverride={true}
             value={purchaseOrder.partial}
             onValueChange={(partial) =>
               handleChange('partial', parseFloat(partial) || 0)

--- a/src/pages/quotes/common/components/QuoteDetails.tsx
+++ b/src/pages/quotes/common/components/QuoteDetails.tsx
@@ -55,6 +55,7 @@ export function QuoteDetails(props: Props) {
           <InputField
             id="partial"
             type="number"
+            changeOverride={true}
             onValueChange={(value) =>
               handleChange('partial', parseFloat(value))
             }


### PR DESCRIPTION
This PR allows us to use an override on the Inputfield in order to combine both onBlur and onChange.

There are some inputs which require immediate reactivity (partial) and search fields.

This PR addresses this edge case.
