### PR TITLE
[Cleanup] Showing All Invoice In Invoice Number Payment Column

### DIFF
--- a/src/pages/payments/common/hooks/usePaymentColumns.tsx
+++ b/src/pages/payments/common/hooks/usePaymentColumns.tsx
@@ -158,12 +158,19 @@ export function usePaymentColumns() {
       id: 'id',
       label: t('invoice_number'),
       format: (value, payment) => (
-        <DynamicLink
-          to={route('/invoices/:id/edit', { id: payment.invoices?.[0]?.id })}
-          renderSpan={disableNavigation('invoice', payment.invoices?.[0])}
-        >
-          {payment.invoices?.[0]?.number}
-        </DynamicLink>
+        <div className="flex space-x-2">
+          {payment.invoices?.map((invoice) => (
+            <DynamicLink
+              key={invoice.id}
+              to={route('/invoices/:id/edit', {
+                id: invoice.id,
+              })}
+              renderSpan={disableNavigation('invoice', invoice)}
+            >
+              {invoice.number}
+            </DynamicLink>
+          ))}
+        </div>
       ),
     },
     {


### PR DESCRIPTION
@beganovich @turbo124 The PR includes displaying all invoices linked to the payment instead of just the first one in the invoice number payment column. Screenshot:

![Screenshot 2023-12-13 at 17 29 45](https://github.com/invoiceninja/ui/assets/51542191/6551177e-654a-4da8-9408-54873be9ad40)

Let me know your thoughts.