### PR TITLE
[Cleanup] Permissions Adjustment Recurring Expenses && Transaction With Additional Tests Fixes

### DIFF
--- a/src/common/hooks/useDisableNavigation.ts
+++ b/src/common/hooks/useDisableNavigation.ts
@@ -19,6 +19,7 @@ import { Quote } from '../interfaces/quote';
 import { RecurringExpense } from '../interfaces/recurring-expense';
 import { RecurringInvoice } from '../interfaces/recurring-invoice';
 import { Task } from '../interfaces/task';
+import { Transaction } from '../interfaces/transactions';
 import { Vendor } from '../interfaces/vendor';
 import { useHasPermission } from './permissions/useHasPermission';
 import { useEntityAssigned } from './useEntityAssigned';
@@ -35,7 +36,8 @@ type Entity =
   | 'task'
   | 'expense'
   | 'vendor'
-  | 'recurring_expense';
+  | 'recurring_expense'
+  | 'bank_transaction';
 
 type Resource =
   | Client
@@ -49,7 +51,8 @@ type Resource =
   | Task
   | Expense
   | Vendor
-  | RecurringExpense;
+  | RecurringExpense
+  | Transaction;
 
 export function useDisableNavigation() {
   const hasPermission = useHasPermission();

--- a/src/common/hooks/useEntityAssigned.ts
+++ b/src/common/hooks/useEntityAssigned.ts
@@ -19,6 +19,7 @@ import { Quote } from '../interfaces/quote';
 import { RecurringExpense } from '../interfaces/recurring-expense';
 import { RecurringInvoice } from '../interfaces/recurring-invoice';
 import { Task } from '../interfaces/task';
+import { Transaction } from '../interfaces/transactions';
 import { Vendor } from '../interfaces/vendor';
 import { useAdmin } from './permissions/useHasPermission';
 import { useCurrentUser } from './useCurrentUser';
@@ -35,7 +36,8 @@ type Entity =
   | Expense
   | Vendor
   | RecurringExpense
-  | Product;
+  | Product
+  | Transaction;
 
 export function useEntityAssigned() {
   const user = useCurrentUser();
@@ -50,13 +52,16 @@ export function useEntityAssigned() {
       );
     }
 
+    const isEntityAssigned =
+      user &&
+      entity &&
+      'assigned_user_id' in entity &&
+      entity.assigned_user_id === user.id;
+
     return Boolean(
       user &&
         entity &&
-        (entity.user_id === user.id ||
-          entity.assigned_user_id === user.id ||
-          isAdmin ||
-          isOwner)
+        (entity.user_id === user.id || isEntityAssigned || isAdmin || isOwner)
     );
   };
 }

--- a/src/common/interfaces/transactions.ts
+++ b/src/common/interfaces/transactions.ts
@@ -34,4 +34,5 @@ export interface Transaction {
   vendor_id: string;
   participant: string;
   participant_name: string;
+  user_id: string;
 }

--- a/src/common/queries/expense-categories.ts
+++ b/src/common/queries/expense-categories.ts
@@ -14,7 +14,7 @@ import { useQuery } from 'react-query';
 import { Params } from './common/params.interface';
 import { ExpenseCategory } from '$app/common/interfaces/expense-category';
 import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-api-response';
-import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
+import { useAdmin } from '$app/common/hooks/permissions/useHasPermission';
 import { toast } from '$app/common/helpers/toast/toast';
 import { $refetch } from '../hooks/useRefetch';
 
@@ -79,7 +79,7 @@ export function useBulkAction() {
 }
 
 export function useBlankExpenseCategoryQuery() {
-  const hasPermission = useHasPermission();
+  const { isAdmin, isOwner } = useAdmin();
 
   return useQuery<ExpenseCategory>(
     '/api/v1/expense_categories/create',
@@ -88,6 +88,6 @@ export function useBlankExpenseCategoryQuery() {
         (response: GenericSingleResourceResponse<ExpenseCategory>) =>
           response.data.data
       ),
-    { staleTime: Infinity, enabled: hasPermission('create_expense') }
+    { staleTime: Infinity, enabled: isAdmin || isOwner }
   );
 }

--- a/src/common/queries/vendor.ts
+++ b/src/common/queries/vendor.ts
@@ -16,6 +16,7 @@ import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-ap
 import { Params } from './common/params.interface';
 import { toast } from '../helpers/toast/toast';
 import { $refetch } from '../hooks/useRefetch';
