### PR TITLE
[Bugfix] Chart Points | Dates

### DIFF
--- a/src/pages/dashboard/components/Chart.tsx
+++ b/src/pages/dashboard/components/Chart.tsx
@@ -59,15 +59,16 @@ export function Chart(props: Props) {
   const generateDateRange = (
     startDate: Date,
     endDate: Date,
-    rangeKey: 'day' | 'week' | 'month'
+    period: 'day' | 'week' | 'month'
   ) => {
+    let dates = [];
+
     const start = dayjs(startDate);
     const end = dayjs(endDate);
-    let dates = [];
 
     let currentDate = start.clone();
 
-    switch (rangeKey) {
+    switch (period) {
       case 'day':
         while (currentDate.isBefore(end) || currentDate.isSame(end, 'day')) {
           dates.push(currentDate.toDate());

--- a/src/pages/dashboard/components/Chart.tsx
+++ b/src/pages/dashboard/components/Chart.tsx
@@ -53,17 +53,44 @@ export function Chart(props: Props) {
 
   const [chartData, setChartData] = useState<LineChartData>([]);
 
-  const generateDateRange = (start: Date, end: Date, range: 1 | 7 | 30) => {
-    const date = new Date(start.getTime());
+  const generateDateRange = (
+    startDate: Date,
+    endDate: Date,
+    rangeKey: 'day' | 'week' | 'month'
+  ) => {
+    const start = dayjs(startDate);
+    const end = dayjs(endDate);
+    const result = [];
 
-    const dates = [];
+    let current = start.clone();
 
-    while (date <= end) {
-      dates.push(new Date(date));
-      date.setDate(date.getDate() + range);
+    switch (rangeKey) {
+      case 'day':
+        while (current.isBefore(end) || current.isSame(end, 'day')) {
+          result.push(current.toDate());
+          current = current.add(1, 'day');
+        }
+        break;
+
+      case 'week':
+        while (current.isBefore(end) || current.isSame(end, 'day')) {
+          result.push(current.endOf('week').toDate());
+          current = current.add(1, 'week');
+        }
+        break;
+
+      case 'month':
+        while (current.isBefore(end) || current.isSame(end, 'day')) {
+          result.push(current.endOf('month').toDate());
+          current = current.add(1, 'month');
+        }
+        break;
+
+      default:
+        return [];
     }
 
-    return dates;
+    return result;
   };
 
   const getRecordIndex = (data: LineChartData | undefined, date: string) => {
@@ -112,59 +139,21 @@ export function Chart(props: Props) {
   useEffect(() => {
     const data: LineChartData = [];
 
-    if (props.chartSensitivity === 'day') {
-      const dates = generateDateRange(
-        new Date(props.dates.start_date),
-        new Date(props.dates.end_date),
-        1
-      );
+    const dates = generateDateRange(
+      new Date(props.dates.start_date),
+      new Date(props.dates.end_date),
+      props.chartSensitivity
+    );
 
-      dates.map((date) => {
-        data.push({
-          date: formatDate(date.toString(), dateFormat),
-          invoices: 0,
-          outstanding: 0,
-          payments: 0,
-          expenses: 0,
-        });
+    dates.map((date) => {
+      data.push({
+        date: formatDate(date.toString(), dateFormat),
+        invoices: 0,
+        outstanding: 0,
+        payments: 0,
+        expenses: 0,
       });
-    }
-
-    if (props.chartSensitivity === 'week') {
-      const dates = generateDateRange(
-        new Date(props.dates.start_date),
-        new Date(props.dates.end_date),
-        7
-      );
-
-      dates.map((date) => {
-        data.push({
-          date: formatDate(date.toString(), dateFormat),
-          invoices: 0,
-          outstanding: 0,
-          payments: 0,
-          expenses: 0,
-        });
-      });
-    }
-
-    if (props.chartSensitivity === 'month') {
-      const dates = generateDateRange(
-        new Date(props.dates.start_date),
-        new Date(props.dates.end_date),
-        30
-      );
-
-      dates.map((date) => {
-        data.push({
-          date: formatDate(date.toString(), dateFormat),
-          invoices: 0,
-          outstanding: 0,
-          payments: 0,
-          expenses: 0,
-        });
-      });
-    }
+    });
 
     props.data?.invoices.forEach((invoice) => {
       const date = formatDate(invoice.date, dateFormat);
@@ -267,6 +256,7 @@ export function Chart(props: Props) {
           tick={{ fontSize: 14 }}
           stroke={colors.$3}
         />
+
         <YAxis
           interval={0}
           tickCount={6}

--- a/src/pages/dashboard/hooks/useGenerateWeekDateRange.ts
+++ b/src/pages/dashboard/hooks/useGenerateWeekDateRange.ts
@@ -1,0 +1,37 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+
+dayjs.extend(utc);
+
+export function useGenerateWeekDateRange() {
+  return (startDate: Date, endDate: Date) => {
+    const start = dayjs.utc(startDate);
+    const end = dayjs.utc(endDate);
+    const dates = [];
+
+    let currentDate = start.clone();
+
+    while (currentDate.isBefore(end) || currentDate.isSame(end, 'day')) {
+      dates.push(currentDate.endOf('week').toDate());
+      currentDate = currentDate.add(1, 'week');
+    }
+
+    const lengthOfDates = dates.length;
+
+    if (dayjs.utc(dates[lengthOfDates - 1]).isAfter(end)) {
+      dates[lengthOfDates - 1] = end.toDate();
+    }
+
+    return dates;
+  };
+}


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for chart points for the 'week' and 'month' periods. Previously, our logic for generating date ranges to obtain the chart was not optimal. I have now addressed this issue, eliminating unnecessary chart points.

It's important to note that the exact same logic applies to the 'day' period. However, for the 'week' period, we will consistently obtain the last date of the week. Similarly, for the 'month' period, the logic remains unchanged. In cases where the end date of the selected period does not encompass the last date of the week/month, the chart's end date will be the last date within the selected range.

Let me know your thoughts.