### PR TITLE
[Cleanup] Remove Logo CTA Implementation On All Edit Pages With PDF Preview

### DIFF
--- a/src/components/RemoveLogoCTA.tsx
+++ b/src/components/RemoveLogoCTA.tsx
@@ -15,14 +15,17 @@ import { proPlan } from '$app/common/guards/guards/pro-plan';
 import { enterprisePlan } from '$app/common/guards/guards/enterprise-plan';
 import { route } from '$app/common/helpers/route';
 import { useCurrentUser } from '$app/common/hooks/useCurrentUser';
+import { useAdmin } from '$app/common/hooks/permissions/useHasPermission';
 
 export function RemoveLogoCTA() {
   const [t] = useTranslation();
   const user = useCurrentUser();
 
+  const { isOwner } = useAdmin();
+
   return (
     <>
-      {!proPlan() && !enterprisePlan() ? (
+      {!proPlan() && !enterprisePlan() && isOwner ? (
         <div className="flex text-base space-x-1">
           <Link
             className="capitalize"

--- a/src/components/RemoveLogoCTA.tsx
+++ b/src/components/RemoveLogoCTA.tsx
@@ -1,0 +1,51 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { trans } from '$app/common/helpers';
+import { useTranslation } from 'react-i18next';
+import { Link } from './forms';
+import { proPlan } from '$app/common/guards/guards/pro-plan';
+import { enterprisePlan } from '$app/common/guards/guards/enterprise-plan';
+import { route } from '$app/common/helpers/route';
+import { useCurrentUser } from '$app/common/hooks/useCurrentUser';
+
+export function RemoveLogoCTA() {
+  const [t] = useTranslation();
+  const user = useCurrentUser();
+
+  return (
+    <>
+      {!proPlan() && !enterprisePlan() ? (
+        <div className="flex text-base space-x-1">
+          <Link
+            className="capitalize"
+            to={
+              user?.company_user?.ninja_portal_url ||
+              route('/settings/account_management')
+            }
+            setBaseFont
+            external={Boolean(user?.company_user?.ninja_portal_url)}
+          >
+            {t('click_here')}
+          </Link>
+
+          <span>
+            {trans('pro_plan_remove_logo', {
+              link: '',
+            })}
+            .
+          </span>
+        </div>
+      ) : (
+        <></>
+      )}
+    </>
+  );
+}

--- a/src/components/RemoveLogoCTA.tsx
+++ b/src/components/RemoveLogoCTA.tsx
@@ -23,32 +23,30 @@ export function RemoveLogoCTA() {
 
   const { isOwner } = useAdmin();
 
-  return (
-    <>
-      {!proPlan() && !enterprisePlan() && isOwner ? (
-        <div className="flex text-base space-x-1">
-          <Link
-            className="capitalize"
-            to={
-              user?.company_user?.ninja_portal_url ||
-              route('/settings/account_management')
-            }
-            setBaseFont
-            external={Boolean(user?.company_user?.ninja_portal_url)}
-          >
-            {t('click_here')}
-          </Link>
+  if (!proPlan() && !enterprisePlan() && isOwner) {
+    return (
+      <div className="flex text-base space-x-1">
+        <Link
+          className="capitalize"
+          to={
+            user?.company_user?.ninja_portal_url ||
+            route('/settings/account_management')
+          }
+          setBaseFont
+          external={Boolean(user?.company_user?.ninja_portal_url)}
+        >
+          {t('click_here')}
+        </Link>
 
-          <span>
-            {trans('pro_plan_remove_logo', {
-              link: '',
-            })}
-            .
-          </span>
-        </div>
-      ) : (
-        <></>
-      )}
-    </>
-  );
+        <span>
+          {trans('pro_plan_remove_logo', {
+            link: '',
+          })}
+          .
+        </span>
+      </div>
+    );
+  }
+
+  return null;
 }

--- a/src/components/forms/Link.tsx
+++ b/src/components/forms/Link.tsx
@@ -12,15 +12,19 @@ import { useAccentColor } from '$app/common/hooks/useAccentColor';
 import React, { ReactNode } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import CommonProps from '../../common/interfaces/common-props.interface';
+import classNames from 'classnames';
 
 interface Props extends CommonProps {
   to: string;
   children: ReactNode;
   external?: boolean;
+  setBaseFont?: boolean;
 }
 
 export function Link(props: Props) {
   const accentColor = useAccentColor();
+
+  const { setBaseFont } = props;
 
   const css: React.CSSProperties = {
     color: accentColor,
@@ -31,7 +35,13 @@ export function Link(props: Props) {
       <a
         target="_blank"
         href={props.to}
-        className={`text-center text-sm hover:underline ${props.className}`}
+        className={classNames(
+          `text-center hover:underline ${props.className}`,
+          {
+            'text-sm': !setBaseFont,
+            'text-base': setBaseFont,
+          }
+        )}
         style={css}
         rel="noreferrer"
       >
@@ -42,7 +52,10 @@ export function Link(props: Props) {
 
   return (
     <RouterLink
-      className={`text-sm hover:underline ${props.className}`}
+      className={classNames(`hover:underline ${props.className}`, {
+        'text-sm': !setBaseFont,
+        'text-base': setBaseFont,
+      })}
       style={css}
       to={props.to}
     >

--- a/src/pages/credits/edit/Edit.tsx
+++ b/src/pages/credits/edit/Edit.tsx
@@ -36,6 +36,7 @@ import { useActions, useCreditUtilities, useSave } from '../common/hooks';
 import { useCreditQuery } from '../common/queries';
 import { Card } from '$app/components/cards';
 import { CreditStatus as CreditStatusBadge } from '../common/components/CreditStatus';
+import { RemoveLogoCTA } from '$app/components/RemoveLogoCTA';
 
 export default function Edit() {
   const { documentTitle } = useTitle('edit_credit');
@@ -171,7 +172,7 @@ export default function Edit() {
       </div>
 
       {reactSettings?.show_pdf_preview && (
-        <div className="my-4">
+        <div className="flex flex-col space-y-3 my-4">
           {credit && (
             <InvoicePreview
               for="invoice"
@@ -181,6 +182,8 @@ export default function Edit() {
               endpoint="/api/v1/live_preview?entity=:entity"
             />
           )}
+
+          <RemoveLogoCTA />
         </div>
       )}
     </Default>

--- a/src/pages/credits/edit/Edit.tsx
+++ b/src/pages/credits/edit/Edit.tsx
@@ -36,7 +36,6 @@ import { useActions, useCreditUtilities, useSave } from '../common/hooks';
 import { useCreditQuery } from '../common/queries';
 import { Card } from '$app/components/cards';
 import { CreditStatus as CreditStatusBadge } from '../common/components/CreditStatus';
-import { RemoveLogoCTA } from '$app/components/RemoveLogoCTA';
 
 export default function Edit() {
   const { documentTitle } = useTitle('edit_credit');
@@ -172,7 +171,7 @@ export default function Edit() {
       </div>
 
       {reactSettings?.show_pdf_preview && (
-        <div className="flex flex-col space-y-3 my-4">
+        <div className="my-4">
           {credit && (
             <InvoicePreview
               for="invoice"
@@ -180,10 +179,9 @@ export default function Edit() {
               entity="credit"
               relationType="client_id"
               endpoint="/api/v1/live_preview?entity=:entity"
+              withRemoveLogoCTA
             />
           )}
-
-          <RemoveLogoCTA />
         </div>
       )}
     </Default>

--- a/src/pages/invoices/common/components/InvoicePreview.tsx
+++ b/src/pages/invoices/common/components/InvoicePreview.tsx
@@ -17,6 +17,7 @@ import { RecurringInvoice } from '$app/common/interfaces/recurring-invoice';
 import { useEffect, useRef, useState } from 'react';
 import { InvoiceViewer } from './InvoiceViewer';
 import { RelationType } from './ProductsTable';
+import { RemoveLogoCTA } from '$app/components/RemoveLogoCTA';
 
 export type Resource =
   | Invoice
@@ -40,6 +41,7 @@ interface Props {
     | '/api/v1/live_preview/purchase_order?entity=:entity';
   initiallyVisible?: boolean;
   observable?: boolean;
+  withRemoveLogoCTA?: boolean;
 }
 
 export function InvoicePreview(props: Props) {
@@ -101,17 +103,21 @@ export function InvoicePreview(props: Props) {
     props.entity === 'purchase_order'
   ) {
     return (
-      <InvoiceViewer
-        link={previewEndpoint(
-          '/api/v1/live_preview/purchase_order?entity=:entity&entity_id=:id',
-          {
-            entity: props.entity,
-            id: props.resource?.id,
-          }
-        )}
-        resource={props.resource}
-        method="POST"
-      />
+      <div className="flex flex-col space-y-3">
+        <InvoiceViewer
+          link={previewEndpoint(
+            '/api/v1/live_preview/purchase_order?entity=:entity&entity_id=:id',
+            {
+              entity: props.entity,
+              id: props.resource?.id,
+            }
+          )}
+          resource={props.resource}
+          method="POST"
+        />
+
+        {props.withRemoveLogoCTA && <RemoveLogoCTA />}
+      </div>
     );
   }
 
@@ -121,19 +127,23 @@ export function InvoicePreview(props: Props) {
     props.for === 'invoice'
   ) {
     return (
-      <div ref={divRef}>
-        <InvoiceViewer
-          link={previewEndpoint(
-            '/api/v1/live_preview?entity=:entity&entity_id=:id',
-            {
-              entity: props.entity,
-              id: props.resource?.id,
-            }
-          )}
-          method="POST"
-          resource={props.resource}
-          enabled={props.observable ? isIntersecting : true}
-        />
+      <div className="flex flex-col space-y-3">
+        <div ref={divRef}>
+          <InvoiceViewer
+            link={previewEndpoint(
+              '/api/v1/live_preview?entity=:entity&entity_id=:id',
+              {
+                entity: props.entity,
+                id: props.resource?.id,
+              }
+            )}
+            method="POST"
+            resource={props.resource}
+            enabled={props.observable ? isIntersecting : true}
+          />
+        </div>
+
+        {props.withRemoveLogoCTA && <RemoveLogoCTA />}
       </div>
     );
   }

--- a/src/pages/invoices/edit/Edit.tsx
+++ b/src/pages/invoices/edit/Edit.tsx
@@ -44,7 +44,6 @@ import { InvoiceStatus as InvoiceStatusBadge } from '../common/components/Invoic
 import { CommonActions } from './components/CommonActions';
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
-import { RemoveLogoCTA } from '$app/components/RemoveLogoCTA';
 
 export default function Edit() {
   const { t } = useTranslation();
@@ -242,7 +241,7 @@ export default function Edit() {
       </div>
 
       {reactSettings?.show_pdf_preview && (
-        <div className="flex flex-col space-y-3 my-4">
+        <div className="my-4">
           {invoice && (
             <InvoicePreview
               for="invoice"
@@ -252,10 +251,9 @@ export default function Edit() {
               endpoint="/api/v1/live_preview?entity=:entity"
               observable={true}
               initiallyVisible={false}
+              withRemoveLogoCTA
             />
           )}
-
-          <RemoveLogoCTA />
         </div>
       )}
     </Default>

--- a/src/pages/invoices/edit/Edit.tsx
+++ b/src/pages/invoices/edit/Edit.tsx
@@ -44,6 +44,7 @@ import { InvoiceStatus as InvoiceStatusBadge } from '../common/components/Invoic
 import { CommonActions } from './components/CommonActions';
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
+import { RemoveLogoCTA } from '$app/components/RemoveLogoCTA';
 
 export default function Edit() {
   const { t } = useTranslation();
@@ -241,7 +242,7 @@ export default function Edit() {
       </div>
 
       {reactSettings?.show_pdf_preview && (
-        <div className="my-4">
+        <div className="flex flex-col space-y-3 my-4">
           {invoice && (
             <InvoicePreview
               for="invoice"
@@ -253,6 +254,8 @@ export default function Edit() {
               initiallyVisible={false}
             />
           )}
+
+          <RemoveLogoCTA />
         </div>
       )}
     </Default>

--- a/src/pages/purchase-orders/edit/Edit.tsx
+++ b/src/pages/purchase-orders/edit/Edit.tsx
@@ -42,7 +42,6 @@ import { Card } from '$app/components/cards';
 import { PurchaseOrderStatus } from '$app/pages/purchase-orders/common/components/PurchaseOrderStatus';
 import { usePurchaseOrderQuery } from '$app/common/queries/purchase-orders';
 import { useColorScheme } from '$app/common/colors';
-import { RemoveLogoCTA } from '$app/components/RemoveLogoCTA';
 
 export default function Edit() {
   const { documentTitle } = useTitle('edit_purchase_order');
@@ -210,7 +209,7 @@ export default function Edit() {
       </div>
 
       {reactSettings?.show_pdf_preview && (
-        <div className="flex flex-col space-y-3 my-4">
+        <div className="my-4">
           {purchaseOrder && (
             <InvoicePreview
               for="invoice"
@@ -218,10 +217,9 @@ export default function Edit() {
               entity="purchase_order"
               relationType="vendor_id"
               endpoint="/api/v1/live_preview/purchase_order?entity=:entity"
+              withRemoveLogoCTA
             />
           )}
-
-          <RemoveLogoCTA />
         </div>
       )}
     </Default>

--- a/src/pages/purchase-orders/edit/Edit.tsx
+++ b/src/pages/purchase-orders/edit/Edit.tsx
@@ -42,6 +42,7 @@ import { Card } from '$app/components/cards';
 import { PurchaseOrderStatus } from '$app/pages/purchase-orders/common/components/PurchaseOrderStatus';
 import { usePurchaseOrderQuery } from '$app/common/queries/purchase-orders';
 import { useColorScheme } from '$app/common/colors';
+import { RemoveLogoCTA } from '$app/components/RemoveLogoCTA';
 
 export default function Edit() {
   const { documentTitle } = useTitle('edit_purchase_order');
@@ -128,9 +129,16 @@ export default function Edit() {
         <Card className="col-span-12 xl:col-span-4 h-max" withContainer>
           {purchaseOrder && (
             <div className="flex space-x-20">
-              <span className="text-sm"
-                style={{ backgroundColor: colors.$2, color: colors.$3, colorScheme: colors.$0 }}
-              >{t('status')}</span>
+              <span
+                className="text-sm"
+                style={{
+                  backgroundColor: colors.$2,
+                  color: colors.$3,
+                  colorScheme: colors.$0,
+                }}
+              >
+                {t('status')}
+              </span>
               <PurchaseOrderStatus entity={purchaseOrder} />
             </div>
           )}
@@ -202,7 +210,7 @@ export default function Edit() {
       </div>
 
       {reactSettings?.show_pdf_preview && (
-        <div className="my-4">
+        <div className="flex flex-col space-y-3 my-4">
           {purchaseOrder && (
             <InvoicePreview
               for="invoice"
@@ -212,6 +220,8 @@ export default function Edit() {
               endpoint="/api/v1/live_preview/purchase_order?entity=:entity"
             />
           )}
+
+          <RemoveLogoCTA />
         </div>
       )}
     </Default>

--- a/src/pages/quotes/edit/Edit.tsx
+++ b/src/pages/quotes/edit/Edit.tsx
@@ -41,7 +41,6 @@ import { useTaskColumns } from '$app/pages/invoices/common/hooks/useTaskColumns'
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
 import { useColorScheme } from '$app/common/colors';
-import { RemoveLogoCTA } from '$app/components/RemoveLogoCTA';
 
 export default function Edit() {
   const { documentTitle } = useTitle('edit_quote');
@@ -222,7 +221,7 @@ export default function Edit() {
       </div>
 
       {reactSettings?.show_pdf_preview && (
-        <div className="flex flex-col space-y-3 my-4">
+        <div className="my-4">
           {quote && (
             <InvoicePreview
               for="invoice"
@@ -230,10 +229,9 @@ export default function Edit() {
               entity="quote"
               relationType="client_id"
               endpoint="/api/v1/live_preview?entity=:entity"
+              withRemoveLogoCTA
             />
           )}
-
-          <RemoveLogoCTA />
         </div>
       )}
     </Default>

--- a/src/pages/quotes/edit/Edit.tsx
+++ b/src/pages/quotes/edit/Edit.tsx
@@ -41,6 +41,7 @@ import { useTaskColumns } from '$app/pages/invoices/common/hooks/useTaskColumns'
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
 import { useColorScheme } from '$app/common/colors';
+import { RemoveLogoCTA } from '$app/components/RemoveLogoCTA';
 
 export default function Edit() {
   const { documentTitle } = useTitle('edit_quote');
@@ -221,7 +222,7 @@ export default function Edit() {
       </div>
 
       {reactSettings?.show_pdf_preview && (
-        <div className="my-4">
+        <div className="flex flex-col space-y-3 my-4">
           {quote && (
             <InvoicePreview
               for="invoice"
@@ -231,6 +232,8 @@ export default function Edit() {
               endpoint="/api/v1/live_preview?entity=:entity"
             />
           )}
+
+          <RemoveLogoCTA />
         </div>
       )}
     </Default>

--- a/src/pages/recurring-invoices/edit/Edit.tsx
+++ b/src/pages/recurring-invoices/edit/Edit.tsx
@@ -53,6 +53,7 @@ import {
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
 import { useColorScheme } from '$app/common/colors';
+import { RemoveLogoCTA } from '$app/components/RemoveLogoCTA';
 
 export default function Edit() {
   const { t } = useTranslation();
@@ -280,7 +281,7 @@ export default function Edit() {
       </div>
 
       {reactSettings?.show_pdf_preview && (
-        <div className="my-4">
+        <div className="flex flex-col space-y-3 my-4">
           {recurringInvoice && (
             <InvoicePreview
               for="invoice"
@@ -290,6 +291,8 @@ export default function Edit() {
               endpoint="/api/v1/live_preview?entity=:entity"
             />
           )}
+
+          <RemoveLogoCTA />
         </div>
       )}
 

--- a/src/pages/recurring-invoices/edit/Edit.tsx
+++ b/src/pages/recurring-invoices/edit/Edit.tsx
@@ -53,7 +53,6 @@ import {
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
 import { useColorScheme } from '$app/common/colors';
-import { RemoveLogoCTA } from '$app/components/RemoveLogoCTA';
 
 export default function Edit() {
   const { t } = useTranslation();
@@ -281,7 +280,7 @@ export default function Edit() {
       </div>
 
       {reactSettings?.show_pdf_preview && (
-        <div className="flex flex-col space-y-3 my-4">
+        <div className="my-4">
           {recurringInvoice && (
             <InvoicePreview
               for="invoice"
@@ -289,10 +288,9 @@ export default function Edit() {
               entity="recurring_invoice"
               relationType="client_id"
               endpoint="/api/v1/live_preview?entity=:entity"
+              withRemoveLogoCTA
             />
           )}
-
-          <RemoveLogoCTA />
         </div>
       )}
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of the Remove Logo CTA for all edit pages with PDF preview, which encompasses `Invoices`, `Recurring Invoices`, `Quotes`, `Credits`, and `Purchase Orders`. Screenshot:

![Screenshot 2023-12-13 at 17 57 00](https://github.com/invoiceninja/ui/assets/51542191/3a999659-6776-4fdc-943c-7a2d00deccf3)

@turbo124 Currently, this is shown only for `HOSTED` users with a `FREE PLAN`. Is it supposed to be like that?

Let me know your thoughts.