### PR TITLE
[Bugfix] Recurring Invoices Caching Conflict

### DIFF
--- a/src/pages/recurring-invoices/common/components/RecurringInvoiceSlider.tsx
+++ b/src/pages/recurring-invoices/common/components/RecurringInvoiceSlider.tsx
@@ -109,7 +109,7 @@ export const RecurringInvoiceSlider = () => {
   const { dateFormat } = useCurrentCompanyDateFormats();
 
   const { data: resource } = useQuery({
-    queryKey: ['/api/v1/recurring_invoices', recurringInvoice?.id],
+    queryKey: ['/api/v1/recurring_invoices', recurringInvoice?.id, 'slider'],
     queryFn: () =>
       request(
         'GET',


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for RI caching conflicts. The slider endpoint has different parameters but the same caching query key, which caused a bug that prevented the correct data from being displayed for the slider. Let me know your thoughts.