### PR TITLE
[Feature] Nordigen Redirect Button

### DIFF
--- a/src/common/interfaces/company.interface.ts
+++ b/src/common/interfaces/company.interface.ts
@@ -8,6 +8,8 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
+import { BankAccount } from './bank-accounts';
+
 export interface Company {
   id: string;
   size_id: string;
@@ -62,6 +64,7 @@ export interface Company {
   company_key: string;
   fill_products: boolean;
   convert_products: boolean;
+  bank_integrations: BankAccount[];
 }
 
 export interface Settings {

--- a/src/pages/settings/bank-accounts/common/components/ConnectAccounts.tsx
+++ b/src/pages/settings/bank-accounts/common/components/ConnectAccounts.tsx
@@ -23,10 +23,15 @@ import { useAccentColor } from '$app/common/hooks/useAccentColor';
 import { useClickAway } from 'react-use';
 import { useColorScheme } from '$app/common/colors';
 import { enterprisePlan } from '$app/common/guards/guards/enterprise-plan';
+import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 
 export function ConnectAccounts() {
   const [t] = useTranslation();
   const accentColor = useAccentColor();
+
+  const company = useCurrentCompany();
+
+  console.log(company.bank_integrations[0].disabled_upstream);
 
   const colors = useColorScheme();
 

--- a/src/pages/settings/bank-accounts/common/components/ConnectAccounts.tsx
+++ b/src/pages/settings/bank-accounts/common/components/ConnectAccounts.tsx
@@ -31,8 +31,6 @@ export function ConnectAccounts() {
 
   const company = useCurrentCompany();
 
-  console.log(company.bank_integrations[0].disabled_upstream);
-
   const colors = useColorScheme();
 
   const divRef = useRef<HTMLDivElement>(null);
@@ -89,6 +87,10 @@ export function ConnectAccounts() {
     }
   };
 
+  const isUpstreamDisabled = () => {
+    return company.bank_integrations[0].disabled_upstream;
+  };
+
   return (
     <>
       <Button
@@ -98,7 +100,9 @@ export function ConnectAccounts() {
         }
       >
         <span className="mr-2">{<Icon element={MdLink} size={20} />}</span>
-        {t('connect_accounts')}
+        {isUpstreamDisabled() && isSelfHosted()
+          ? t('reconnect_account')
+          : t('connect_accounts')}
       </Button>
 
       <Modal
@@ -137,7 +141,9 @@ export function ConnectAccounts() {
             disableWithoutIcon
             disabled={!account}
           >
-            {t('connect')}
+            {account === 'nordigen' && isUpstreamDisabled()
+              ? t('reconnect')
+              : t('connect')}
           </Button>
         </div>
       </Modal>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the refactoring of the UI for the button related to the connecting_account for bank_integrations. If the user is on the `SELF-HOSTED` platform where only `Nordigen` is available, and the `disabled_upstream` property is true, then we will show the `reconnect_account` translation text instead of `connect_accounts`. However, if it is a `HOSTED` platform and the user is trying to connect `Nordigen`, and `disabled_upstream` is true, instead of the `connect` button, we will have a `reconnect` button there. Screenshot:

![Screenshot 2024-01-15 at 20 02 01](https://github.com/invoiceninja/ui/assets/51542191/284efae3-034c-4d0c-b16b-f2b16254c630)

Let me know your thoughts.