### PR TITLE
[Bugfix] Mapping the "product_cost" line item property to the "cost" property of the product when selecting

### DIFF
--- a/src/pages/invoices/common/hooks/useHandleProductChange.ts
+++ b/src/pages/invoices/common/hooks/useHandleProductChange.ts
@@ -68,6 +68,8 @@ export function useHandleProductChange(props: Props) {
     lineItem.custom_value4 = product?.custom_value4 || '';
     lineItem.tax_id = product?.tax_id || '1';
 
+    lineItem.product_cost = product?.cost;
+
     return props.onChange(index, lineItem);
   };
 }


### PR DESCRIPTION
@beganovich @turbo124 The PR includes mapping the "product_cost" of the line item to the value of "product.cost". So, once the product is selected, the "lineItem.product_cost" will be populated with the value of "product.cost." Let me know your thoughts.