### PR TITLE
[Cleanup] Project Split Button && Additional Test Adjustment

### DIFF
--- a/src/pages/projects/Project.tsx
+++ b/src/pages/projects/Project.tsx
@@ -22,7 +22,7 @@ import { Container } from '$app/components/Container';
 import { Default } from '$app/components/layouts/Default';
 import { ResourceActions } from '$app/components/ResourceActions';
 import { Tab, Tabs } from '$app/components/Tabs';
-import { FormEvent, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Outlet, useParams } from 'react-router-dom';
 import { useActions } from './common/hooks';
@@ -73,8 +73,7 @@ export default function Project() {
     },
   ];
 
-  const onSave = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
+  const onSave = () => {
     toast.processing();
     setErrors(undefined);
 
@@ -97,12 +96,11 @@ export default function Project() {
       title={documentTitle}
       breadcrumbs={pages}
       disableSaveButton={!projectValue}
-      onSaveClick={onSave}
       navigationTopRight={
         projectValue && (
           <ResourceActions
             resource={projectValue}
-            label={t('more_actions')}
+            onSaveClick={onSave}
             actions={actions}
             cypressRef="projectActionDropdown"
           />

--- a/tests/e2e/projects.spec.ts
+++ b/tests/e2e/projects.spec.ts
@@ -54,11 +54,7 @@ const checkEditPage = async (page: Page, isEditable: boolean) => {
         .getByRole('button', { name: 'Save', exact: true })
     ).toBeVisible();
 
-    await expect(
-      page
-        .locator('[data-cy="topNavbar"]')
-        .getByRole('button', { name: 'More Actions', exact: true })
-    ).toBeVisible();
+    await expect(page.locator('[data-cy="chevronDownButton"]')).toBeVisible();
   } else {
     await expect(
       page
@@ -67,9 +63,7 @@ const checkEditPage = async (page: Page, isEditable: boolean) => {
     ).not.toBeVisible();
 
     await expect(
-      page
-        .locator('[data-cy="topNavbar"]')
-        .getByRole('button', { name: 'More Actions', exact: true })
+      page.locator('[data-cy="chevronDownButton"]')
     ).not.toBeVisible();
   }
 };
@@ -249,10 +243,7 @@ test('can edit project', async ({ page }) => {
     page.getByText('Successfully updated project', { exact: true })
   ).toBeVisible();
 
-  await page
-    .locator('[data-cy="topNavbar"]')
-    .getByRole('button', { name: 'More Actions', exact: true })
-    .click();
+  await page.locator('[data-cy="chevronDownButton"]').first().click();
 
   await checkDropdownActions(page, actions, 'projectActionDropdown', '', true);
 
@@ -287,10 +278,7 @@ test('can create a project', async ({ page }) => {
     page.getByText('Successfully updated project', { exact: true })
   ).toBeVisible();
 
-  await page
-    .locator('[data-cy="topNavbar"]')
-    .getByRole('button', { name: 'More Actions', exact: true })
-    .click();
+  await page.locator('[data-cy="chevronDownButton"]').first().click();
 
   await checkDropdownActions(page, actions, 'projectActionDropdown', '', true);
 
@@ -352,10 +340,7 @@ test('can view and edit assigned project with create_project', async ({
     page.getByText('Successfully updated project', { exact: true })
   ).toBeVisible();
 
-  await page
-    .locator('[data-cy="topNavbar"]')
-    .getByRole('button', { name: 'More Actions', exact: true })
-    .click();
+  await page.locator('[data-cy="chevronDownButton"]').first().click();
 
   await checkDropdownActions(page, actions, 'projectActionDropdown', '', true);
 
@@ -388,11 +373,7 @@ test('deleting project with edit_project', async ({ page }) => {
   if (!doRecordsExist) {
     await createProject({ page });
 
-    const moreActionsButton = page
-      .locator('[data-cy="chevronDownButton"]')
-      .first();
-
-    await moreActionsButton.click();
+    await page.locator('[data-cy="chevronDownButton"]').first().click();
 
     await page.getByText('Delete').click();
 
@@ -588,10 +569,7 @@ test('Invoice project and clone action in dropdown displayed with admin permissi
 
   await checkEditPage(page, true);
 
-  await page
-    .locator('[data-cy="topNavbar"]')
-    .getByRole('button', { name: 'More Actions', exact: true })
-    .click();
+  await page.locator('[data-cy="chevronDownButton"]').first().click();
 
   await checkDropdownActions(page, actions, 'projectActionDropdown', '', true);
 
@@ -619,10 +597,7 @@ test('Invoice project and clone action displayed with creation permissions', asy
 
   await checkEditPage(page, true);
 
-  await page
-    .locator('[data-cy="topNavbar"]')
-    .getByRole('button', { name: 'More Actions', exact: true })
-    .click();
+  await page.locator('[data-cy="chevronDownButton"]').first().click();
 
   await checkDropdownActions(page, actions, 'projectActionDropdown', '', true);
 
@@ -658,11 +633,7 @@ test('cloning project', async ({ page }) => {
   if (!doRecordsExist) {
     await createProject({ page });
 
-    const moreActionsButton = page
-      .locator('[data-cy="topNavbar"]')
-      .getByRole('button', { name: 'More Actions', exact: true });
-
-    await moreActionsButton.click();
+    await page.locator('[data-cy="chevronDownButton"]').first().click();
   } else {
     const moreActionsButton = tableRow
       .getByRole('button')


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of a split button on the edit Project page, along with additional test adjustments related to the UI change. Screenshot:

![Screenshot 2024-01-14 at 18 46 17](https://github.com/invoiceninja/ui/assets/51542191/91dd71f5-3f73-4b88-99da-37851327a38a)

Let me know your thoughts.