### PR TITLE
[Feature] Warning Tooltip | Client Contact is_locked

### DIFF
--- a/src/pages/clients/common/components/UserUnsubscribedTooltip.tsx
+++ b/src/pages/clients/common/components/UserUnsubscribedTooltip.tsx
@@ -1,0 +1,48 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { Tooltip } from '$app/components/Tooltip';
+import { Link } from '$app/components/forms';
+import { useTranslation } from 'react-i18next';
+import { MdWarning } from 'react-icons/md';
+import reactStringReplace from 'react-string-replace';
+
+interface Props {
+  size?: number;
+}
+export function UserUnsubscribedTooltip(props?: Props) {
+  const [t] = useTranslation();
+
+  const { size = 22 } = props || {};
+
+  ('User unsubscribed from emails :link');
+
+  return (
+    <Tooltip
+      tooltipElement={reactStringReplace(
+        t('user_unsubscribed') as string,
+        ':link',
+        () => (
+          <Link
+            className="lowercase text-xs"
+            to="https://invoiceninja.github.io/en/hosted-mail/"
+            external
+          >
+            {t('link')}.
+          </Link>
+        )
+      )}
+      width="auto"
+      placement="top"
+    >
+      <MdWarning color="red" size={size} />
+    </Tooltip>
+  );
+}

--- a/src/pages/clients/edit/components/Contacts.tsx
+++ b/src/pages/clients/edit/components/Contacts.tsx
@@ -21,6 +21,7 @@ import { ChangeEvent, Dispatch, SetStateAction } from 'react';
 import { useTranslation } from 'react-i18next';
 import { v4 } from 'uuid';
 import { useColorScheme } from '$app/common/colors';
+import { UserUnsubscribedTooltip } from '../../common/components/UserUnsubscribedTooltip';
 
 interface Props {
   contacts: Partial<ClientContact>[];
@@ -233,9 +234,17 @@ export function Contacts(props: Props) {
             />
           )}
 
-          <Element>
+          <Element
+            {...(!contact.is_locked && {
+              leftSide: (
+                <div className="flex">
+                  <UserUnsubscribedTooltip size={25} />
+                </div>
+              ),
+            })}
+          >
             <div className="flex items-center">
