### PR TITLE
[Bugfix] Breadcrump URL On Quote Import Page

### DIFF
--- a/src/pages/quotes/import/Import.tsx
+++ b/src/pages/quotes/import/Import.tsx
@@ -19,7 +19,7 @@ export default function Import() {
   const { documentTitle } = useTitle('import');
 
   const pages: Page[] = [
-    { name: t('quotes'), href: '/quote' },
+    { name: t('quotes'), href: '/quotes' },
     { name: t('import'), href: '/quotes/import' },
   ];
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes on the Breadcrumb URL to the Quotes table page. Let me know your thoughts.