### PR TITLE
[Feature] Custom Designs Preview Action + Bulk Actions On Edit Page && Additional Tests

### DIFF
--- a/src/common/queries/invoice-design.ts
+++ b/src/common/queries/invoice-design.ts
@@ -1,0 +1,38 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { useAtomValue } from 'jotai';
+import { useQueryClient } from 'react-query';
+import { invalidationQueryAtom } from '../atoms/data-table';
+import { toast } from '../helpers/toast/toast';
+import { request } from '../helpers/request';
+import { endpoint } from '../helpers';
+import { $refetch } from '../hooks/useRefetch';
+
+export function useBulkAction() {
+  const queryClient = useQueryClient();
+  const invalidateQueryValue = useAtomValue(invalidationQueryAtom);
+
+  return async (ids: string[], action: 'archive' | 'restore' | 'delete') => {
+    toast.processing();
+
+    return request('POST', endpoint('/api/v1/designs/bulk'), {
+      action,
+      ids,
+    }).then(() => {
+      toast.success(`${action}d_design`);
+
+      $refetch(['designs']);
+
+      invalidateQueryValue &&
+        queryClient.invalidateQueries([invalidateQueryValue]);
+    });
+  };
+}

--- a/src/components/layouts/Default.tsx
+++ b/src/components/layouts/Default.tsx
@@ -46,7 +46,10 @@ import { useCurrentCompanyUser } from '$app/common/hooks/useCurrentCompanyUser';
 import { useEnabled } from '$app/common/guards/guards/enabled';
 import { Dropdown } from '$app/components/dropdown/Dropdown';
 import { DropdownElement } from '$app/components/dropdown/DropdownElement';
-import { useSaveBtn } from '$app/components/layouts/common/hooks';
+import {
+  useNavigationTopRightElement,
+  useSaveBtn,
+} from '$app/components/layouts/common/hooks';
 import { VerifyEmail } from '../banners/VerifyEmail';
 import { ActivateCompany } from '../banners/ActivateCompany';
 import { VerifyPhone } from '../banners/VerifyPhone';
