### PR TITLE
[Bugfix] Purchase Order Cloning

### DIFF
--- a/src/pages/purchase-orders/edit/components/VendorSelector.tsx
+++ b/src/pages/purchase-orders/edit/components/VendorSelector.tsx
@@ -27,17 +27,25 @@ interface Props {
 
 export function VendorSelector(props: Props) {
   const { t } = useTranslation();
-  const [vendor, setVendor] = useState<Vendor>();
+
+  const { resource } = props;
 
   const vendorResolver = useVendorResolver();
 
+  const [vendor, setVendor] = useState<Vendor>();
+  const [vendorId, setVendorId] = useState<string>('');
+
   useEffect(() => {
-    if (props.resource && props.resource.vendor_id.length > 0) {
-      vendorResolver
-        .find(props.resource.vendor_id)
-        .then((vendor) => setVendor(vendor));
+    if (vendorId) {
+      vendorResolver.find(vendorId).then((vendor) => setVendor(vendor));
     }
-  }, [props.resource?.vendor_id]);
+  }, [vendorId]);
+
+  useEffect(() => {
+    if (resource) {
+      setVendorId(resource.vendor_id ?? (resource.vendor?.id || ''));
+    }
+  }, [resource?.vendor_id, resource?.vendor?.id]);
 
   const isChecked = (id: string) => {
     const potential = props.resource?.invitations.find(
@@ -53,15 +61,14 @@ export function VendorSelector(props: Props) {
         <Selector
           inputLabel={t('vendor')}
           onChange={(vendor) => props.onChange(vendor.id)}
-          value={props.resource?.vendor_id}
+          value={vendorId}
           readonly={props.readonly}
-          clearButton={Boolean(props.resource?.vendor_id)}
           onClearButtonClick={props.onClearButtonClick}
           errorMessage={props.errorMessage}
         />
       </div>
 
-      {props.resource?.vendor_id &&
+      {vendorId &&
         vendor &&
         vendor.contacts.map((contact, index) => (
           <div key={index}>

--- a/src/pages/purchase-orders/edit/components/VendorSelector.tsx
+++ b/src/pages/purchase-orders/edit/components/VendorSelector.tsx
@@ -43,7 +43,7 @@ export function VendorSelector(props: Props) {
 
   useEffect(() => {
     if (resource) {
-      setVendorId(resource.vendor_id ?? (resource.vendor?.id || ''));
+      setVendorId(resource.vendor_id || resource.vendor?.id || '');
     }
   }, [resource?.vendor_id, resource?.vendor?.id]);
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for the Vendor Selector when cloning the Purchase Order. The root cause of the bug originates from the purchase_order object response. In this object, the `vendor_id` property is NOT populated, preventing us from fetching the correct Vendor. I have adjusted the logic to retrieve the vendor ID from the Vendor's object under the Purchase Order if the vendor_id property is not populated. Otherwise, we will use the vendor_id property. Here's a quick demo of the bug:

https://github.com/invoiceninja/ui/assets/51542191/857ad95a-4c64-468c-9e7b-b5682089fbc8

Let me know your thoughts.