### PR TITLE
[Cleanup] Split Button | Client Show Page

### DIFF
--- a/src/components/ResourceActions.tsx
+++ b/src/components/ResourceActions.tsx
@@ -22,12 +22,13 @@ interface Props {
   onSaveClick?: () => void;
   disableSaveButton?: boolean;
   cypressRef?: string;
+  saveButtonLabel?: string | null;
 }
 
 export function ResourceActions(props: Props) {
   const [t] = useTranslation();
 
-  const { onSaveClick, disableSaveButton, label } = props;
+  const { onSaveClick, disableSaveButton, label, saveButtonLabel } = props;
 
   return (
     <>
@@ -40,7 +41,7 @@ export function ResourceActions(props: Props) {
             disabled={disableSaveButton}
             disableWithoutIcon
           >
-            {t('save')}
+            {saveButtonLabel ?? t('save')}
           </Button>
 
           <Dropdown

--- a/src/pages/clients/show/Client.tsx
+++ b/src/pages/clients/show/Client.tsx
@@ -16,7 +16,7 @@ import { Spinner } from '$app/components/Spinner';
 import { Tabs } from '$app/components/Tabs';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Outlet, useParams } from 'react-router-dom';
+import { Outlet, useNavigate, useParams } from 'react-router-dom';
 import { Address } from './components/Address';
 import { Contacts } from './components/Contacts';
 import { Details } from './components/Details';
@@ -28,7 +28,6 @@ import { Gateways } from './components/Gateways';
 import { ResourceActions } from '$app/components/ResourceActions';
 import { useActions } from '../common/hooks/useActions';
 import { MergeClientModal } from '../common/components/MergeClientModal';
-import { Button } from '$app/components/forms';
 import { useTabs } from './hooks/useTabs';
 import { EmailHistory } from './components/EmailHistory';
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
@@ -40,9 +39,9 @@ export default function Client() {
   const { data: client, isLoading } = useClientQuery({ id, enabled: true });
 
   const [t] = useTranslation();
+  const navigate = useNavigate();
 
   const hasPermission = useHasPermission();
-
   const entityAssigned = useEntityAssigned();
 
   const [isMergeModalOpen, setIsMergeModalOpen] = useState<boolean>(false);
@@ -76,21 +75,15 @@ export default function Client() {
       title={documentTitle}
       breadcrumbs={pages}
       navigationTopRight={
+        client &&
         (hasPermission('edit_client') || entityAssigned(client)) && (
-          <div className="flex space-x-3">
-            <Button to={route('/clients/:id/edit', { id })}>
-              {t('edit_client')}
-            </Button>
-
-            {client && (
-              <ResourceActions
-                label={t('more_actions')}
-                resource={client}
-                actions={actions}
-                cypressRef="clientActionDropdown"
-              />
-            )}
-          </div>
+          <ResourceActions
+            resource={client}
+            actions={actions}
+            saveButtonLabel={t('edit')}
+            onSaveClick={() => navigate(route('/clients/:id/edit', { id }))}
+            cypressRef="clientActionDropdown"
+          />
         )
       }
     >

--- a/tests/e2e/clients.spec.ts
+++ b/tests/e2e/clients.spec.ts
@@ -136,25 +136,13 @@ const checkShowPage = async (page: Page, isEditable: boolean) => {
     await expect(
       page
         .locator('[data-cy="topNavbar"]')
-        .getByRole('link', { name: 'Edit Client', exact: true })
-    ).not.toBeVisible();
-
-    await expect(
-      page
-        .locator('[data-cy="topNavbar"]')
-        .getByRole('button', { name: 'More Actions', exact: true })
+        .getByRole('button', { name: 'Edit', exact: true })
     ).not.toBeVisible();
   } else {
     await expect(
       page
         .locator('[data-cy="topNavbar"]')
-        .getByRole('link', { name: 'Edit Client', exact: true })
-    ).toBeVisible();
-
-    await expect(
-      page
-        .locator('[data-cy="topNavbar"]')
-        .getByRole('button', { name: 'More Actions', exact: true })
+        .getByRole('button', { name: 'Edit', exact: true })
     ).toBeVisible();
   }
 };
@@ -269,7 +257,7 @@ test('can edit client', async ({ page }) => {
 
   await page
     .locator('[data-cy="topNavbar"]')
-    .getByRole('link', { name: 'Edit Client', exact: true })
+    .getByRole('button', { name: 'Edit', exact: true })
     .click();
 
   await checkEditPage(page);
@@ -283,7 +271,9 @@ test('can edit client', async ({ page }) => {
     page.getByText('Successfully updated client', { exact: true })
   ).toBeVisible();
 
-  await checkDropdownActions(page, actions, 'clientActionDropdown');
+  await page.locator('[data-cy="chevronDownButton"]').first().click();
+
+  await checkDropdownActions(page, actions, 'clientActionDropdown', '', true);
 
   await logout(page);
 });
@@ -325,7 +315,7 @@ test('can create a client', async ({ page }) => {
 
   await page
     .locator('[data-cy="topNavbar"]')
-    .getByRole('link', { name: 'Edit Client', exact: true })
+    .getByRole('button', { name: 'Edit', exact: true })
     .click();
 
   await checkEditPage(page);
@@ -339,7 +329,9 @@ test('can create a client', async ({ page }) => {
     page.getByText('Successfully updated client', { exact: true })
   ).toBeVisible();
 
-  await checkDropdownActions(page, actions, 'clientActionDropdown');
+  await page.locator('[data-cy="chevronDownButton"]').first().click();
+
+  await checkDropdownActions(page, actions, 'clientActionDropdown', '', true);
 
   await logout(page);
 });
@@ -382,7 +374,7 @@ test('can view and edit assigned client with create_client', async ({
 
   await page
     .locator('[data-cy="topNavbar"]')
-    .getByRole('link', { name: 'Edit Client', exact: true })
+    .getByRole('button', { name: 'Edit', exact: true })
     .click();
 
   await checkEditPage(page);
@@ -396,7 +388,9 @@ test('can view and edit assigned client with create_client', async ({
     page.getByText('Successfully updated client', { exact: true })
   ).toBeVisible();
 
-  await checkDropdownActions(page, actions, 'clientActionDropdown');
+  await page.locator('[data-cy="chevronDownButton"]').first().click();
+
+  await checkDropdownActions(page, actions, 'clientActionDropdown', '', true);
 
   await logout(page);
 });
@@ -427,12 +421,7 @@ test('deleting client with edit_client', async ({ page }) => {
   if (!doRecordsExist) {
     await createClient({ page, withNavigation: false });
 
-    const moreActionsButton = page
-      .getByRole('button')
-      .filter({ has: page.getByText('More Actions') })
-      .first();
-
-    await moreActionsButton.click();
+    await page.locator('[data-cy="chevronDownButton"]').first().click();
 
     await page.getByText('Delete').click();
 
@@ -480,12 +469,7 @@ test('archiving client withe edit_client', async ({ page }) => {
   if (!doRecordsExist) {
     await createClient({ page, withNavigation: false });
 
-    const moreActionsButton = page
-      .getByRole('button')
-      .filter({ has: page.getByText('More Actions') })
-      .first();
-
-    await moreActionsButton.click();
+    await page.locator('[data-cy="chevronDownButton"]').first().click();
 
     await page.getByText('Archive').click();
 
@@ -536,7 +520,9 @@ test("can't purge client without admin permission", async ({ page }) => {
 
   await checkShowPage(page, true);
 
-  await checkDropdownActions(page, actions, 'clientActionDropdown');
+  await page.locator('[data-cy="chevronDownButton"]').first().click();
+
+  await checkDropdownActions(page, actions, 'clientActionDropdown', '', true);
 
   await logout(page);
 });
@@ -560,10 +546,7 @@ test('can purge client with admin permission', async ({ page }) => {
 
   await checkShowPage(page, true);
 
-  await page
-    .locator('[data-cy="topNavbar"]')
-    .getByRole('button', { name: 'More Actions', exact: true })
-    .click();
+  await page.locator('[data-cy="chevronDownButton"]').first().click();
 
   await page.getByText('Purge', { exact: true }).click();
 
@@ -606,8 +589,8 @@ test('client documents preview with edit_client', async ({ page }) => {
     await createClient({ page });
 
     await page
-      .getByRole('link')
-      .filter({ has: page.getByText('Edit Client') })
+      .getByRole('button')
+      .filter({ has: page.getByText('Edit') })
       .click();
   } else {
     const moreActionsButton = tableRow
@@ -659,8 +642,8 @@ test('client documents uploading with edit_client', async ({ page }) => {
     await createClient({ page });
 
     await page
-      .getByRole('link')
-      .filter({ has: page.getByText('Edit Client') })
+      .getByRole('button')
+      .filter({ has: page.getByText('Edit') })
       .click();
   } else {
     const moreActionsButton = tableRow
@@ -718,7 +701,9 @@ test('all actions in dropdown displayed with admin permission', async ({
 
   await checkShowPage(page, true);
 
-  await checkDropdownActions(page, actions, 'clientActionDropdown');
+  await page.locator('[data-cy="chevronDownButton"]').first().click();
+
+  await checkDropdownActions(page, actions, 'clientActionDropdown', '', true);
 
   await logout(page);
 });
@@ -759,7 +744,9 @@ test('New Invoice, Enter Credit, New Quote and Enter Payment displayed with crea
 
   await checkShowPage(page, true);
 
-  await checkDropdownActions(page, actions, 'clientActionDropdown');
+  await page.locator('[data-cy="chevronDownButton"]').first().click();
+
+  await checkDropdownActions(page, actions, 'clientActionDropdown', '', true);
 
   await logout(page);
 });
@@ -779,10 +766,7 @@ test('Merge client action', async ({ page }) => {
     email: 'secondMerge@example.com',
   });
 
-  await page
-    .getByRole('button', { name: 'More Actions', exact: true })
-    .first()
-    .click();
+  await page.locator('[data-cy="chevronDownButton"]').first().click();
 
   await page
     .getByRole('button', { name: 'Merge', exact: true })


### PR DESCRIPTION
@beganovich @turbo124 The PR includes refactoring of the Client show page navigation (implementing a split button) along with adjustments to tests. Screenshot: 

![Screenshot 2024-01-10 at 00 02 45](https://github.com/invoiceninja/ui/assets/51542191/a632df76-e86c-4cb0-8984-83fafb83df15)

Let me know your thoughts.

 