-              <div className="w-1/2">
+              <div className="flex items-center justify-between w-1/2">
                 {props.contacts.length >= 2 && (
                   <button
                     type="button"

--- a/src/pages/clients/show/components/Contacts.tsx
+++ b/src/pages/clients/show/components/Contacts.tsx
@@ -14,6 +14,7 @@ import { ClientContact } from '$app/common/interfaces/client-contact';
 import { InfoCard } from '$app/components/InfoCard';
 import { useTranslation } from 'react-i18next';
 import { CopyToClipboard } from '$app/components/CopyToClipboard';
+import { UserUnsubscribedTooltip } from '../../common/components/UserUnsubscribedTooltip';
 
 interface Props {
   client: Client;
@@ -36,17 +37,24 @@ export function Contacts(props: Props) {
               <div className="space-y-2">
                 {client.contacts.map(
                   (contact: ClientContact, index: number) => (
-                    <div key={index}>
-                      <p
-                        className="font-semibold"
-                        style={{ color: accentColor }}
-                      >
-                        {contact.first_name} {contact.last_name}
-                      </p>
+                    <div
+                      key={index}
+                      className="flex justify-between items-center"
+                    >
+                      <div>
+                        <p
+                          className="font-semibold"
+                          style={{ color: accentColor }}
+                        >
+                          {contact.first_name} {contact.last_name}
+                        </p>
 
-                      <p>{contact.phone}</p>
+                        <p>{contact.phone}</p>
 
-                      <CopyToClipboard text={contact.email} />
+                        <CopyToClipboard text={contact.email} />
+                      </div>
+
+                      {contact.is_locked && <UserUnsubscribedTooltip />}
                     </div>
                   )
                 )}

--- a/src/pages/invoices/common/components/ClientSelector.tsx
+++ b/src/pages/invoices/common/components/ClientSelector.tsx
@@ -20,6 +20,7 @@ import { route } from '$app/common/helpers/route';
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 import { CopyToClipboardIconOnly } from '$app/components/CopyToClipBoardIconOnly';
 import { useColorScheme } from '$app/common/colors';
+import { UserUnsubscribedTooltip } from '$app/pages/clients/common/components/UserUnsubscribedTooltip';
 
 interface Props {
   readonly?: boolean;
@@ -103,45 +104,49 @@ export function ClientSelector(props: Props) {
       {resource?.client_id &&
         client &&
         client.contacts.map((contact, index) => (
-          <div key={index}>
-            <Checkbox
-              id={contact.id}
-              value={contact.id}
-              label={
-                contact.first_name.length >= 1
-                  ? `${contact.first_name} ${contact.last_name}`
-                  : contact.email || client.display_name
-              }
-              checked={handleCheckedState(contact.id)}
-              onChange={(event: ChangeEvent<HTMLInputElement>) =>
-                props.onContactCheckboxChange(
-                  event.target.value,
-                  event.target.checked
-                )
-              }
-            />
-
+          <div key={index} className="flex justify-between items-center">
             <div>
-              {contact.first_name && (
-                <p className="text-sm" style={{ color: colors.$3 }}>
-                  {contact.email}
-                </p>
-              )}
+              <Checkbox
+                id={contact.id}
+                value={contact.id}
+                label={
+                  contact.first_name.length >= 1
+                    ? `${contact.first_name} ${contact.last_name}`
+                    : contact.email || client.display_name
+                }
+                checked={handleCheckedState(contact.id)}
+                onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                  props.onContactCheckboxChange(
+                    event.target.value,
+                    event.target.checked
+                  )
+                }
+              />
 
-              {resource.invitations.length >= 1 && (
-                <>
-                  <Link
-                    to={`${resource.invitations[0].link}?silent=true&client_hash=${client.client_hash}`}
-                    external
-                  >
-                    {t('view_in_portal')}
-                  </Link>
-                  <CopyToClipboardIconOnly
-                    text={resource.invitations[0].link}
-                  />
-                </>
-              )}
+              <div>
+                {contact.first_name && (
+                  <p className="text-sm" style={{ color: colors.$3 }}>
+                    {contact.email}
+                  </p>
+                )}
+
+                {resource.invitations.length >= 1 && (
+                  <>
+                    <Link
+                      to={`${resource.invitations[0].link}?silent=true&client_hash=${client.client_hash}`}
+                      external
+                    >
+                      {t('view_in_portal')}
+                    </Link>
+                    <CopyToClipboardIconOnly
+                      text={resource.invitations[0].link}
+                    />
+                  </>
+                )}
+              </div>
             </div>
+
+            {contact.is_locked && <UserUnsubscribedTooltip size={24} />}
           </div>
         ))}
     </>


### PR DESCRIPTION
@beganovich @turbo124 The PR implements the tooltip for the client contacts when the `is_locked` property is set to true. The tooltip will be displayed in three different places:

- Show Client Page
- Edit Client Page
- All pages where we have a client selector (contacts displayed for the selected client on edit pages of entities).

Screenshots:

![Screenshot 2024-01-31 at 00 21 15](https://github.com/invoiceninja/ui/assets/51542191/c28280e3-6b5b-412c-b2ba-2d46a3bd5a77)

![Screenshot 2024-01-31 at 00 39 55](https://github.com/invoiceninja/ui/assets/51542191/fdf05c46-6768-417b-a7f0-77cfc8ab5852)

![Screenshot 2024-01-31 at 00 42 38](https://github.com/invoiceninja/ui/assets/51542191/53ef0060-2af6-4e16-9f96-38939cc5e953)

`The important note:` The recommended translation keyword in the ticket ("unsubscribed") is already in the translation files, but it is only translated to the word "Unsubscribed," not in the entire sentence ("User unsubscribed from emails :link"). Therefore, I used `user_unsubscribed` instead, with the ":link" variable at the end. So, I envisioned it to be translated like this: "User unsubscribed from emails :link," and instead of the "link" variable, we will have a link to the documentation.

Let me know your thoughts.