### PR TITLE
[Bugfix] dashboard_charts props null values

### DIFF
--- a/src/pages/dashboard/components/Totals.tsx
+++ b/src/pages/dashboard/components/Totals.tsx
@@ -92,9 +92,10 @@ export function Totals() {
   const [chartData, setChartData] = useState<ChartData[]>([]);
 
   const chartScale =
-    settings.preferences.dashboard_charts.default_view || 'month';
-  const currency = settings.preferences.dashboard_charts.currency || 1;
-  const dateRange = settings.preferences.dashboard_charts.range || 'this_month';
+    settings.preferences.dashboard_charts?.default_view || 'month';
+  const currency = settings.preferences.dashboard_charts?.currency || 1;
+  const dateRange =
+    settings.preferences.dashboard_charts?.range || 'this_month';
 
   const [dates, setDates] = useState<{ start_date: string; end_date: string }>({
     start_date: new Date(new Date().getFullYear(), new Date().getMonth(), 1)
@@ -118,7 +119,7 @@ export function Totals() {
       ...current,
       date_range: dateRange,
     }));
-  }, [settings.preferences.dashboard_charts.range]);
+  }, [settings.preferences.dashboard_charts?.range]);
 
   const handleDateChange = (DateSet: string) => {
     const [startDate, endDate] = DateSet.split(',');

--- a/src/pages/dashboard/components/Totals.tsx
+++ b/src/pages/dashboard/components/Totals.tsx
@@ -92,10 +92,10 @@ export function Totals() {
   const [chartData, setChartData] = useState<ChartData[]>([]);
 
   const chartScale =
-    settings.preferences.dashboard_charts?.default_view || 'month';
-  const currency = settings.preferences.dashboard_charts?.currency || 1;
+    settings?.preferences?.dashboard_charts?.default_view || 'month';
+  const currency = settings?.preferences?.dashboard_charts?.currency || 1;
   const dateRange =
-    settings.preferences.dashboard_charts?.range || 'this_month';
+    settings?.preferences?.dashboard_charts?.range || 'this_month';
 
   const [dates, setDates] = useState<{ start_date: string; end_date: string }>({
     start_date: new Date(new Date().getFullYear(), new Date().getMonth(), 1)
@@ -119,7 +119,7 @@ export function Totals() {
       ...current,
       date_range: dateRange,
     }));
-  }, [settings.preferences.dashboard_charts?.range]);
+  }, [settings?.preferences?.dashboard_charts?.range]);
 
   const handleDateChange = (DateSet: string) => {
     const [startDate, endDate] = DateSet.split(',');

--- a/src/pages/dashboard/components/Totals.tsx
+++ b/src/pages/dashboard/components/Totals.tsx
@@ -91,8 +91,10 @@ export function Totals() {
 
   const [chartData, setChartData] = useState<ChartData[]>([]);
 
-  const chartScale = settings.preferences.dashboard_charts.default_view;
-  const currency = settings.preferences.dashboard_charts.currency;
+  const chartScale =
+    settings.preferences.dashboard_charts.default_view || 'month';
+  const currency = settings.preferences.dashboard_charts.currency || 1;
+  const dateRange = settings.preferences.dashboard_charts.range || 'this_month';
 
   const [dates, setDates] = useState<{ start_date: string; end_date: string }>({
     start_date: new Date(new Date().getFullYear(), new Date().getMonth(), 1)
@@ -108,13 +110,13 @@ export function Totals() {
   }>({
     start_date: '',
     end_date: '',
-    date_range: settings.preferences.dashboard_charts.range,
+    date_range: dateRange,
   });
 
   useEffect(() => {
     setBody((current) => ({
       ...current,
-      date_range: settings.preferences.dashboard_charts.range,
+      date_range: dateRange,
     }));
   }, [settings.preferences.dashboard_charts.range]);
 
@@ -262,7 +264,7 @@ export function Totals() {
           <Preferences>
             <CurrencySelector
               label={t('currency')}
-              value={settings.preferences.dashboard_charts.currency.toString()}
+              value={currency.toString()}
               onChange={(v) =>
                 update('preferences.dashboard_charts.currency', parseInt(v))
               }
@@ -270,7 +272,7 @@ export function Totals() {
 
             <SelectField
               label={t('range')}
-              value={settings.preferences.dashboard_charts.default_view}
+              value={chartScale}
               onValueChange={(value) =>
                 update(
                   'preferences.dashboard_charts.default_view',
@@ -285,7 +287,7 @@ export function Totals() {
 
             <SelectField
               label={t('date_range')}
-              value={settings.preferences.dashboard_charts.range}
+              value={dateRange}
               onValueChange={(value) =>
                 update('preferences.dashboard_charts.range', value)
               }


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adding optional chaining and adding fallback values for properties of the `dashboard_charts` object. However, I was not able to recreate the bug in the production environment, and also locally, it seems that David found a very edge case here. Nevertheless, I believe that these changes will ensure 100% that we do not have any `null` values passed to the chart. Let me know your thoughts.