### PR TITLE
[Bugfix] Updating Products Selector List After Query Invalidation | Reports/Schedules

### DIFF
--- a/src/pages/reports/common/components/ProductItemsSelector.tsx
+++ b/src/pages/reports/common/components/ProductItemsSelector.tsx
@@ -99,7 +99,7 @@ export function ProductItemsSelector(props: Props) {
 
   return (
     <>
-      {productItems || !value || !value?.length ? (
+      {productItems ? (
         <Element leftSide={t('products')}>
           <Select
             id="productItemSelector"

--- a/src/pages/reports/common/components/ProductItemsSelector.tsx
+++ b/src/pages/reports/common/components/ProductItemsSelector.tsx
@@ -34,7 +34,7 @@ export function ProductItemsSelector(props: Props) {
   const { data: products } = useProductsQuery({ status: ['active'] });
 
   useEffect(() => {
-    if (products && !productItems) {
+    if (products) {
       setProductItems(
         products.map((product) => ({
           value: product.product_key,

--- a/tests/e2e/product.spec.ts
+++ b/tests/e2e/product.spec.ts
@@ -743,3 +743,30 @@ test('rendering documents and product_fields tabs with admin permission', async 
 
   await logout(page);
 });
+
+test('Product selector list gets updated on the report page when it is created', async ({
+  page,
+}) => {
+  await login(page);
+
+  await createProduct({ page, name: 'test product selector' });
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Reports', exact: true })
+    .click();
+
+  await page
+    .locator('[data-cy="reportNameSelector"]')
+    .selectOption({ label: 'Product Sales' });
+
+  await page.waitForTimeout(200);
+
+  await page.locator('[id="productItemSelector"]').click();
+
+  await expect(
+    page.getByText('test product selector', { exact: true })
+  ).toBeVisible();
+
+  await logout(page);
+});


### PR DESCRIPTION
@beganovich @turbo124 The PR addresses the bug related to updating the list of products in the Product selector for Reports/Schedules. The bug was not due to invalidation, we had the correct invalidation in place. However, the issue originated from a logic problem within the selector. Let me know your thoughts.