+import { useHasPermission } from '../hooks/permissions/useHasPermission';
 
 interface VendorParams {
   id: string | undefined;
@@ -34,13 +35,15 @@ export function useVendorQuery(params: VendorParams) {
 }
 
 export function useBlankVendorQuery() {
+  const hasPermission = useHasPermission();
+
   return useQuery<Vendor>(
     ['/api/v1/vendors', 'create'],
     () =>
       request('GET', endpoint('/api/v1/vendors/create')).then(
         (response) => response.data.data
       ),
-    { staleTime: Infinity }
+    { staleTime: Infinity, enabled: hasPermission('create_vendor') }
   );
 }
 

--- a/src/pages/recurring-expenses/RecurringExpense.tsx
+++ b/src/pages/recurring-expenses/RecurringExpense.tsx
@@ -27,11 +27,16 @@ import { useTranslation } from 'react-i18next';
 import { Outlet, useParams } from 'react-router-dom';
 import { Spinner } from '$app/components/Spinner';
 import { $refetch } from '$app/common/hooks/useRefetch';
+import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
+import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
 
 export default function RecurringExpense() {
   const [t] = useTranslation();
 
   const { documentTitle } = useTitle('edit_recurring_expense');
+
+  const hasPermission = useHasPermission();
+  const entityAssigned = useEntityAssigned();
 
   const actions = useActions();
 
@@ -103,17 +108,20 @@ export default function RecurringExpense() {
     <Default
       title={documentTitle}
       breadcrumbs={pages}
-      onSaveClick={handleSave}
-      navigationTopRight={
-        recurringExpense && (
-          <ResourceActions
-            resource={recurringExpense}
-            label={t('more_actions')}
-            actions={actions}
-          />
-        )
-      }
-      disableSaveButton={!recurringExpense}
+      {...((hasPermission('edit_recurring_expense') ||
+        entityAssigned(recurringExpense)) &&
+        recurringExpense && {
+          onSaveClick: handleSave,
+          disableSaveButton: !recurringExpense,
+          navigationTopRight: (
+            <ResourceActions
+              resource={recurringExpense}
+              label={t('more_actions')}
+              actions={actions}
+              cypressRef="recurringExpenseActionDropdown"
+            />
+          ),
+        })}
     >
       {recurringExpense ? (
         <div className="space-y-4">

--- a/src/pages/recurring-expenses/components/Details.tsx
+++ b/src/pages/recurring-expenses/components/Details.tsx
@@ -61,6 +61,7 @@ export function Details(props: Props) {
 
           <Element leftSide={t('number')}>
             <InputField
+              id="number"
               value={recurringExpense.number}
               onValueChange={(value) => handleChange('number', value)}
               errorMessage={errors?.errors.number}

--- a/src/pages/recurring-expenses/components/Taxes.tsx
+++ b/src/pages/recurring-expenses/components/Taxes.tsx
@@ -9,11 +9,13 @@
  */
 
 import { Card, Element } from '$app/components/cards';
-import { Link, Radio } from '$app/components/forms';
+import { Radio } from '$app/components/forms';
 import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import Toggle from '$app/components/forms/Toggle';
 import { useTranslation } from 'react-i18next';
 import { RecurringExpenseCardProps } from './Details';
+import { DynamicLink } from '$app/components/DynamicLink';
+import { useAdmin } from '$app/common/hooks/permissions/useHasPermission';
 
 interface Props extends RecurringExpenseCardProps {
   taxInputType: 'by_rate' | 'by_amount';
@@ -24,6 +26,8 @@ export function TaxSettings(props: Props) {
   const [t] = useTranslation();
 
   const company = useCurrentCompany();
+
+  const { isAdmin, isOwner } = useAdmin();
 
   const { recurringExpense, handleChange, taxInputType, setTaxInputType } =
     props;
@@ -37,7 +41,12 @@ export function TaxSettings(props: Props) {
     <Card title={t('taxes')} isLoading={!recurringExpense}>
       {!company?.enabled_expense_tax_rates && (
         <Element leftSide={t('expense_tax_help')}>
-          <Link to="/settings/tax_settings">{t('settings')}</Link>
+          <DynamicLink
+            to="/settings/tax_settings"
+            renderSpan={!isAdmin && !isOwner}
+          >
+            {t('settings')}
+          </DynamicLink>
         </Element>
       )}
 

--- a/src/pages/recurring-expenses/documents/Documents.tsx
+++ b/src/pages/recurring-expenses/documents/Documents.tsx
@@ -14,11 +14,16 @@ import { Upload } from '$app/pages/settings/company/documents/components';
 import { useOutletContext } from 'react-router-dom';
 import { Context } from '../edit/Edit';
 import { $refetch } from '$app/common/hooks/useRefetch';
+import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
+import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
 
 export default function Documents() {
   const context: Context = useOutletContext();
 
   const { recurringExpense } = context;
+
+  const hasPermission = useHasPermission();
+  const entityAssigned = useEntityAssigned();
 
   const invalidateCache = () => {
     $refetch(['recurring_expenses']);
@@ -32,11 +37,16 @@ export default function Documents() {
           id: recurringExpense.id,
         })}
         onSuccess={invalidateCache}
+        disableUpload={
+          !hasPermission('edit_recurring_expense') &&
+          !entityAssigned(recurringExpense)
+        }
       />
 
       <DocumentsTable
         documents={recurringExpense?.documents || []}
         onDocumentDelete={invalidateCache}
+        disableEditableOptions={!entityAssigned(recurringExpense, true)}
       />
     </div>
   );

--- a/src/pages/recurring-expenses/index/RecurringExpenses.tsx
+++ b/src/pages/recurring-expenses/index/RecurringExpenses.tsx
@@ -20,11 +20,14 @@ import {
 } from '../common/hooks';
 import { permission } from '$app/common/guards/guards/permission';
 import { useCustomBulkActions } from '../common/hooks/useCustomBulkActions';
+import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 
 export default function RecurringExpenses() {
   useTitle('recurring_expenses');
 
   const [t] = useTranslation();
+
+  const hasPermission = useHasPermission();
 
   const pages = [
     { name: t('recurring_expenses'), href: '/recurring_expenses' },
@@ -63,6 +66,7 @@ export default function RecurringExpenses() {
           />
         }
         linkToCreateGuards={[permission('create_recurring_expense')]}
+        hideEditableOptions={!hasPermission('edit_recurring_expense')}
       />
     </Default>
   );

--- a/src/pages/settings/bank-accounts/common/queries.ts
+++ b/src/pages/settings/bank-accounts/common/queries.ts
@@ -13,6 +13,7 @@ import { request } from '$app/common/helpers/request';
 import { useQuery } from 'react-query';
 import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-api-response';
 import { BankAccount } from '$app/common/interfaces/bank-accounts';
+import { useAdmin } from '$app/common/hooks/permissions/useHasPermission';
 
 interface BankAccountParams {
   id: string | undefined;
@@ -20,6 +21,8 @@ interface BankAccountParams {
 }
 
 export function useBankAccountQuery(params: BankAccountParams) {
+  const { isAdmin, isOwner } = useAdmin();
+
   return useQuery<BankAccount>(
     ['/api/v1/bank_integrations', params.id],
     () =>
@@ -30,7 +33,10 @@ export function useBankAccountQuery(params: BankAccountParams) {
         (response: GenericSingleResourceResponse<BankAccount>) =>
           response.data.data
       ),
-    { enabled: params.enabled ?? true, staleTime: Infinity }
+    {
+      enabled: (params.enabled ?? true) && (isAdmin || isOwner),
+      staleTime: Infinity,
+    }
   );
 }
 
@@ -47,6 +53,8 @@ export function useBankAccountsQuery() {
 }
 
 export function useBlankBankAccountQuery() {
+  const { isAdmin, isOwner } = useAdmin();
+
   return useQuery<BankAccount>(
     ['/api/v1/bank_integrations', 'create'],
     () =>
@@ -54,6 +62,6 @@ export function useBlankBankAccountQuery() {
         (response: GenericSingleResourceResponse<BankAccount>) =>
           response.data.data
       ),
-    { staleTime: Infinity }
+    { staleTime: Infinity, enabled: isAdmin || isOwner }
   );
 }

--- a/src/pages/transactions/common/hooks/useTransactionColumns.tsx
+++ b/src/pages/transactions/common/hooks/useTransactionColumns.tsx
@@ -12,9 +12,11 @@ import { ApiTransactionType } from '$app/common/enums/transactions';
 import { route } from '$app/common/helpers/route';
 import { useFormatMoney } from '$app/common/hooks/money/useFormatMoney';
 import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
+import { useDisableNavigation } from '$app/common/hooks/useDisableNavigation';
 import { Transaction } from '$app/common/interfaces/transactions';
 import { useExpensesQuery } from '$app/common/queries/expenses';
 import { DataTableColumns } from '$app/components/DataTable';
+import { DynamicLink } from '$app/components/DynamicLink';
 import { Tooltip } from '$app/components/Tooltip';
 import { Link } from '$app/components/forms';
 import { useInvoicesQuery } from '$app/pages/invoices/common/queries';
@@ -27,6 +29,7 @@ export function useTransactionColumns() {
   const company = useCurrentCompany();
 
   const formatMoney = useFormatMoney();
+  const disableNavigation = useDisableNavigation();
 
   const { data: invoices } = useInvoicesQuery({ perPage: 1000 });
 
@@ -44,13 +47,14 @@ export function useTransactionColumns() {
     {
       id: 'status',
       label: t('status'),
-      format: (_, transaction) => {
-        return (
-          <Link to={route('/transactions/:id/edit', { id: transaction.id })}>
-            <EntityStatus transaction={transaction} />
-          </Link>
-        );
-      },
+      format: (_, transaction) => (
+        <DynamicLink
+          to={route('/transactions/:id/edit', { id: transaction.id })}
+          renderSpan={disableNavigation('bank_transaction', transaction)}
+        >
+          <EntityStatus transaction={transaction} />
+        </DynamicLink>
+      ),
     },
     {
       id: 'deposit',

--- a/src/pages/transactions/edit/Edit.tsx
+++ b/src/pages/transactions/edit/Edit.tsx
@@ -17,7 +17,7 @@ import { Default } from '$app/components/layouts/Default';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { request } from '$app/common/helpers/request';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { toast } from '$app/common/helpers/toast/toast';
 import { AxiosError } from 'axios';
 import { DecimalInputSeparators } from '$app/common/interfaces/decimal-number-input-separators';
@@ -35,8 +35,6 @@ import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
 
 export default function Edit() {
   const [t] = useTranslation();
-
-  const navigate = useNavigate();
 
   const hasPermission = useHasPermission();
   const entityAssigned = useEntityAssigned();
@@ -90,8 +88,6 @@ export default function Edit() {
         toast.success('updated_transaction');
 
         $refetch(['bank_transactions']);
-
-        navigate('/transactions');
       })
       .catch((error: AxiosError<ValidationBag>) => {
         if (error.response?.status === 422) {

--- a/src/pages/transactions/index/Transactions.tsx
+++ b/src/pages/transactions/index/Transactions.tsx
@@ -25,11 +25,14 @@ import { Guard } from '$app/common/guards/Guard';
 import { or } from '$app/common/guards/guards/or';
 import { permission } from '$app/common/guards/guards/permission';
 import { useCustomBulkActions } from '../common/hooks/useCustomBulkActions';
+import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 
 export default function Transactions() {
   useTitle('transactions');
 
   const [t] = useTranslation();
+
+  const hasPermission = useHasPermission();
 
   const columns = useTransactionColumns();
 
@@ -104,6 +107,7 @@ export default function Transactions() {
           }
           withResourcefulActions
           linkToCreateGuards={[permission('create_bank_transaction')]}
+          hideEditableOptions={!hasPermission('edit_bank_transaction')}
         />
       </Default>
     </>

--- a/tests/e2e/bank-transactions.spec.ts
+++ b/tests/e2e/bank-transactions.spec.ts
@@ -1,89 +1,303 @@
-import { login, logout, permissions } from '$tests/e2e/helpers';
-import test, { expect } from '@playwright/test';
+import {
+  checkTableEditability,
+  login,
+  logout,
+  permissions,
+} from '$tests/e2e/helpers';
+import test, { expect, Page } from '@playwright/test';
 
-test("can't view bank transactions without permission", async ({ page }) => {
+interface CreateParams {
+  page: Page;
+  isTableEditable?: boolean;
+  withNavigation?: boolean;
+}
+const createBankTransaction = async (params: CreateParams) => {
+  const { page, withNavigation = true, isTableEditable = true } = params;
+
+  if (withNavigation) {
+    await page
+      .locator('[data-cy="navigationBar"]')
+      .getByRole('link', { name: 'Transactions', exact: true })
+      .click();
+
+    await checkTableEditability(page, isTableEditable);
+  }
+
+  await page
+    .getByRole('main')
+    .getByRole('link', { name: 'New Transaction' })
+    .click();
+
+  await page.getByRole('main').locator('[type="text"]').nth(0).fill('100');
+
+  await page.getByTestId('combobox-input-field').first().click();
+  await page.waitForTimeout(200);
+  await page.getByRole('main').locator('[role="option"]').first().click();
+
+  await page
+    .getByRole('main')
+    .locator('[type="text"]')
+    .nth(1)
+    .fill('Transaction Notes');
+
+  await page.getByRole('button', { name: 'Save' }).click();
+
+  await expect(
+    page.getByText('Successfully created transaction', { exact: true })
+  ).toBeVisible();
+};
+
+const checkEditPage = async (page: Page, isEditable: boolean) => {
+  if (isEditable) {
+    await expect(
+      page
+        .locator('[data-cy="topNavbar"]')
+        .getByRole('button', { name: 'Save', exact: true })
+    ).toBeVisible();
+
+    await expect(
+      page
+        .locator('[data-cy="topNavbar"]')
+        .getByRole('button', { name: 'More Actions', exact: true })
+    ).toBeVisible();
+  } else {
+    await expect(
+      page
+        .locator('[data-cy="topNavbar"]')
+        .getByRole('button', { name: 'Save', exact: true })
+    ).not.toBeVisible();
+
+    await expect(
+      page
+        .locator('[data-cy="topNavbar"]')
+        .getByRole('button', { name: 'More Actions', exact: true })
+    ).not.toBeVisible();
+  }
+};
+
+test("can't view transactions without permission", async ({ page }) => {
   const { clear, save } = permissions(page);
 
   await login(page);
-  await clear();
+  await clear('bank_transactions@example.com');
   await save();
   await logout(page);
 
-  await login(page, 'permissions@example.com', 'password');
+  await login(page, 'bank_transactions@example.com', 'password');
 
-  await expect(page.locator('.flex-grow > .flex-1').first()).not.toContainText(
+  await expect(page.locator('[data-cy="navigationBar"]')).not.toContainText(
     'Transactions'
   );
+
+  await logout(page);
 });
 
-test('can view bank transactions', async ({ page }) => {
+test('can view transaction', async ({ page }) => {
   const { clear, save, set } = permissions(page);
 
   await login(page);
-  await clear();
+  await clear('bank_transactions@example.com');
   await set('view_bank_transaction');
+  await save();
+
+  await createBankTransaction({ page });
+
+  await logout(page);
+
+  await login(page, 'bank_transactions@example.com', 'password');
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Transactions', exact: true })
+    .click();
+
+  await checkTableEditability(page, false);
+
+  await page.getByRole('row').nth(1).getByRole('link').first().click();
+
+  await checkEditPage(page, false);
+
+  await logout(page);
+});
+
+test('can edit transaction', async ({ page }) => {
+  const { clear, save, set } = permissions(page);
+
+  await login(page);
+  await clear('bank_transactions@example.com');
+  await set('edit_bank_transaction');
+  await save();
+
+  await createBankTransaction({ page });
+
+  await logout(page);
+
+  await login(page, 'bank_transactions@example.com', 'password');
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Transactions', exact: true })
+    .click();
+
+  await checkTableEditability(page, true);
+
+  console.log(await page.getByRole('row').nth(1).textContent());
+
+  await page.getByRole('row').nth(1).getByRole('link').first().click();
+
+  await page.waitForURL('**/transactions/**/edit');
+
+  await checkEditPage(page, true);
+
+  await page
+    .locator('[data-cy="topNavbar"]')
+    .getByRole('button', { name: 'Save', exact: true })
+    .click();
+
+  await expect(
+    page.getByText('Successfully updated transaction', { exact: true })
+  ).toBeVisible();
+
+  await logout(page);
+});
+
+test('can create a transaction', async ({ page }) => {
+  const { clear, save, set } = permissions(page);
+
+  await login(page);
+  await clear('bank_transactions@example.com');
+  await set('create_bank_transaction');
   await save();
   await logout(page);
 
-  await login(page, 'permissions@example.com', 'password');
+  await login(page, 'bank_transactions@example.com', 'password');
+
+  await createBankTransaction({
+    page,
+    isTableEditable: false,
+  });
+
+  await checkEditPage(page, true);
+
+  await page
+    .locator('[data-cy="topNavbar"]')
+    .getByRole('button', { name: 'Save', exact: true })
+    .click();
+
+  await expect(
+    page.getByText('Successfully updated transaction', { exact: true })
+  ).toBeVisible();
+
+  await logout(page);
+});
+
+test('deleting transaction with edit_bank_transaction', async ({ page }) => {
+  const { clear, save, set } = permissions(page);
+
+  await login(page);
+  await clear('bank_transactions@example.com');
+  await set('create_bank_transaction', 'edit_bank_transaction');
+  await save();
+  await logout(page);
+
+  await login(page, 'bank_transactions@example.com', 'password');
+
+  const tableBody = page.locator('tbody').first();
+
+  await page.getByRole('link', { name: 'Transactions', exact: true }).click();
+
+  const tableRow = tableBody.getByRole('row').first();
+
+  await page.waitForURL('**/transactions');
+
+  await page.waitForTimeout(200);
+
+  const doRecordsExist = await page.getByText('No records found').isHidden();
+
+  if (!doRecordsExist) {
+    await createBankTransaction({ page, withNavigation: false });
+
+    await page
+      .getByRole('button')
+      .filter({ has: page.getByText('More Actions') })
+      .first()
+      .click();
+
+    await page.getByText('Delete').click();
+
+    await expect(
+      page.getByText('Successfully deleted transaction')
+    ).toBeVisible();
+
+    await expect(
+      page.getByRole('button', { name: 'Restore', exact: true })
+    ).toBeVisible();
+  } else {
+    await tableRow
+      .getByRole('button')
+      .filter({ has: page.getByText('More Actions') })
+      .click();
+
+    await page.getByText('Delete').click();
+
+    await expect(
+      page.getByText('Successfully deleted transaction')
+    ).toBeVisible();
+  }
+});
+
+test('archiving transaction withe edit_bank_transaction', async ({ page }) => {
+  const { clear, save, set } = permissions(page);
+
+  await login(page);
+  await clear('bank_transactions@example.com');
+  await set('create_bank_transaction', 'edit_bank_transaction');
+  await save();
+  await logout(page);
+
+  await login(page, 'bank_transactions@example.com', 'password');
+
+  const tableBody = page.locator('tbody').first();
 
   await page.getByRole('link', { name: 'Transactions', exact: true }).click();
 
   await page.waitForURL('**/transactions');
 
-  await expect(
-    page.getByRole('heading', {
-      name: "Sorry, you don't have the needed permissions.",
-    })
-  ).not.toBeVisible();
-});
+  const tableRow = tableBody.getByRole('row').first();
 
-test('can create a bank transaction', async ({ page }) => {
-  const { clear, save, set } = permissions(page);
+  await page.waitForTimeout(200);
 
-  await login(page);
-  await clear();
-  await set('create_bank_transaction');
-  await save();
-  await logout(page);
+  const doRecordsExist = await page.getByText('No records found').isHidden();
 
-  await login(page, 'permissions@example.com', 'password');
+  if (!doRecordsExist) {
+    await createBankTransaction({ page, withNavigation: false });
 
-  await page.getByRole('link', { name: 'Transactions', exact: true }).click();
-  await page.getByText('New Transaction').click();
+    await page
+      .getByRole('button')
+      .filter({ has: page.getByText('More Actions') })
+      .first()
+      .click();
 
-  await expect(
-    page.getByRole('heading', {
-      name: "Sorry, you don't have the needed permissions.",
-    })
-  ).not.toBeVisible();
-  
-});
+    await page.getByText('Archive').click();
 
-test.skip('can view assigned bank_transaction with create_bank_transaction', async ({
-  page,
-}) => {
-  //Blocker bank account
+    await expect(
+      page.getByText('Successfully archived transaction')
+    ).toBeVisible();
 
-  const { clear, save, set } = permissions(page);
+    await expect(
+      page.getByRole('button', { name: 'Restore', exact: true })
+    ).toBeVisible();
+  } else {
+    await tableRow
+      .getByRole('button')
+      .filter({ has: page.getByText('More Actions') })
+      .first()
+      .click();
 
-  await login(page);
-  await clear();
-  await set('create_bank_transaction');
-  await save();
-  await logout(page);
+    await page.getByText('Archive').click();
 
-  await login(page, 'permissions@example.com', 'password');
-
-  await page.getByRole('link', { name: 'Transactions' }).click();
-  await page
-    .getByRole('main')
-    .getByRole('link', { name: 'New Transaction' })
-    .click();
-  await page.getByRole('option', { name: 'cypress' }).click();
-  await page.getByRole('button', { name: 'Save' }).click();
-
-  await expect(
-    page.getByRole('heading', { name: 'Edit Transaction' })
-  ).toBeVisible();
+    await expect(
+      page.getByText('Successfully archived transaction')
+    ).toBeVisible();
+  }
 });

--- a/tests/e2e/recurring-expense.spec.ts
+++ b/tests/e2e/recurring-expense.spec.ts
@@ -103,9 +103,7 @@ const createRecurringExpense = async (params: CreateParams) => {
   }
 };
 
-test.skip("can't view recurring expenses without permission", async ({
-  page,
-}) => {
+test("can't view recurring expenses without permission", async ({ page }) => {
   const { clear, save } = permissions(page);
 
   await login(page);
@@ -122,7 +120,7 @@ test.skip("can't view recurring expenses without permission", async ({
   await logout(page);
 });
 
-test.skip('can view recurring expense', async ({ page }) => {
+test('can view recurring expense', async ({ page }) => {
   const { clear, save, set } = permissions(page);
 
   await login(page);
@@ -152,7 +150,7 @@ test.skip('can view recurring expense', async ({ page }) => {
   await logout(page);
 });
 
-test.skip('can edit recurring expense', async ({ page }) => {
+test('can edit recurring expense', async ({ page }) => {
   const { clear, save, set } = permissions(page);
 
   const actions = useRecurringExpensesActions({
@@ -197,16 +195,16 @@ test.skip('can edit recurring expense', async ({ page }) => {
   await logout(page);
 });
 
-test('can create a expense', async ({ page }) => {
+test('can create a recurring expense', async ({ page }) => {
   const { clear, save, set } = permissions(page);
 
   const actions = useRecurringExpensesActions({
-    permissions: ['create_expense'],
+    permissions: ['create_recurring_expense'],
   });
 
   await login(page);
   await clear('expenses@example.com');
-  await set('create_expense');
+  await set('create_recurring_expense');
   await save();
   await logout(page);
 
@@ -222,7 +220,7 @@ test('can create a expense', async ({ page }) => {
     .click();
 
   await expect(
-    page.getByText('Successfully updated expense', { exact: true })
+    page.getByText('Successfully updated recurring expense', { exact: true })
   ).toBeVisible();
 
   await checkDropdownActions(page, actions, 'recurringExpenseActionDropdown');
@@ -230,21 +228,21 @@ test('can create a expense', async ({ page }) => {
   await logout(page);
 });
 
-test.skip('can view and edit assigned expense with create_expense', async ({
+test('can view and edit assigned recurring expense with create_recurring_expense', async ({
   page,
 }) => {
   const { clear, save, set } = permissions(page);
 
   const actions = useRecurringExpensesActions({
-    permissions: ['create_expense'],
+    permissions: ['create_recurring_expense'],
   });
 
   await login(page);
   await clear('expenses@example.com');
-  await set('create_expense');
+  await set('create_recurring_expense');
   await save();
 
-  const expenseNumber = await createRecurringExpense({
+  const recurringExpenseNumber = await createRecurringExpense({
     page,
     assignTo: 'Expenses Example',
     returnCreditNumber: true,
@@ -261,7 +259,9 @@ test.skip('can view and edit assigned expense with create_expense', async ({
 
   await checkTableEditability(page, false);
 
-  await page.getByRole('link', { name: expenseNumber, exact: true }).click();
+  await page
+    .getByRole('link', { name: recurringExpenseNumber, exact: true })
+    .click();
 
   await checkEditPage(page, true);
 
@@ -271,7 +271,7 @@ test.skip('can view and edit assigned expense with create_expense', async ({
     .click();
 
   await expect(
-    page.getByText('Successfully updated expense', { exact: true })
+    page.getByText('Successfully updated recurring expense', { exact: true })
   ).toBeVisible();
 
   await checkDropdownActions(page, actions, 'recurringExpenseActionDropdown');
@@ -279,12 +279,14 @@ test.skip('can view and edit assigned expense with create_expense', async ({
   await logout(page);
 });
 
-test.skip('deleting expense with edit_expense', async ({ page }) => {
+test('deleting recurring expense with edit_recurring_expense', async ({
+  page,
+}) => {
   const { clear, save, set } = permissions(page);
 
   await login(page);
   await clear('expenses@example.com');
-  await set('create_expense', 'edit_expense');
+  await set('create_recurring_expense', 'edit_recurring_expense');
   await save();
   await logout(page);
 
@@ -298,7 +300,7 @@ test.skip('deleting expense with edit_expense', async ({ page }) => {
 
   const tableRow = tableBody.getByRole('row').first();
 
-  await page.waitForURL('**/expenses');
+  await page.waitForURL('**/recurring_expenses');
 
   await page.waitForTimeout(200);
 
@@ -324,15 +326,19 @@ test.skip('deleting expense with edit_expense', async ({ page }) => {
     await page.getByText('Delete').click();
   }
 
-  await expect(page.getByText('Successfully deleted expense')).toBeVisible();
+  await expect(
+    page.getByText('Successfully deleted recurring expense')
+  ).toBeVisible();
 });
 
-test.skip('archiving expense with edit_expense', async ({ page }) => {
+test('archiving recurring expense with edit_recurring_expense', async ({
+  page,
+}) => {
   const { clear, save, set } = permissions(page);
 
   await login(page);
   await clear('expenses@example.com');
-  await set('create_expense', 'edit_expense');
+  await set('create_recurring_expense', 'edit_recurring_expense');
   await save();
   await logout(page);
 
@@ -344,7 +350,7 @@ test.skip('archiving expense with edit_expense', async ({ page }) => {
     .getByRole('link', { name: 'Recurring Expenses', exact: true })
     .click();
 
-  await page.waitForURL('**/expenses');
+  await page.waitForURL('**/recurring_expenses');
 
   const tableRow = tableBody.getByRole('row').first();
 
@@ -376,15 +382,19 @@ test.skip('archiving expense with edit_expense', async ({ page }) => {
     await page.getByText('Archive').click();
   }
 
-  await expect(page.getByText('Successfully archived expense')).toBeVisible();
+  await expect(
+    page.getByText('Successfully archived recurring expense')
+  ).toBeVisible();
 });
 
-test.skip('expense documents preview with edit_expense', async ({ page }) => {
+test('recurring expense documents preview with edit_recurring_expense', async ({
+  page,
+}) => {
   const { clear, save, set } = permissions(page);
 
   await login(page);
   await clear('expenses@example.com');
-  await set('create_expense', 'edit_expense');
+  await set('create_recurring_expense', 'edit_recurring_expense');
   await save();
   await logout(page);
 
@@ -396,7 +406,7 @@ test.skip('expense documents preview with edit_expense', async ({ page }) => {
     .getByRole('link', { name: 'Recurring Expenses', exact: true })
     .click();
 
-  await page.waitForURL('**/expenses');
+  await page.waitForURL('**/recurring_expenses');
 
   const tableRow = tableBody.getByRole('row').first();
 
@@ -430,12 +440,14 @@ test.skip('expense documents preview with edit_expense', async ({ page }) => {
   await expect(page.getByText('Drop files or click to upload')).toBeVisible();
 });
 
-test.skip('expense documents uploading with edit_expense', async ({ page }) => {
+test('recurring expense documents uploading with edit_recurring_expense', async ({
+  page,
+}) => {
   const { clear, save, set } = permissions(page);
 
   await login(page);
   await clear('expenses@example.com');
-  await set('create_expense', 'edit_expense');
+  await set('create_recurring_expense', 'edit_recurring_expense');
   await save();
   await logout(page);
 
@@ -447,7 +459,7 @@ test.skip('expense documents uploading with edit_expense', async ({ page }) => {
     .getByRole('link', { name: 'Recurring Expenses', exact: true })
     .click();
 
-  await page.waitForURL('**/expenses');
+  await page.waitForURL('**/recurring_expenses');
 
   const tableRow = tableBody.getByRole('row').first();
 
@@ -489,7 +501,7 @@ test.skip('expense documents uploading with edit_expense', async ({ page }) => {
   ).toBeVisible();
 });
 
-test.skip('all actions in dropdown displayed with admin permission', async ({
+test('all actions in dropdown displayed with admin permission', async ({
   page,
 }) => {
   const { clear, save, set } = permissions(page);
@@ -515,7 +527,7 @@ test.skip('all actions in dropdown displayed with admin permission', async ({
   await logout(page);
 });
 
-test.skip('all clone actions displayed with creation permissions', async ({
+test('all clone actions displayed with creation permissions', async ({
   page,
 }) => {
   const { clear, save, set } = permissions(page);
@@ -541,12 +553,12 @@ test.skip('all clone actions displayed with creation permissions', async ({
   await logout(page);
 });
 
-test.skip('cloning expense', async ({ page }) => {
+test('cloning recurring expense', async ({ page }) => {
   const { clear, save, set } = permissions(page);
 
   await login(page);
   await clear('expenses@example.com');
-  await set('create_expense', 'edit_expense');
+  await set('create_recurring_expense', 'edit_recurring_expense');
   await save();
   await logout(page);
 
@@ -557,7 +569,7 @@ test.skip('cloning expense', async ({ page }) => {
     .getByRole('link', { name: 'Recurring Expenses', exact: true })
     .click();
 
-  await page.waitForURL('**/expenses');
+  await page.waitForURL('**/recurring_expenses');
 
   const tableBody = page.locator('tbody').first();
 
@@ -590,11 +602,13 @@ test.skip('cloning expense', async ({ page }) => {
 
   await page.getByRole('button', { name: 'Save' }).click();
 
-  await expect(page.getByText('Successfully created expense')).toBeVisible();
+  await expect(
+    page.getByText('Successfully created recurring expense')
+  ).toBeVisible();
 
   await page.waitForURL('**/recurring_expenses/**/edit');
 
   await expect(
-    page.getByRole('heading', { name: 'Edit Expense' }).first()
+    page.getByRole('heading', { name: 'Edit Recurring Expense' }).first()
   ).toBeVisible();
 });


### PR DESCRIPTION
@beganovich @turbo124 The PR includes permission adjustments for Recurring Expenses and Transactions. Once we merge the last two open PRs for permissions, the adjustments will be applied throughout the entire app, along with corresponding tests.

Important note: Currently, two transaction tests fail because we experienced an issue with the transaction archive/delete functionality. Once we address this issue in the API, those two tests should pass.

Let me know your thoughts.