### PR TITLE
[Bugfix] Custom Designs Export

### DIFF
--- a/src/pages/settings/invoice-design/pages/custom-designs/pages/edit/components/Settings.tsx
+++ b/src/pages/settings/invoice-design/pages/custom-designs/pages/edit/components/Settings.tsx
@@ -35,14 +35,38 @@ export function Settings(props: Props) {
   const [, setIsImportModalVisible] = useAtom(importModalVisiblityAtom);
 
   const handleExport = useCallback(() => {
-    if (payload.design && navigator.clipboard) {
-      navigator.clipboard.writeText(JSON.stringify(payload.design.design));
+    if (payload.design) {
+      navigator.clipboard
+        .writeText(JSON.stringify(payload.design.design))
+        .then(() =>
+          toast.success(
+            trans('copied_to_clipboard', {
+              value: t('design').toLowerCase(),
+            })
+          )
+        )
+        .catch(() => {
+          if (payload.design) {
+            const blob = new Blob([JSON.stringify(payload.design.design)], {
+              type: 'text/plain',
+            });
+            const url = URL.createObjectURL(blob);
 
-      toast.success(
-        trans('copied_to_clipboard', {
-          value: t('design').toLowerCase(),
-        })
-      );
+            const link = document.createElement('a');
+
+            link.download = `${payload.design.name}_${t(
+              'export'
+            ).toLowerCase()}`;
+            link.href = url;
+            link.target = '_blank';
+
+            document.body.appendChild(link);
+
+            link.click();
+
+            document.body.removeChild(link);
+          }
+        });
     }
   }, [payload.design]);
 

--- a/src/pages/settings/invoice-design/pages/custom-designs/pages/edit/components/Settings.tsx
+++ b/src/pages/settings/invoice-design/pages/custom-designs/pages/edit/components/Settings.tsx
@@ -35,7 +35,7 @@ export function Settings(props: Props) {
   const [, setIsImportModalVisible] = useAtom(importModalVisiblityAtom);
 
   const handleExport = useCallback(() => {
-    if (payload.design) {
+    if (payload.design && navigator.clipboard) {
       navigator.clipboard.writeText(JSON.stringify(payload.design.design));
 
       toast.success(

--- a/src/pages/settings/invoice-design/pages/custom-designs/pages/edit/components/Settings.tsx
+++ b/src/pages/settings/invoice-design/pages/custom-designs/pages/edit/components/Settings.tsx
@@ -34,7 +34,32 @@ export function Settings(props: Props) {
   const [payload] = useAtom(payloadAtom);
   const [, setIsImportModalVisible] = useAtom(importModalVisiblityAtom);
 
+  const handleExportToTxtFile = () => {
+    if (payload.design) {
+      const blob = new Blob([JSON.stringify(payload.design.design)], {
+        type: 'text/plain',
+      });
+      const url = URL.createObjectURL(blob);
+
+      const link = document.createElement('a');
+
+      link.download = `${payload.design.name}_${t('export').toLowerCase()}`;
+      link.href = url;
+      link.target = '_blank';
+
+      document.body.appendChild(link);
+
+      link.click();
+
+      document.body.removeChild(link);
+    }
+  };
+
   const handleExport = useCallback(() => {
+    if (!navigator.clipboard) {
+      return handleExportToTxtFile();
+    }
+
     if (payload.design) {
       navigator.clipboard
         .writeText(JSON.stringify(payload.design.design))
@@ -45,28 +70,7 @@ export function Settings(props: Props) {
             })
           )
         )
-        .catch(() => {
-          if (payload.design) {
-            const blob = new Blob([JSON.stringify(payload.design.design)], {
-              type: 'text/plain',
-            });
-            const url = URL.createObjectURL(blob);
-
-            const link = document.createElement('a');
-
-            link.download = `${payload.design.name}_${t(
-              'export'
-            ).toLowerCase()}`;
-            link.href = url;
-            link.target = '_blank';
-
-            document.body.appendChild(link);
-
-            link.click();
-
-            document.body.removeChild(link);
-          }
-        });
+        .catch(() => handleExportToTxtFile());
     }
   }, [payload.design]);
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of a fallback action for design export. If copying to the clipboard fails, the design will be exported to a .txt file. Here is what will happen when copying to the clipboard fails:

https://github.com/invoiceninja/ui/assets/51542191/b3dcec0f-3b00-4e5d-b168-74d5b32be698

Note: The file will be named as `designName_[translating the 'export' keyword to lowercase].txt`.

Let me know your thoughts.