@@ -361,6 +364,7 @@ export function Default(props: Props) {
 
   const { isOwner } = useAdmin();
   const saveBtn = useSaveBtn();
+  const navigationTopRightElement = useNavigationTopRightElement();
   const colors = useColorScheme();
 
   return (
@@ -499,9 +503,10 @@ export function Default(props: Props) {
                 </div>
               )}
 
-              {props.navigationTopRight && (
+              {(navigationTopRightElement || props.navigationTopRight) && (
                 <div className="space-x-3 items-center hidden lg:flex">
-                  {props.navigationTopRight}
+                  {navigationTopRightElement?.element ||
+                    props.navigationTopRight}
                 </div>
               )}
             </div>

--- a/src/components/layouts/common/hooks.ts
+++ b/src/components/layouts/common/hooks.ts
@@ -11,7 +11,7 @@
 import { useAdmin } from '$app/common/hooks/permissions/useHasPermission';
 import { useCurrentSettingsLevel } from '$app/common/hooks/useCurrentSettingsLevel';
 import { atom, useAtom } from 'jotai';
-import { useEffect } from 'react';
+import { ReactNode, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 
@@ -207,4 +207,31 @@ export function useSaveBtn(options?: SaveButton, deps: unknown[] = []) {
   }, deps);
 
   return saveBtn;
+}
+
+interface NavigationTopRight {
+  element: ReactNode;
+}
+
+export const navigationTopRightAtom = atom<NavigationTopRight | null>(null);
+
+export function useNavigationTopRightElement(
+  options?: NavigationTopRight,
+  deps: unknown[] = []
+) {
+  const [navigationTopRightElement, setNavigationTopRightElement] = useAtom(
+    navigationTopRightAtom
+  );
+
+  useEffect(() => {
+    if (options) {
+      setNavigationTopRightElement(options);
+    }
+
+    return () => {
+      setNavigationTopRightElement(null);
+    };
+  }, deps);
+
+  return navigationTopRightElement;
 }

--- a/src/pages/invoices/common/components/InvoiceViewer.tsx
+++ b/src/pages/invoices/common/components/InvoiceViewer.tsx
@@ -25,14 +25,18 @@ interface Props {
   withToast?: boolean;
   height?: number;
   enabled?: boolean;
+  renderAsHTML?: boolean;
 }
 
 export const android = Boolean(navigator.userAgent.match(/Android/i));
 
 export function InvoiceViewer(props: Props) {
-  const iframeRef = useRef<HTMLIFrameElement>(null);
-  const linkRef = useRef<HTMLAnchorElement>(null);
   const queryClient = useQueryClient();
+
+  const { renderAsHTML } = props;
+
+  const linkRef = useRef<HTMLAnchorElement>(null);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
 
   const [isLoading, setIsLoading] = useState(false);
 
@@ -53,7 +57,7 @@ export function InvoiceViewer(props: Props) {
           })
             .then((response) => {
               const blob = new Blob([response.data], {
-                type: 'application/pdf',
+                type: renderAsHTML ? 'text/html' : 'application/pdf',
               });
               const url = URL.createObjectURL(blob);
 

--- a/src/pages/settings/invoice-design/common/hooks/useActions.tsx
+++ b/src/pages/settings/invoice-design/common/hooks/useActions.tsx
@@ -1,0 +1,59 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { EntityState } from '$app/common/enums/entity-state';
+import { getEntityState } from '$app/common/helpers';
+import { Design } from '$app/common/interfaces/design';
+import { useBulkAction } from '$app/common/queries/invoice-design';
+import { DropdownElement } from '$app/components/dropdown/DropdownElement';
+import { Icon } from '$app/components/icons/Icon';
+import { Action } from '$app/components/ResourceActions';
+import { useTranslation } from 'react-i18next';
+import { MdArchive, MdDelete, MdRestore } from 'react-icons/md';
+
+export function useActions() {
+  const [t] = useTranslation();
+
+  const bulk = useBulkAction();
+
+  const actions: Action<Design>[] = [
+    (invoiceDesign) =>
+      getEntityState(invoiceDesign) === EntityState.Active && (
+        <DropdownElement
+          onClick={() => bulk([invoiceDesign.id], 'archive')}
+          icon={<Icon element={MdArchive} />}
+        >
+          {t('archive')}
+        </DropdownElement>
+      ),
+    (invoiceDesign) =>
+      (getEntityState(invoiceDesign) === EntityState.Archived ||
+        getEntityState(invoiceDesign) === EntityState.Deleted) && (
+        <DropdownElement
+          onClick={() => bulk([invoiceDesign.id], 'restore')}
+          icon={<Icon element={MdRestore} />}
+        >
+          {t('restore')}
+        </DropdownElement>
+      ),
+    (invoiceDesign) =>
+      (getEntityState(invoiceDesign) === EntityState.Active ||
+        getEntityState(invoiceDesign) === EntityState.Archived) && (
+        <DropdownElement
+          onClick={() => bulk([invoiceDesign.id], 'delete')}
+          icon={<Icon element={MdDelete} />}
+        >
+          {t('delete')}
+        </DropdownElement>
+      ),
+  ];
+
+  return actions;
+}

--- a/src/pages/settings/invoice-design/pages/custom-designs/pages/edit/Edit.tsx
+++ b/src/pages/settings/invoice-design/pages/custom-designs/pages/edit/Edit.tsx
@@ -29,8 +29,6 @@ import { AxiosError } from 'axios';
 import { $refetch } from '$app/common/hooks/useRefetch';
 import { ResourceActions } from '$app/components/ResourceActions';
 import { useActions } from '$app/pages/settings/invoice-design/common/hooks/useActions';
-import Toggle from '$app/components/forms/Toggle';
-import { useTranslation } from 'react-i18next';
 
 export interface PreviewPayload {
   design: Design | null;
@@ -45,8 +43,6 @@ export const payloadAtom = atom<PreviewPayload>({
 });
 
 export default function Edit() {
-  const [t] = useTranslation();
-
   const actions = useActions();
 
   const { id } = useParams();
@@ -81,21 +77,12 @@ export default function Edit() {
   useNavigationTopRightElement(
     {
       element: payload?.design && (
-        <div className="flex space-x-3">
-          <Toggle
-            label={t('render_html')}
-            checked={shouldRenderHTML}
-            onChange={(value) => setShouldRenderHTML(value)}
-            disabled={isFormBusy}
-          />
-
-          <ResourceActions
-            resource={payload.design}
-            onSaveClick={handleSaveInvoiceDesign}
-            actions={actions}
-            disableSaveButton={isFormBusy}
-          />
-        </div>
+        <ResourceActions
+          resource={payload.design}
+          onSaveClick={handleSaveInvoiceDesign}
+          actions={actions}
+          disableSaveButton={isFormBusy}
+        />
       ),
     },
     [payload.design, isFormBusy]
@@ -117,7 +104,12 @@ export default function Edit() {
     <div className="flex flex-col lg:flex-row gap-4">
       <div className="w-full lg:w-1/2 overflow-y-auto">
         <div className="space-y-4 max-h-[80vh] pl-1 py-2 pr-2">
-          <Settings errors={errors} />
+          <Settings
+            errors={errors}
+            isFormBusy={isFormBusy}
+            shouldRenderHTML={shouldRenderHTML}
+            setShouldRenderHTML={setShouldRenderHTML}
+          />
           <Body />
           <Header />
           <Footer />

--- a/src/pages/settings/invoice-design/pages/custom-designs/pages/edit/Edit.tsx
+++ b/src/pages/settings/invoice-design/pages/custom-designs/pages/edit/Edit.tsx
@@ -89,14 +89,12 @@ export default function Edit() {
             disabled={isFormBusy}
           />
 
-          {payload.design && (
-            <ResourceActions
-              resource={payload.design}
-              onSaveClick={handleSaveInvoiceDesign}
-              actions={actions}
-              disableSaveButton={isFormBusy}
-            />
-          )}
+          <ResourceActions
+            resource={payload.design}
+            onSaveClick={handleSaveInvoiceDesign}
+            actions={actions}
+            disableSaveButton={isFormBusy}
+          />
         </div>
       ),
     },

--- a/src/pages/settings/invoice-design/pages/custom-designs/pages/edit/components/Settings.tsx
+++ b/src/pages/settings/invoice-design/pages/custom-designs/pages/edit/components/Settings.tsx
@@ -13,7 +13,7 @@ import { Card, ClickableElement, Element } from '$app/components/cards';
 import { DesignSelector } from '$app/common/generic/DesignSelector';
 import { InputField } from '$app/components/forms';
 import { Divider } from '$app/components/cards/Divider';
-import { useCallback } from 'react';
+import { Dispatch, SetStateAction, useCallback } from 'react';
 import { toast } from '$app/common/helpers/toast/toast';
 import { trans } from '$app/common/helpers';
 import { useAtom } from 'jotai';
@@ -21,9 +21,13 @@ import { payloadAtom } from '../Edit';
 import { Import, importModalVisiblityAtom } from './Import';
 import { useDesignUtilities } from '../common/hooks';
 import { ValidationBag } from '$app/common/interfaces/validation-bag';
+import Toggle from '$app/components/forms/Toggle';
 
 interface Props {
   errors: ValidationBag | undefined;
+  isFormBusy: boolean;
+  shouldRenderHTML: boolean;
+  setShouldRenderHTML: Dispatch<SetStateAction<boolean>>;
 }
 
 export function Settings(props: Props) {
@@ -115,6 +119,14 @@ export function Settings(props: Props) {
         <ClickableElement onClick={handleExport}>
           {t('export')}
         </ClickableElement>
+
+        <Element leftSide={t('html_mode')}>
+          <Toggle
+            checked={props.shouldRenderHTML}
+            onChange={(value) => props.setShouldRenderHTML(value)}
+            disabled={props.isFormBusy}
+          />
+        </Element>
       </Card>
     </>
   );

--- a/tests/e2e/invoice-designs.spec.ts
+++ b/tests/e2e/invoice-designs.spec.ts
@@ -1,0 +1,88 @@
+import { login } from '$tests/e2e/helpers';
+import test, { expect, Page } from '@playwright/test';
+
+interface CreateParams {
+  page: Page;
+  name?: string;
+}
+const createInvoiceDesign = async (params: CreateParams) => {
+  const { page, name } = params;
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Settings', exact: true })
+    .click();
+
+  await page.getByRole('link', { name: 'Invoice Design', exact: true }).click();
+
+  await page.getByRole('link', { name: 'Custom Designs', exact: true }).click();
+
+  await page
+    .getByRole('main')
+    .getByRole('link', { name: 'New Design' })
+    .click();
+
+  await page.waitForTimeout(900);
+
+  await page
+    .getByRole('main')
+    .locator('[type="text"]')
+    .first()
+    .fill(name || 'Design Name');
+
+  await page
+    .getByRole('main')
+    .getByTestId('combobox-input-field')
+    .first()
+    .click();
+
+  await page.getByRole('option').first().click();
+
+  await page.getByRole('button', { name: 'Save' }).click();
+
+  await page.waitForURL('**/settings/invoice_design/custom_designs/**/edit');
+
+  await expect(
+    page.getByRole('main').locator('[type="text"]').first()
+  ).toHaveValue(name || 'Design Name');
+};
+
+test('deleting invoice design with admin owner account', async ({ page }) => {
+  await login(page);
+
+  await createInvoiceDesign({ page, name: 'test deleting invoice design' });
+
+  await page.locator('[data-cy="chevronDownButton"]').first().click();
+
+  await page.getByText('Delete').click();
+
+  await expect(
+    page.getByRole('button', { name: 'Restore', exact: true })
+  ).toBeVisible();
+
+  await expect(
+    page.getByRole('button', { name: 'Archive', exact: true })
+  ).not.toBeVisible();
+});
+
+test('archiving invoice design with admin owner account', async ({ page }) => {
+  await login(page);
+
+  await createInvoiceDesign({ page, name: 'test archiving invoice design' });
+
+  await page.locator('[data-cy="chevronDownButton"]').first().click();
+
+  await page.getByText('Archive').click();
+
+  await expect(
+    page.getByRole('button', { name: 'Restore', exact: true })
+  ).toBeVisible();
+
+  await expect(
+    page.getByRole('button', { name: 'Delete', exact: true })
+  ).toBeVisible();
+
+  await expect(
+    page.getByRole('button', { name: 'Archive', exact: true })
+  ).not.toBeVisible();
+});


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of bulk actions on the edit page of invoice_design along with a split button. Additionally, the PR implements the render_html action to retrieve HTML code instead of PDF, allowing users to inspect the structure of the rendered design. Screenshot:

![Screenshot 2024-02-03 at 17 55 04](https://github.com/invoiceninja/ui/assets/51542191/0a786f0a-2291-4688-91d2-ec3aecccd97f)

Note: If you agree with the translation keyword "render_html," please just add it to the translation files.

Let me know your thoughts.