### PR TITLE
[Cleanup] Switching Company Adjustment && Adjusting Logic if User Does Not Have Dashboard Permission to Go to User Details Page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -152,7 +152,7 @@ export function App() {
     if (
       user &&
       Object.keys(user).length &&
-      location.pathname === '/dashboard' &&
+      location.pathname.endsWith('/dashboard') &&
       !hasPermission('view_dashboard')
     ) {
       navigate('/settings/user_details');

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,52 +19,51 @@ import { RootState } from './common/stores/store';
 import dayjs from 'dayjs';
 import { useResolveDayJSLocale } from './common/hooks/useResolveDayJSLocale';
 import { useResolveAntdLocale } from './common/hooks/useResolveAntdLocale';
-import { useAtom, useSetAtom } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import { useSwitchToCompanySettings } from './common/hooks/useSwitchToCompanySettings';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useCurrentSettingsLevel } from './common/hooks/useCurrentSettingsLevel';
 import { dayJSLocaleAtom } from './components/forms';
 import { antdLocaleAtom } from './components/DropdownDateRangePicker';
 import { CompanyEdit } from './pages/settings/company/edit/CompanyEdit';
-import { useAdmin } from './common/hooks/permissions/useHasPermission';
+import {
+  useAdmin,
+  useHasPermission,
+} from './common/hooks/permissions/useHasPermission';
 import { colorSchemeAtom } from './common/colors';
 import { useCurrentUser } from './common/hooks/useCurrentUser';
 import { useRefetch } from './common/hooks/useRefetch';
 
 export function App() {
   const [t] = useTranslation();
+  const { isOwner } = useAdmin();
   const { i18n } = useTranslation();
 
-  const { isOwner } = useAdmin();
-
-  const company = useCurrentCompany();
+  const darkMode = useSelector((state: RootState) => state.settings.darkMode);
 
   const navigate = useNavigate();
 
+  const user = useCurrentUser();
   const location = useLocation();
+  const company = useCurrentCompany();
 
+  const refetch = useRefetch();
+  const hasPermission = useHasPermission();
+  const resolveLanguage = useResolveLanguage();
+  const resolveAntdLocale = useResolveAntdLocale();
+  const resolveDayJSLocale = useResolveDayJSLocale();
   const switchToCompanySettings = useSwitchToCompanySettings();
 
+  const colorScheme = useAtomValue(colorSchemeAtom);
+
+  const updateAntdLocale = useSetAtom(antdLocaleAtom);
   const updateDayJSLocale = useSetAtom(dayJSLocaleAtom);
 
   const { isCompanySettingsActive, isGroupSettingsActive } =
     useCurrentSettingsLevel();
 
-  const updateAntdLocale = useSetAtom(antdLocaleAtom);
-
-  const resolveLanguage = useResolveLanguage();
-
-  const resolveDayJSLocale = useResolveDayJSLocale();
-
-  const resolveAntdLocale = useResolveAntdLocale();
-
-  const darkMode = useSelector((state: RootState) => state.settings.darkMode);
-
   const [isCompanyEditModalOpened, setIsCompanyEditModalOpened] =
     useState(false);
-
-  const user = useCurrentUser();
-  const refetch = useRefetch();
 
   const resolvedLanguage = company
     ? resolveLanguage(
@@ -73,8 +72,6 @@ export function App() {
           : company.settings.language_id
       )
     : undefined;
-
-  const [colorScheme] = useAtom(colorSchemeAtom);
 
   useEffect(() => {
     document.body.style.backgroundColor = colorScheme.$2;
@@ -150,6 +147,17 @@ export function App() {
       navigate('/settings/company_details');
     }
   }, [location]);
+
+  useEffect(() => {
+    if (
+      user &&
+      Object.keys(user).length &&
+      location.pathname === '/dashboard' &&
+      !hasPermission('view_dashboard')
+    ) {
+      navigate('/settings/user_details');
+    }
+  }, [location, user]);
 
   return (
     <>

--- a/src/components/CompanySwitcher.tsx
+++ b/src/components/CompanySwitcher.tsx
@@ -18,7 +18,6 @@ import { Check, ChevronDown } from 'react-feather';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from 'react-query';
 import { useDispatch, useSelector } from 'react-redux';
-import { route } from '$app/common/helpers/route';
 import { DropdownElement } from './dropdown/DropdownElement';
 import { useLogo } from '$app/common/hooks/useLogo';
 import { useCompanyName } from '$app/common/hooks/useLogo';
@@ -76,7 +75,7 @@ export function CompanySwitcher() {
 
     queryClient.invalidateQueries();
 
-    window.location.href = route('/');
+    window.location.reload();
   };
 
   useEffect(() => {

--- a/src/components/PublicRoute.tsx
+++ b/src/components/PublicRoute.tsx
@@ -10,21 +10,9 @@
 
 import { Navigate, Outlet } from 'react-router';
 import { useAuthenticated } from '../common/hooks/useAuthenticated';
-import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 
 export function PublicRoute() {
   const authenticated = useAuthenticated();
-  const hasPermission = useHasPermission();
 
-  return authenticated ? (
-    <Navigate
-      to={
-        hasPermission('view_dashboard')
-          ? '/dashboard'
-          : '/settings/user_details'
-      }
-    />
-  ) : (
-    <Outlet />
-  );
+  return authenticated ? <Navigate to="/dashboard" /> : <Outlet />;
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -10,20 +10,12 @@
 
 import { Navigate } from 'react-router';
 import { useAuthenticated } from '../common/hooks/useAuthenticated';
-import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 
 export function Index() {
   const authenticated = useAuthenticated();
-  const hasPermission = useHasPermission();
 
   return authenticated ? (
-    <Navigate
-      to={
-        hasPermission('view_dashboard')
-          ? '/dashboard'
-          : '/settings/user_details'
-      }
-    />
+    <Navigate to="/dashboard" />
   ) : (
     <Navigate to="/login" />
   );

--- a/src/pages/settings/company/create/CompanyCreate.tsx
+++ b/src/pages/settings/company/create/CompanyCreate.tsx
@@ -13,7 +13,6 @@ import { AxiosError, AxiosResponse } from 'axios';
 import { AuthenticationTypes } from '$app/common/dtos/authentication';
 import { endpoint } from '$app/common/helpers';
 import { request } from '$app/common/helpers/request';
-import { route } from '$app/common/helpers/route';
 import { toast } from '$app/common/helpers/toast/toast';
 import { updateCompanyUsers } from '$app/common/stores/slices/company-users';
 import { authenticate } from '$app/common/stores/slices/user';
@@ -57,7 +56,7 @@ export function CompanyCreate(props: Props) {
 
     queryClient.invalidateQueries();
 
-    window.location.href = route('/');
+    window.location.reload();
   };
 
   const handleSave = async () => {
@@ -111,10 +110,16 @@ export function CompanyCreate(props: Props) {
       onClose={() => props.setIsModalOpen(false)}
       backgroundColor="white"
     >
-      <span className="text-lg"
-        style={{ backgroundColor: colors.$2, color: colors.$3, colorScheme: colors.$0 }}
-
-      >{t('are_you_sure')}</span>
+      <span
+        className="text-lg"
+        style={{
+          backgroundColor: colors.$2,
+          color: colors.$3,
+          colorScheme: colors.$0,
+        }}
+      >
+        {t('are_you_sure')}
+      </span>
 
       <div className="flex justify-end space-x-4 mt-5">
         <Button


### PR DESCRIPTION
@beganovich @turbo124 The PR addresses two bugs. The first one occurs when the user switches the company or creates a new one, and they've been navigated to the "/" (Dashboard). Now, even if the user creates a new company or switches to another, they will stay on the SAME page.

The second bug that the PR addresses involves adjusting the logic when the user does not have the "view_dashboard" permission. I attempted to address it in the first permission PR, but I realized that it did NOT work. Now, it is fixed as well. If the user has the "view_dashboard" permission, they will be navigated to the "/dashboard" page upon login or manual navigation through the browser. If not, they will be directed to the "user_details" page because it is the only one they must be able to access.

Let me know your thoughts.