### PR TITLE
[Cleanup] Vendor Split Button Implementation && Tests Adjustment

### DIFF
--- a/src/pages/vendors/Vendor.tsx
+++ b/src/pages/vendors/Vendor.tsx
@@ -8,7 +8,7 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
-import { Button, Link } from '$app/components/forms';
+import { Link } from '$app/components/forms';
 import { route } from '$app/common/helpers/route';
 import { useAccentColor } from '$app/common/hooks/useAccentColor';
 import { useCountries } from '$app/common/hooks/useCountries';
@@ -20,10 +20,9 @@ import { Default } from '$app/components/layouts/Default';
 import { Tabs } from '$app/components/Tabs';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Outlet, useParams } from 'react-router-dom';
+import { Outlet, useNavigate, useParams } from 'react-router-dom';
 import { ResourceActions } from '$app/components/ResourceActions';
 import { useActions } from './common/hooks/useActions';
-import { Inline } from '$app/components/Inline';
 import { useTabs } from './show/hooks/useTabs';
 import { useCurrentCompanyDateFormats } from '$app/common/hooks/useCurrentCompanyDateFormats';
 import { date } from '$app/common/helpers';
@@ -43,6 +42,7 @@ export default function Vendor() {
   const actions = useActions();
 
   const [t] = useTranslation();
+  const navigate = useNavigate();
 
   const hasPermission = useHasPermission();
   const entityAssigned = useEntityAssigned();
@@ -73,17 +73,12 @@ export default function Vendor() {
       {...((hasPermission('edit_vendor') || entityAssigned(vendor)) &&
         vendor && {
           navigationTopRight: (
-            <Inline>
-              <Button to={route('/vendors/:id/edit', { id })}>
-                {t('edit_vendor')}
-              </Button>
-
-              <ResourceActions
-                label={t('more_actions')}
-                resource={vendor}
-                actions={actions}
-              />
-            </Inline>
+            <ResourceActions
+              saveButtonLabel={t('edit_vendor')}
+              onSaveClick={() => navigate(route('/vendors/:id/edit', { id }))}
+              resource={vendor}
+              actions={actions}
+            />
           ),
         })}
     >

--- a/src/pages/vendors/edit/Edit.tsx
+++ b/src/pages/vendors/edit/Edit.tsx
@@ -85,11 +85,10 @@ export default function Edit() {
     <Default
       title={documentTitle}
       breadcrumbs={pages}
-      onSaveClick={onSave}
       navigationTopRight={
         vendor && (
           <ResourceActions
-            label={t('more_actions')}
+            onSaveClick={onSave}
             resource={vendor}
             actions={actions}
           />

--- a/tests/e2e/vendors.spec.ts
+++ b/tests/e2e/vendors.spec.ts
@@ -85,13 +85,21 @@ const checkShowPage = async (page: Page, isEditable: boolean) => {
     await expect(
       page
         .locator('[data-cy="topNavbar"]')
-        .getByRole('link', { name: 'Edit Vendor', exact: true })
+        .getByRole('button', { name: 'Edit Vendor', exact: true })
+    ).not.toBeVisible();
+
+    await expect(
+      page.locator('[data-cy="chevronDownButton"]').first()
     ).not.toBeVisible();
   } else {
     await expect(
       page
         .locator('[data-cy="topNavbar"]')
-        .getByRole('link', { name: 'Edit Vendor', exact: true })
+        .getByRole('button', { name: 'Edit Vendor', exact: true })
+    ).toBeVisible();
+
+    await expect(
+      page.locator('[data-cy="chevronDownButton"]').first()
     ).toBeVisible();
   }
 };
@@ -106,9 +114,7 @@ const checkEditPage = async (page: Page) => {
   ).toBeVisible();
 
   await expect(
-    page
-      .locator('[data-cy="topNavbar"]')
-      .getByRole('button', { name: 'More Actions', exact: true })
+    page.locator('[data-cy="chevronDownButton"]').first()
   ).toBeVisible();
 
   await expect(
@@ -202,7 +208,7 @@ test('can edit vendor', async ({ page }) => {
 
   await page
     .locator('[data-cy="topNavbar"]')
-    .getByRole('link', { name: 'Edit Vendor', exact: true })
+    .getByRole('button', { name: 'Edit Vendor', exact: true })
     .click();
 
   await checkEditPage(page);
@@ -252,7 +258,7 @@ test('can create a vendor', async ({ page }) => {
 
   await page
     .locator('[data-cy="topNavbar"]')
-    .getByRole('link', { name: 'Edit Vendor', exact: true })
+    .getByRole('button', { name: 'Edit Vendor', exact: true })
     .click();
 
   await checkEditPage(page);
@@ -303,7 +309,7 @@ test('can view and edit assigned vendor with create_vendor', async ({
 
   await page
     .locator('[data-cy="topNavbar"]')
-    .getByRole('link', { name: 'Edit Vendor', exact: true })
+    .getByRole('button', { name: 'Edit Vendor', exact: true })
     .click();
 
   await checkEditPage(page);
@@ -356,11 +362,11 @@ test('deleting vendor with edit_vendor', async ({ page }) => {
       page.getByRole('button', { name: 'Restore', exact: true })
     ).toBeVisible();
   } else {
-    const moreActionsButton = tableRow
+    await tableRow
       .getByRole('button')
-      .filter({ has: page.getByText('More Actions') });
-
-    await moreActionsButton.click();
+      .filter({ has: page.getByText('More Actions') })
+      .first()
+      .click();
 
     await page.getByText('Delete').click();
 
@@ -404,12 +410,11 @@ test('archiving vendor withe edit_vendor', async ({ page }) => {
       page.getByRole('button', { name: 'Restore', exact: true })
     ).toBeVisible();
   } else {
-    const moreActionsButton = tableRow
+    await tableRow
       .getByRole('button')
       .filter({ has: page.getByText('More Actions') })
-      .first();
-
-    await moreActionsButton.click();
+      .first()
+      .click();
 
     await page.getByText('Archive').click();
 
@@ -487,13 +492,11 @@ test('vendor documents uploading with edit_vendor', async ({ page }) => {
 
   if (!doRecordsExist) {
     await createVendor({ page });
-
-    await checkShowPage(page, true);
   } else {
     await tableRow.getByRole('link').first().click();
-
-    await checkShowPage(page, false);
   }
+
+  await checkShowPage(page, true);
 
   await page
     .getByRole('link', {


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of split buttons for showing and editing the Vendor page. Screenshots:

![Screenshot 2024-02-02 at 16 14 04](https://github.com/invoiceninja/ui/assets/51542191/cb8d6bbd-7e59-4bf9-a33e-cc3fa4d55f2e)

![Screenshot 2024-02-02 at 16 17 13](https://github.com/invoiceninja/ui/assets/51542191/081816e4-42ff-43bd-a356-3820eb65c68f)

Let me know your thoughts.