### PR TITLE
[Cleanup] Custom Fields Translations | Reports

### DIFF
--- a/src/pages/reports/common/components/SortableColumns.tsx
+++ b/src/pages/reports/common/components/SortableColumns.tsx
@@ -17,7 +17,6 @@ import {
 } from '@hello-pangea/dnd';
 import { cloneDeep } from 'lodash';
 import { Record, clientMap } from '$app/common/constants/exports/client-map';
-import { invoiceMap } from '$app/common/constants/exports/invoice-map';
 import { paymentMap } from '$app/common/constants/exports/payment-map';
 import { t } from 'i18next';
 import { quoteMap } from '$app/common/constants/exports/quote-map';
@@ -34,8 +33,60 @@ import { usePreferences } from '$app/common/hooks/usePreferences';
 import { Identifier } from '../useReports';
 import { contactMap } from '$app/common/constants/exports/contact-map';
 import { useColorScheme } from '$app/common/colors';
+import { Entity } from '$app/common/hooks/useEntityCustomFields';
+import { invoiceMap } from '$app/common/constants/exports/invoice-map';
+import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
+import { customField } from '$app/components/CustomField';
 
 export const reportColumn = 11;
+
+export function useTranslationAlias() {
+  const company = useCurrentCompany();
+  const customFields = company?.custom_fields;
+
+  const entityAlias = {
+    credit: 'invoice',
+    quote: 'invoice',
+    recurring_invoice: 'invoice',
+    purchase_order: 'invoice',
+    recurring_expense: 'expense',
+    item: 'product',
+  };
+
+  const findCustomField = (field: string, isVendorContactField?: boolean) => {
+    const updatedField = field.includes('custom_value')
+      ? field.replace('custom_value', 'custom')
+      : field;
+
+    return customFields[updatedField]
+      ? customField(customFields[updatedField]).label()
+      : `${
+          isVendorContactField ? 'contact_custom' : 'custom'
+        }${updatedField.charAt(updatedField.length - 1)}`;
+  };
+
+  return (field: string, entity: Entity) => {
+    const updatedEntity =
+      entityAlias[entity as keyof typeof entityAlias] || entity;
+
+    const fields = {
+      custom_value1: findCustomField(`${updatedEntity}1`),
+      custom_value2: findCustomField(`${updatedEntity}2`),
+      custom_value3: findCustomField(`${updatedEntity}3`),
+      custom_value4: findCustomField(`${updatedEntity}4`),
+      surcharge1: customFields.surcharge1,
+      surcharge2: customFields.surcharge2,
+      surcharge3: customFields.surcharge3,
+      surcharge4: customFields.surcharge4,
+      contact_custom_value1: findCustomField('vendor_contact1', true),
+      contact_custom_value2: findCustomField('vendor_contact2', true),
+      contact_custom_value3: findCustomField('vendor_contact3', true),
+      contact_custom_value4: findCustomField('vendor_contact4', true),
+    };
+
+    return fields[field as keyof typeof fields] || field;
+  };
+}
 
 interface ColumnProps {
   title: string | (() => JSX.Element);
@@ -54,10 +105,14 @@ export function Column({
 }: ColumnProps) {
   const [t] = useTranslation();
 
+  const findTranslationAlias = useTranslationAlias();
+
   const translateLabel = (record: Record) => {
     const parts = record.value.split('.');
 
-    return `${t(`${parts[0]}`)} - ${t(`${record.trans}`)}`;
+    return `${t(`${parts[0]}`)} - ${t(
+      `${findTranslationAlias(record.trans, parts[0] as Entity)}`
+    )}`;
   };
   const colors = useColorScheme();
 
@@ -70,7 +125,12 @@ export function Column({
       <Droppable droppableId={droppableId} isDropDisabled={isDropDisabled}>
         {(provided) => (
           <div
-            style={{ color: colors.$3, colorScheme: colors.$0, backgroundColor: colors.$1, borderColor: colors.$4 }}
+            style={{
+              color: colors.$3,
+              colorScheme: colors.$0,
+              backgroundColor: colors.$1,
+              borderColor: colors.$4,
+            }}
             className="w-80 flex-column"
             ref={provided.innerRef}
             {...provided.droppableProps}
@@ -90,7 +150,12 @@ export function Column({
                         {...provided.dragHandleProps}
                       >
                         <span
-                          style={{ color: colors.$3, colorScheme: colors.$0, backgroundColor: colors.$1, borderColor: colors.$4 }}
+                          style={{
+                            color: colors.$3,
+                            colorScheme: colors.$0,
+                            backgroundColor: colors.$1,
+                            borderColor: colors.$4,
+                          }}
                           className="p-2 flex justify-between items-center cursor-move ml-2 text-sm"
                           key={i}
                         >
@@ -98,7 +163,12 @@ export function Column({
 
                           {droppableId === reportColumn.toString() && (
                             <button
-                              style={{ color: colors.$3, colorScheme: colors.$0, backgroundColor: colors.$1, borderColor: colors.$4 }}
+                              style={{
+                                color: colors.$3,
+                                colorScheme: colors.$0,
+                                backgroundColor: colors.$1,
+                                borderColor: colors.$4,
+                              }}
                               type="button"
                               onClick={() =>
                                 onRemove ? onRemove(record) : null
@@ -259,17 +329,50 @@ export function SortableColumns({ report, columns }: Props) {
   const colors = useColorScheme();
 
   return (
-    <div className="min-w-min" style={{ color: colors.$3, colorScheme: colors.$0, backgroundColor: colors.$1, borderColor: colors.$4 }}>
+    <div
+      className="min-w-min"
+      style={{
+        color: colors.$3,
+        colorScheme: colors.$0,
+        backgroundColor: colors.$1,
+        borderColor: colors.$4,
+      }}
+    >
       <Card className="my-6">
         <DragDropContext onDragEnd={onDragEnd}>
-          <div className="flex w-full py-2 px-6 space-x-4" style={{ color: colors.$3, colorScheme: colors.$0, backgroundColor: colors.$1, borderColor: colors.$4 }}>
+          <div
+            className="flex w-full py-2 px-6 space-x-4"
+            style={{
+              color: colors.$3,
+              colorScheme: colors.$0,
+              backgroundColor: colors.$1,
+              borderColor: colors.$4,
+            }}
+          >
             {columns.includes('client') && (
               <Column
                 title={() => (
-                  <div className="flex justify-between items-center" style={{ color: colors.$3, colorScheme: colors.$0, backgroundColor: colors.$1, borderColor: colors.$4 }}>
+                  <div
+                    className="flex justify-between items-center"
+                    style={{
+                      color: colors.$3,
+                      colorScheme: colors.$0,
+                      backgroundColor: colors.$1,
+                      borderColor: colors.$4,
+                    }}
+                  >
                     <p>{t('client')}</p>
 
-                    <button type="button" onClick={() => onAddAll(0)} style={{ color: colors.$3, colorScheme: colors.$0, backgroundColor: colors.$1, borderColor: colors.$4 }}>
+                    <button
+                      type="button"
+                      onClick={() => onAddAll(0)}
+                      style={{
+                        color: colors.$3,
+                        colorScheme: colors.$0,
+                        backgroundColor: colors.$1,
+                        borderColor: colors.$4,
+                      }}
+                    >
                       <ChevronsRight size={16} />
                     </button>
                   </div>
@@ -286,7 +389,16 @@ export function SortableColumns({ report, columns }: Props) {
                   <div className="flex justify-between items-center">
                     <p>{t('invoice')}</p>
 
-                    <button type="button" onClick={() => onAddAll(1)} style={{ color: colors.$3, colorScheme: colors.$0, backgroundColor: colors.$1, borderColor: colors.$4 }}>
+                    <button
+                      type="button"
+                      onClick={() => onAddAll(1)}
+                      style={{
+                        color: colors.$3,
+                        colorScheme: colors.$0,
+                        backgroundColor: colors.$1,
+                        borderColor: colors.$4,
+                      }}
+                    >
                       <ChevronsRight size={16} />
                     </button>
                   </div>
@@ -300,10 +412,27 @@ export function SortableColumns({ report, columns }: Props) {
             {columns.includes('credit') && (
               <Column
                 title={() => (
-                  <div className="flex justify-between items-center" style={{ color: colors.$3, colorScheme: colors.$0, backgroundColor: colors.$1, borderColor: colors.$4 }}>
+                  <div
+                    className="flex justify-between items-center"
+                    style={{
+                      color: colors.$3,
+                      colorScheme: colors.$0,
+                      backgroundColor: colors.$1,
+                      borderColor: colors.$4,
+                    }}
+                  >
                     <p>{t('credit')}</p>
 
-                    <button type="button" onClick={() => onAddAll(2)} style={{ color: colors.$3, colorScheme: colors.$0, backgroundColor: colors.$1, borderColor: colors.$4 }}>
+                    <button
+                      type="button"
+                      onClick={() => onAddAll(2)}
+                      style={{
+                        color: colors.$3,
+                        colorScheme: colors.$0,
+                        backgroundColor: colors.$1,
+                        borderColor: colors.$4,
+                      }}
+                    >
                       <ChevronsRight size={16} />
                     </button>
                   </div>
@@ -317,7 +446,15 @@ export function SortableColumns({ report, columns }: Props) {
             {columns.includes('quote') && (
               <Column
                 title={() => (
-                  <div className="flex justify-between items-center" style={{ color: colors.$3, colorScheme: colors.$0, backgroundColor: colors.$1, borderColor: colors.$4 }}>
+                  <div
+                    className="flex justify-between items-center"
+                    style={{
+                      color: colors.$3,
+                      colorScheme: colors.$0,
+                      backgroundColor: colors.$1,
+                      borderColor: colors.$4,
+                    }}
+                  >
                     <p>{t('quote')}</p>
 
                     <button type="button" onClick={() => onAddAll(3)}>
@@ -334,10 +471,27 @@ export function SortableColumns({ report, columns }: Props) {
             {columns.includes('payment') && (
               <Column
                 title={() => (
-                  <div className="flex justify-between items-center" style={{ color: colors.$3, colorScheme: colors.$0, backgroundColor: colors.$1, borderColor: colors.$4 }}>
+                  <div
+                    className="flex justify-between items-center"
+                    style={{
+                      color: colors.$3,
+                      colorScheme: colors.$0,
+                      backgroundColor: colors.$1,
+                      borderColor: colors.$4,
+                    }}
+                  >
                     <p>{t('payment')}</p>
 
-                    <button type="button" onClick={() => onAddAll(4)} style={{ color: colors.$3, colorScheme: colors.$0, backgroundColor: colors.$1, borderColor: colors.$4 }}>
+                    <button
+                      type="button"
+                      onClick={() => onAddAll(4)}
+                      style={{
+                        color: colors.$3,
+                        colorScheme: colors.$0,
+                        backgroundColor: colors.$1,
+                        borderColor: colors.$4,
+                      }}
+                    >
                       <ChevronsRight size={16} />
                     </button>
                   </div>
@@ -351,10 +505,27 @@ export function SortableColumns({ report, columns }: Props) {
             {columns.includes('vendor') && (
               <Column
                 title={() => (
-                  <div className="flex justify-between items-center" style={{ color: colors.$3, colorScheme: colors.$0, backgroundColor: colors.$1, borderColor: colors.$4 }}>
+                  <div
+                    className="flex justify-between items-center"
+                    style={{
+                      color: colors.$3,
+                      colorScheme: colors.$0,
+                      backgroundColor: colors.$1,
+                      borderColor: colors.$4,
+                    }}
+                  >
                     <p>{t('vendor')}</p>
 
-                    <button type="button" onClick={() => onAddAll(5)} style={{ color: colors.$3, colorScheme: colors.$0, backgroundColor: colors.$1, borderColor: colors.$4 }}>
+                    <button
+                      type="button"
+                      onClick={() => onAddAll(5)}
+                      style={{
+                        color: colors.$3,
+                        colorScheme: colors.$0,
+                        backgroundColor: colors.$1,
+                        borderColor: colors.$4,
+                      }}
+                    >
                       <ChevronsRight size={16} />
                     </button>
                   </div>
@@ -368,7 +539,15 @@ export function SortableColumns({ report, columns }: Props) {
             {columns.includes('purchase_order') && (
               <Column
                 title={() => (
-                  <div className="flex justify-between items-center" style={{ color: colors.$3, colorScheme: colors.$0, backgroundColor: colors.$1, borderColor: colors.$4 }}>
+                  <div
+                    className="flex justify-between items-center"
+                    style={{
+                      color: colors.$3,
+                      colorScheme: colors.$0,
+                      backgroundColor: colors.$1,
+                      borderColor: colors.$4,
+                    }}
+                  >
                     <p>{t('purchase_order')}</p>
 
                     <button type="button" onClick={() => onAddAll(6)}>
@@ -385,10 +564,27 @@ export function SortableColumns({ report, columns }: Props) {
             {columns.includes('task') && (
               <Column
                 title={() => (
-                  <div className="flex justify-between items-center" style={{ color: colors.$3, colorScheme: colors.$0, backgroundColor: colors.$1, borderColor: colors.$4 }}>
+                  <div
+                    className="flex justify-between items-center"
+                    style={{
+                      color: colors.$3,
+                      colorScheme: colors.$0,
+                      backgroundColor: colors.$1,
+                      borderColor: colors.$4,
+                    }}
+                  >
                     <p>{t('task')}</p>
 
-                    <button type="button" onClick={() => onAddAll(7)} style={{ color: colors.$3, colorScheme: colors.$0, backgroundColor: colors.$1, borderColor: colors.$4 }}>
+                    <button
+                      type="button"
+                      onClick={() => onAddAll(7)}
+                      style={{
+                        color: colors.$3,
+                        colorScheme: colors.$0,
+                        backgroundColor: colors.$1,
+                        borderColor: colors.$4,
+                      }}
+                    >
                       <ChevronsRight size={16} />
                     </button>
                   </div>
@@ -402,7 +598,15 @@ export function SortableColumns({ report, columns }: Props) {
             {columns.includes('expense') && (
               <Column
                 title={() => (
-                  <div className="flex justify-between items-center" style={{ color: colors.$3, colorScheme: colors.$0, backgroundColor: colors.$1, borderColor: colors.$4 }}>
+                  <div
+                    className="flex justify-between items-center"
+                    style={{
+                      color: colors.$3,
+                      colorScheme: colors.$0,
+                      backgroundColor: colors.$1,
+                      borderColor: colors.$4,
+                    }}
+                  >
                     <p>{t('expense')}</p>
 
                     <button type="button" onClick={() => onAddAll(8)}>
@@ -419,10 +623,27 @@ export function SortableColumns({ report, columns }: Props) {
             {columns.includes('recurring_invoice') && (
               <Column
                 title={() => (
-                  <div className="flex justify-between items-center" style={{ color: colors.$3, colorScheme: colors.$0, backgroundColor: colors.$1, borderColor: colors.$4 }}>
+                  <div
+                    className="flex justify-between items-center"
+                    style={{
+                      color: colors.$3,
+                      colorScheme: colors.$0,
+                      backgroundColor: colors.$1,
+                      borderColor: colors.$4,
+                    }}
+                  >
                     <p>{t('recurring_invoice')}</p>
 
-                    <button type="button" onClick={() => onAddAll(9)} style={{ color: colors.$3, colorScheme: colors.$0, backgroundColor: colors.$1, borderColor: colors.$4 }}>
+                    <button
+                      type="button"
+                      onClick={() => onAddAll(9)}
+                      style={{
+                        color: colors.$3,
+                        colorScheme: colors.$0,
+                        backgroundColor: colors.$1,
+                        borderColor: colors.$4,
+                      }}
+                    >
                       <ChevronsRight size={16} />
                     </button>
                   </div>
@@ -436,10 +657,27 @@ export function SortableColumns({ report, columns }: Props) {
             {columns.includes('contact') && (
               <Column
                 title={() => (
-                  <div className="flex justify-between items-center" style={{ color: colors.$3, colorScheme: colors.$0, backgroundColor: colors.$1, borderColor: colors.$4 }}>
+                  <div
+                    className="flex justify-between items-center"
+                    style={{
+                      color: colors.$3,
+                      colorScheme: colors.$0,
+                      backgroundColor: colors.$1,
+                      borderColor: colors.$4,
+                    }}
+                  >
                     <p>{t('contact')}</p>
 
-                    <button type="button" onClick={() => onAddAll(10)} style={{ color: colors.$3, colorScheme: colors.$0, backgroundColor: colors.$1, borderColor: colors.$4 }}>
+                    <button
+                      type="button"
+                      onClick={() => onAddAll(10)}
+                      style={{
+                        color: colors.$3,
+                        colorScheme: colors.$0,
+                        backgroundColor: colors.$1,
+                        borderColor: colors.$4,
+                      }}
+                    >
                       <ChevronsRight size={16} />
                     </button>
                   </div>
@@ -452,13 +690,26 @@ export function SortableColumns({ report, columns }: Props) {
 
             <Column
               title={() => (
-                <div className="flex items-center justify-between" style={{ color: colors.$3, colorScheme: colors.$0, backgroundColor: colors.$1, borderColor: colors.$4 }}>
+                <div
+                  className="flex items-center justify-between"
+                  style={{
+                    color: colors.$3,
+                    colorScheme: colors.$0,
+                    backgroundColor: colors.$1,
+                    borderColor: colors.$4,
+                  }}
+                >
                   <p>
                     {t('report')} {t('columns')}
                   </p>
 
                   <div
-                    style={{ color: colors.$3, colorScheme: colors.$0, backgroundColor: colors.$1, borderColor: colors.$4 }}
+                    style={{
+                      color: colors.$3,
+                      colorScheme: colors.$0,
+                      backgroundColor: colors.$1,
+                      borderColor: colors.$4,
+                    }}
                     className="flex items-end space-x-1 cursor-pointer"
                     onClick={onRemoveAll}
                   >

--- a/src/pages/reports/common/components/SortableColumns.tsx
+++ b/src/pages/reports/common/components/SortableColumns.tsx
@@ -61,7 +61,7 @@ export function useTranslationAlias() {
     return customFields[updatedField]
       ? customField(customFields[updatedField]).label()
       : `${
-          isVendorContactField ? 'contact_custom' : 'custom'
+          isVendorContactField ? 'contact_custom_value' : 'custom'
         }${updatedField.charAt(updatedField.length - 1)}`;
   };
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adjustments for column names for Reports. Therefore, if a user has defined the name of a custom field for a specific entity, it will be displayed when customizing columns. Screenshot:

<img width="1028" alt="Screenshot 2023-12-19 at 16 41 39" src="https://github.com/invoiceninja/ui/assets/51542191/446ab350-08dd-4fae-9a5c-2d64986f3c20">

Let me know your thoughts.