### PR TITLE
[Feature] Customer Stripe URL

### DIFF
--- a/src/pages/clients/show/components/Gateways.tsx
+++ b/src/pages/clients/show/components/Gateways.tsx
@@ -78,12 +78,11 @@ export function Gateways(props: Props) {
                 <div>
                   <MdPayment fontSize={22} />
                 </div>
-                <div className="flex items-center">
+                <div className="inline-flex items-center">
                   <span>{t('gateway')}</span>
                   <MdChevronRight size={20} />
                   <span>
-                    {getCompanyGatewayLabel(token.company_gateway_id) ||
-                      'Stripe'}
+                    {getCompanyGatewayLabel(token.company_gateway_id)}
                   </span>
                   {showCustomerStripeLink(token.company_gateway_id) && (
                     <Link

--- a/src/pages/clients/show/components/Gateways.tsx
+++ b/src/pages/clients/show/components/Gateways.tsx
@@ -11,13 +11,14 @@
 import { Client } from '$app/common/interfaces/client';
 import { InfoCard } from '$app/components/InfoCard';
 import { useTranslation } from 'react-i18next';
-import { MdChevronRight, MdLaunch, MdPayment } from 'react-icons/md';
+import { MdChevronRight, MdLaunch, MdPayment, MdPerson2 } from 'react-icons/md';
 import { route } from '$app/common/helpers/route';
 import { GatewayTypeIcon } from './GatewayTypeIcon';
 import { useCompanyGatewaysQuery } from '$app/common/queries/company-gateways';
 import { useEffect, useState } from 'react';
 import { CompanyGateway } from '$app/common/interfaces/company-gateway';
 import { Link } from '$app/components/forms';
+import { Icon } from '$app/components/icons/Icon';
 
 interface Props {
   client: Client;
@@ -43,6 +44,21 @@ export function Gateways(props: Props) {
     );
   };
 
+  const showCustomerStripeLink = (companyGatewayId: string) => {
+    const companyGateway = companyGateways?.find(
+      ({ id }) => id === companyGatewayId
+    );
+
+    if (companyGateway) {
+      return Boolean(
+        companyGateway.gateway_key === 'd14dd26a37cecc30fdd65700bfb55b23' ||
+          companyGateway.gateway_key === 'd14dd26a47cecc30fdd65700bfb67b34'
+      );
+    }
+
+    return false;
+  };
+
   useEffect(() => {
     if (companyGatewaysResponse) {
       setCompanyGateways(companyGatewaysResponse.data.data);
@@ -57,7 +73,7 @@ export function Gateways(props: Props) {
             key={token.id}
             className="flex items-center justify-between my-2.5"
           >
-            <div>
+            <div className="flex flex-col space-y-1.5">
               <div className="inline-flex items-center space-x-1">
                 <div>
                   <MdPayment fontSize={22} />
@@ -85,14 +101,28 @@ export function Gateways(props: Props) {
               </div>
             </div>
 
-            <div>
+            <div className="flex flex-col justify-between">
               <Link
                 to={route('/settings/gateways/:id/edit', {
                   id: token.company_gateway_id,
                 })}
               >
-                <MdLaunch size={18} />
+                <Icon element={MdLaunch} size={18} />
               </Link>
+
+              {showCustomerStripeLink(token.company_gateway_id) && (
+                <Link
+                  external
+                  to={route(
+                    'https://dashboard.stripe.com/customers/:customerReference',
+                    {
+                      customerReference: token.gateway_customer_reference,
+                    }
+                  )}
+                >
+                  <Icon element={MdPerson2} size={20} />
+                </Link>
+              )}
             </div>
           </div>
         ))}

--- a/src/pages/clients/show/components/Gateways.tsx
+++ b/src/pages/clients/show/components/Gateways.tsx
@@ -71,7 +71,6 @@ export function Gateways(props: Props) {
                     getCompanyGateway(token.company_gateway_id)?.gateway_key
                   ) ? (
                     <Link
-                      className="ml-1"
                       external
                       to={route(
                         'https://dashboard.stripe.com/customers/:customerReference',

--- a/src/pages/clients/show/components/Gateways.tsx
+++ b/src/pages/clients/show/components/Gateways.tsx
@@ -67,25 +67,13 @@ export function Gateways(props: Props) {
                   <span>{t('gateway')}</span>
                   <MdChevronRight size={20} />
 
-                  {isStripeGateway(
-                    getCompanyGateway(token.company_gateway_id)?.gateway_key
-                  ) ? (
-                    <Link
-                      external
-                      to={route(
-                        'https://dashboard.stripe.com/customers/:customerReference',
-                        {
-                          customerReference: token.gateway_customer_reference,
-                        }
-                      )}
-                    >
-                      {getCompanyGateway(token.company_gateway_id)?.label}
-                    </Link>
-                  ) : (
-                    <span>
-                      {getCompanyGateway(token.company_gateway_id)?.label}
-                    </span>
-                  )}
+                  <Link
+                    to={route('/settings/gateways/:id/edit', {
+                      id: token.company_gateway_id,
+                    })}
+                  >
+                    {getCompanyGateway(token.company_gateway_id)?.label}
+                  </Link>
                 </div>
               </div>
 
@@ -103,15 +91,21 @@ export function Gateways(props: Props) {
               </div>
             </div>
 
-            <div>
+            {isStripeGateway(
+              getCompanyGateway(token.company_gateway_id)?.gateway_key
+            ) && (
               <Link
-                to={route('/settings/gateways/:id/edit', {
-                  id: token.company_gateway_id,
-                })}
+                external
+                to={route(
+                  'https://dashboard.stripe.com/customers/:customerReference',
+                  {
+                    customerReference: token.gateway_customer_reference,
+                  }
+                )}
               >
                 <Icon element={MdLaunch} size={18} />
               </Link>
-            </div>
+            )}
           </div>
         ))}
       </InfoCard>

--- a/src/pages/clients/show/components/Gateways.tsx
+++ b/src/pages/clients/show/components/Gateways.tsx
@@ -11,7 +11,7 @@
 import { Client } from '$app/common/interfaces/client';
 import { InfoCard } from '$app/components/InfoCard';
 import { useTranslation } from 'react-i18next';
-import { MdChevronRight, MdLaunch, MdPayment, MdPerson2 } from 'react-icons/md';
+import { MdChevronRight, MdLaunch, MdPayment } from 'react-icons/md';
 import { route } from '$app/common/helpers/route';
 import { GatewayTypeIcon } from './GatewayTypeIcon';
 import { useCompanyGatewaysQuery } from '$app/common/queries/company-gateways';
@@ -78,12 +78,27 @@ export function Gateways(props: Props) {
                 <div>
                   <MdPayment fontSize={22} />
                 </div>
-                <div className="inline-flex items-center">
-                  <span> {t('gateway')}</span>
+                <div className="flex items-center">
+                  <span>{t('gateway')}</span>
                   <MdChevronRight size={20} />
                   <span>
-                    {getCompanyGatewayLabel(token.company_gateway_id)}
+                    {getCompanyGatewayLabel(token.company_gateway_id) ||
+                      'Stripe'}
                   </span>
+                  {showCustomerStripeLink(token.company_gateway_id) && (
+                    <Link
+                      className="ml-1"
+                      external
+                      to={route(
+                        'https://dashboard.stripe.com/customers/:customerReference',
+                        {
+                          customerReference: token.gateway_customer_reference,
+                        }
+                      )}
+                    >
+                      <Icon element={MdLaunch} size={18} />
+                    </Link>
+                  )}
                 </div>
               </div>
 
@@ -101,7 +116,7 @@ export function Gateways(props: Props) {
               </div>
             </div>
 
-            <div className="flex flex-col justify-between">
+            <div>
               <Link
                 to={route('/settings/gateways/:id/edit', {
                   id: token.company_gateway_id,
@@ -109,20 +124,6 @@ export function Gateways(props: Props) {
               >
                 <Icon element={MdLaunch} size={18} />
               </Link>
-
-              {showCustomerStripeLink(token.company_gateway_id) && (
-                <Link
-                  external
-                  to={route(
-                    'https://dashboard.stripe.com/customers/:customerReference',
-                    {
-                      customerReference: token.gateway_customer_reference,
-                    }
-                  )}
-                >
-                  <Icon element={MdPerson2} size={20} />
-                </Link>
-              )}
             </div>
           </div>
         ))}

--- a/src/pages/clients/show/components/Gateways.tsx
+++ b/src/pages/clients/show/components/Gateways.tsx
@@ -32,31 +32,16 @@ export function Gateways(props: Props) {
 
   const [companyGateways, setCompanyGateways] = useState<CompanyGateway[]>();
 
-  const getCompanyGatewayLabel = (gatewayId: string) => {
-    const filteredGateways = companyGateways?.filter(
-      ({ id }) => id === gatewayId
-    );
-
-    return (
-      filteredGateways &&
-      filteredGateways.length >= 1 &&
-      filteredGateways[0].label
-    );
+  const getCompanyGateway = (gatewayId: string) => {
+    return companyGateways?.find(({ id }) => id === gatewayId);
   };
 
-  const showCustomerStripeLink = (companyGatewayId: string) => {
-    const companyGateway = companyGateways?.find(
-      ({ id }) => id === companyGatewayId
+  const isStripeGateway = (gatewayKey: string | undefined) => {
+    return Boolean(
+      gatewayKey &&
+        (gatewayKey === 'd14dd26a37cecc30fdd65700bfb55b23' ||
+          gatewayKey === 'd14dd26a47cecc30fdd65700bfb67b34')
     );
-
-    if (companyGateway) {
-      return Boolean(
-        companyGateway.gateway_key === 'd14dd26a37cecc30fdd65700bfb55b23' ||
-          companyGateway.gateway_key === 'd14dd26a47cecc30fdd65700bfb67b34'
-      );
-    }
-
-    return false;
   };
 
   useEffect(() => {
@@ -81,10 +66,10 @@ export function Gateways(props: Props) {
                 <div className="inline-flex items-center">
                   <span>{t('gateway')}</span>
                   <MdChevronRight size={20} />
-                  <span>
-                    {getCompanyGatewayLabel(token.company_gateway_id)}
-                  </span>
-                  {showCustomerStripeLink(token.company_gateway_id) && (
+
+                  {isStripeGateway(
+                    getCompanyGateway(token.company_gateway_id)?.gateway_key
+                  ) ? (
                     <Link
                       className="ml-1"
                       external
@@ -95,8 +80,12 @@ export function Gateways(props: Props) {
                         }
                       )}
                     >
-                      <Icon element={MdLaunch} size={18} />
+                      {getCompanyGateway(token.company_gateway_id)?.label}
                     </Link>
+                  ) : (
+                    <span>
+                      {getCompanyGateway(token.company_gateway_id)?.label}
+                    </span>
                   )}
                 </div>
               </div>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes implementation of a link to the customer Stripe page. So, the gateway token contains a `company_gateway_id`. I used that ID to find the `company_gateway` object from the pulled list from the API. After that, we have a `gateway_key` prop in `company_gateway`, and instead of searching for "cus_" in the `gateway_customer_reference` property, I will compare the `gateway_key` with the Stripe keys that David provided in the ticket. If it matches, then the icon/link to the customer Stripe page will be shown. I think this is the most secure and cleaner way. Screenshot:

<img width="360" alt="Screenshot 2024-02-01 at 18 26 08" src="https://github.com/invoiceninja/ui/assets/51542191/b6fd4de5-f0ae-4999-9b99-5a035cedb1c4">

Let me know your thoughts.