### PR TITLE
[Bugfix] Bank Account Balance Formatting

### DIFF
--- a/src/common/hooks/useResolveCurrency.ts
+++ b/src/common/hooks/useResolveCurrency.ts
@@ -10,8 +10,19 @@
 
 import { useCurrencies } from './useCurrencies';
 
-export function useResolveCurrency() {
+interface Params {
+  resolveBy?: 'code';
+}
+export function useResolveCurrency(params?: Params) {
   const currencies = useCurrencies();
+
+  const { resolveBy } = params || {};
+
+  if (resolveBy === 'code') {
+    return (code: string) => {
+      return currencies.find((currency) => currency.code === code);
+    };
+  }
 
   return (id: string | number) =>
     currencies.find((currency) => currency.id == id);

--- a/src/common/hooks/useResolveCurrency.ts
+++ b/src/common/hooks/useResolveCurrency.ts
@@ -19,7 +19,7 @@ export function useResolveCurrency(params?: Params) {
   const { resolveBy } = params || {};
 
   if (resolveBy === 'code') {
-    return (code: string) => {
+    return (code: string | number) => {
       return currencies.find((currency) => currency.code === code);
     };
   }

--- a/src/pages/settings/bank-accounts/common/hooks/useBankAccountColumns.tsx
+++ b/src/pages/settings/bank-accounts/common/hooks/useBankAccountColumns.tsx
@@ -15,13 +15,14 @@ import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { BankAccount } from '$app/common/interfaces/bank-accounts';
 import { DataTableColumns } from '$app/components/DataTable';
 import { useTranslation } from 'react-i18next';
+import { useResolveCurrency } from '$app/common/hooks/useResolveCurrency';
 
 export const useBankAccountColumns = () => {
   const { t } = useTranslation();
-
   const company = useCurrentCompany();
 
   const formatMoney = useFormatMoney();
+  const resolveCurrency = useResolveCurrency({ resolveBy: 'code' });
 
   const columns: DataTableColumns<BankAccount> = [
     {
@@ -41,11 +42,11 @@ export const useBankAccountColumns = () => {
     {
       id: 'balance',
       label: t('balance'),
-      format: (value) =>
+      format: (value, bankAccount) =>
         formatMoney(
           value,
           company?.settings?.country_id,
-          company?.settings?.currency_id
+          resolveCurrency(bankAccount.currency)?.id
         ),
     },
   ];

--- a/src/pages/settings/bank-accounts/components/Details.tsx
+++ b/src/pages/settings/bank-accounts/components/Details.tsx
@@ -13,6 +13,7 @@ import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { BankAccount } from '$app/common/interfaces/bank-accounts';
 import { useTranslation } from 'react-i18next';
 import { Card, Element } from '../../../../components/cards';
+import { useResolveCurrency } from '$app/common/hooks/useResolveCurrency';
 
 interface Props {
   accountDetails?: BankAccount;
@@ -24,6 +25,7 @@ export function Details(props: Props) {
     bank_account_type: bankAccountType,
     provider_name: providerName,
     bank_account_status: bankAccountStatus,
+    currency = '',
   } = props?.accountDetails || {};
 
   const [t] = useTranslation();
@@ -31,6 +33,7 @@ export function Details(props: Props) {
   const company = useCurrentCompany();
 
   const formatMoney = useFormatMoney();
+  const resolveCurrency = useResolveCurrency({ resolveBy: 'code' });
 
   return (
     <Card title={t('details')}>
@@ -38,7 +41,7 @@ export function Details(props: Props) {
         {formatMoney(
           balance || 0,
           company.settings.country_id,
-          company.settings.currency_id
+          resolveCurrency(currency)?.id
         )}
       </Element>
       <Element leftSide={t('type')}>{bankAccountType}</Element>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for the `balance` value formatting for bank accounts in the table as well as on the Bank Account show page. So, from now on, we will take the `bankAccount.currency` property, using that property we will resolve the currency to get the `currency_id`, and then we will pass it to the `formatMoney` function to get the correct balance value format. Let me know your thoughts.