### PR TITLE
[Cleanup] Product Split Button && Additional Test Adjustment

### DIFF
--- a/src/pages/products/Product.tsx
+++ b/src/pages/products/Product.tsx
@@ -21,7 +21,7 @@ import { Container } from '$app/components/Container';
 import { Default } from '$app/components/layouts/Default';
 import { ResourceActions } from '$app/components/ResourceActions';
 import { Tabs } from '$app/components/Tabs';
-import { FormEvent, useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Outlet, useParams, useSearchParams } from 'react-router-dom';
 import { useActions } from './common/hooks';
@@ -63,9 +63,7 @@ export default function Product() {
 
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const handleSave = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-
+  const handleSave = async () => {
     if (!isFormBusy) {
       setErrors(undefined);
       setIsFormBusy(true);
@@ -105,10 +103,9 @@ export default function Product() {
       {...(productData &&
         (hasPermission('edit_product') ||
           entityAssigned(productData.data.data)) && {
-          onSaveClick: handleSave,
           navigationTopRight: (
             <ResourceActions
-              label={t('more_actions')}
+              onSaveClick={handleSave}
               resource={productData.data.data}
               actions={actions}
               cypressRef="productActionDropdown"

--- a/tests/e2e/product.spec.ts
+++ b/tests/e2e/product.spec.ts
@@ -108,11 +108,7 @@ const checkEditPage = async (
         .getByRole('button', { name: 'Save', exact: true })
     ).toBeVisible();
 
-    await expect(
-      page
-        .locator('[data-cy="topNavbar"]')
-        .getByRole('button', { name: 'More Actions', exact: true })
-    ).toBeVisible();
+    await expect(page.locator('[data-cy="chevronDownButton"]')).toBeVisible();
 
     await expect(
       page
@@ -127,9 +123,7 @@ const checkEditPage = async (
     ).not.toBeVisible();
 
     await expect(
-      page
-        .locator('[data-cy="topNavbar"]')
-        .getByRole('button', { name: 'More Actions', exact: true })
+      page.locator('[data-cy="chevronDownButton"]')
     ).not.toBeVisible();
   }
 
@@ -242,7 +236,9 @@ test('can edit product', async ({ page }) => {
     page.getByText('Successfully updated product', { exact: true })
   ).toBeVisible();
 
-  await checkDropdownActions(page, actions, 'productActionDropdown');
+  await page.locator('[data-cy="chevronDownButton"]').first().click();
+
+  await checkDropdownActions(page, actions, 'productActionDropdown', '', true);
 
   await logout(page);
 });
@@ -279,7 +275,9 @@ test('can create a product', async ({ page }) => {
     page.getByText('Successfully updated product', { exact: true })
   ).toBeVisible();
 
-  await checkDropdownActions(page, actions, 'productActionDropdown');
+  await page.locator('[data-cy="chevronDownButton"]').first().click();
+
+  await checkDropdownActions(page, actions, 'productActionDropdown', '', true);
 
   await logout(page);
 });
@@ -520,7 +518,9 @@ test('all actions in dropdown displayed with admin permission', async ({
 
   await checkEditPage(page, true, true);
 
-  await checkDropdownActions(page, actions, 'productActionDropdown');
+  await page.locator('[data-cy="chevronDownButton"]').first().click();
+
+  await checkDropdownActions(page, actions, 'productActionDropdown', '', true);
 
   await logout(page);
 });
@@ -550,7 +550,9 @@ test('New Invoice, New Purchase Order, and Clone displayed with creation permiss
 
   await checkEditPage(page, true, false);
 
-  await checkDropdownActions(page, actions, 'productActionDropdown');
+  await page.locator('[data-cy="chevronDownButton"]').first().click();
+
+  await checkDropdownActions(page, actions, 'productActionDropdown', '', true);
 
   await logout(page);
 });


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of a split button for the Product entity and additional adjustments to the tests. Screenshot:

![Screenshot 2024-01-22 at 20 33 21](https://github.com/invoiceninja/ui/assets/51542191/dfacd93d-bf69-433c-9528-4a1b51dd9d2b)

Let me know your thoughts.