### PR TITLE
[Cleanup] Quotes Split Button

### DIFF
--- a/src/pages/quotes/edit/Edit.tsx
+++ b/src/pages/quotes/edit/Edit.tsx
@@ -111,12 +111,11 @@ export default function Edit() {
       breadcrumbs={pages}
       {...((hasPermission('edit_quote') || entityAssigned(quote)) &&
         quote && {
-          onSaveClick: () => save(quote),
           navigationTopRight: (
             <ResourceActions
               resource={quote}
-              label={t('more_actions')}
               actions={actions}
+              onSaveClick={() => quote && save(quote)}
               cypressRef="quoteActionDropdown"
             />
           ),

--- a/tests/e2e/quotes.spec.ts
+++ b/tests/e2e/quotes.spec.ts
@@ -102,23 +102,11 @@ const checkEditPage = async (
         .locator('[data-cy="topNavbar"]')
         .getByRole('button', { name: 'Save', exact: true })
     ).toBeVisible();
-
-    await expect(
-      page
-        .locator('[data-cy="topNavbar"]')
-        .getByRole('button', { name: 'More Actions', exact: true })
-    ).toBeVisible();
   } else {
     await expect(
       page
         .locator('[data-cy="topNavbar"]')
         .getByRole('button', { name: 'Save', exact: true })
-    ).not.toBeVisible();
-
-    await expect(
-      page
-        .locator('[data-cy="topNavbar"]')
-        .getByRole('button', { name: 'More Actions', exact: true })
     ).not.toBeVisible();
   }
 
@@ -258,10 +246,7 @@ test('can edit quote', async ({ page }) => {
     page.getByText('Successfully updated quote', { exact: true })
   ).toBeVisible();
 
-  await page
-    .locator('[data-cy="topNavbar"]')
-    .getByRole('button', { name: 'More Actions', exact: true })
-    .click();
+  await page.locator('[data-cy="chevronDownButton"]').first().click();
 
   await checkDropdownActions(page, actions, 'quoteActionDropdown', '', true);
 
@@ -296,10 +281,7 @@ test('can create a quote', async ({ page }) => {
     page.getByText('Successfully updated quote', { exact: true })
   ).toBeVisible();
 
-  await page
-    .locator('[data-cy="topNavbar"]')
-    .getByRole('button', { name: 'More Actions', exact: true })
-    .click();
+  await page.locator('[data-cy="chevronDownButton"]').first().click();
 
   await checkDropdownActions(page, actions, 'quoteActionDropdown', '', true);
 
@@ -346,10 +328,7 @@ test('can view and edit assigned quote with create_quote', async ({ page }) => {
     page.getByText('Successfully updated quote', { exact: true })
   ).toBeVisible();
 
-  await page
-    .locator('[data-cy="topNavbar"]')
-    .getByRole('button', { name: 'More Actions', exact: true })
-    .click();
+  await page.locator('[data-cy="chevronDownButton"]').first().click();
 
   await checkDropdownActions(page, actions, 'quoteActionDropdown', '', true);
 
@@ -582,10 +561,7 @@ test('all actions in dropdown displayed with admin permission', async ({
 
   await checkEditPage(page, true, true);
 
-  await page
-    .locator('[data-cy="topNavbar"]')
-    .getByRole('button', { name: 'More Actions', exact: true })
-    .click();
+  await page.locator('[data-cy="chevronDownButton"]').first().click();
 
   await checkDropdownActions(page, actions, 'quoteActionDropdown', '', true);
 
@@ -626,10 +602,7 @@ test('convert_to_invoice, convert_to_project and all clone actions displayed wit
 
   await checkEditPage(page, true, false);
 
-  await page
-    .locator('[data-cy="topNavbar"]')
-    .getByRole('button', { name: 'More Actions', exact: true })
-    .click();
+  await page.locator('[data-cy="chevronDownButton"]').first().click();
 
   await checkDropdownActions(page, actions, 'quoteActionDropdown', '', true);
 


### PR DESCRIPTION
@beganovich @turbo124 The PR involves implementing a split button for quotes on the Edit page, accompanied by necessary test adjustments to accommodate these changes. Screenshot:

![Screenshot 2024-01-04 at 23 31 19](https://github.com/invoiceninja/ui/assets/51542191/688d497d-75c8-45e0-813f-7952baab524d)

Let me know your thoughts.