### PR TITLE
[Bugfix] Task Creation Page Is Not Displayed Correctly In Edge Case

### DIFF
--- a/src/pages/tasks/create/Create.tsx
+++ b/src/pages/tasks/create/Create.tsx
@@ -66,8 +66,7 @@ export default function Create() {
       if (
         typeof data !== 'undefined' &&
         typeof value === 'undefined' &&
-        searchParams.get('action') !== 'clone' &&
-        taskStatuses
+        searchParams.get('action') !== 'clone'
       ) {
         const _task = cloneDeep(data);
 


### PR DESCRIPTION
@beganovich @turbo124 I noticed that task tests randomly fail because they do not contain anything on the Task creation page. This inconsistency occurs—sometimes all of them pass, but sometimes one or two of them does not. Upon investigation, I found that there was an unnecessary check for `taskStatuses` that caused this behavior. Once it occurs in one out of 1000 attempts, the page looks like this (without content):

![Screenshot 2024-01-24 at 00 11 15](https://github.com/invoiceninja/ui/assets/51542191/f07d9cff-f7a9-4a07-817f-c829cf097178)

Let me know your thoughts.