### PR TITLE
[Cleanup] Plain "Search" Word Replaced With search Translation Keyword

### DIFF
--- a/src/pages/dashboard/components/Search.tsx
+++ b/src/pages/dashboard/components/Search.tsx
@@ -126,7 +126,7 @@ export function Search$() {
           onChange={(event) => setQuery(event.target.value)}
           ref={inputRef}
           onFocus={() => setIsVisible(true)}
-          placeholder="Search..."
+          placeholder={`${t('search')}...`}
           style={{ backgroundColor: colors.$1, color: colors.$3 }}
         />
 


### PR DESCRIPTION
@beganovich @turbo124 The search functionality in the navbar had a plain "Search" word instead of the "search" translation keyword. So, now it has been replaced. Let me know your thoughts.