### PR TITLE
[Cleanup] Expense Edit Page Split Button && Tests Adjustment

### DIFF
--- a/src/pages/expenses/Expense.tsx
+++ b/src/pages/expenses/Expense.tsx
@@ -79,17 +79,16 @@ export default function Expense() {
       breadcrumbs={pages}
       {...((hasPermission('edit_expense') || entityAssigned(expense)) &&
         expense && {
-          onSaveClick: () => save(expense),
           navigationTopRight: (
             <ResourceActions
               resource={expense}
-              label={t('more_actions')}
+              onSaveClick={() => save(expense)}
               actions={actions}
+              disableSaveButton={!expense}
               cypressRef="expenseActionDropdown"
             />
           ),
         })}
-      disableSaveButton={!expense}
     >
       {expense ? (
         <div className="space-y-4">

--- a/tests/e2e/expenses.spec.ts
+++ b/tests/e2e/expenses.spec.ts
@@ -42,9 +42,7 @@ const checkEditPage = async (page: Page, isEditable: boolean) => {
     ).toBeVisible();
 
     await expect(
-      page
-        .locator('[data-cy="topNavbar"]')
-        .getByRole('button', { name: 'More Actions', exact: true })
+      page.locator('[data-cy="chevronDownButton"]').first()
     ).toBeVisible();
   } else {
     await expect(
@@ -54,9 +52,7 @@ const checkEditPage = async (page: Page, isEditable: boolean) => {
     ).not.toBeVisible();
 
     await expect(
-      page
-        .locator('[data-cy="topNavbar"]')
-        .getByRole('button', { name: 'More Actions', exact: true })
+      page.locator('[data-cy="chevronDownButton"]').first()
     ).not.toBeVisible();
   }
 };
@@ -189,7 +185,9 @@ test('can edit expense', async ({ page }) => {
     page.getByText('Successfully updated expense', { exact: true })
   ).toBeVisible();
 
-  await checkDropdownActions(page, actions, 'expenseActionDropdown');
+  await page.locator('[data-cy="chevronDownButton"]').first().click();
+
+  await checkDropdownActions(page, actions, 'expenseActionDropdown', '', true);
 
   await logout(page);
 });
@@ -222,7 +220,9 @@ test('can create a expense', async ({ page }) => {
     page.getByText('Successfully updated expense', { exact: true })
   ).toBeVisible();
 
-  await checkDropdownActions(page, actions, 'expenseActionDropdown');
+  await page.locator('[data-cy="chevronDownButton"]').first().click();
+
+  await checkDropdownActions(page, actions, 'expenseActionDropdown', '', true);
 
   await logout(page);
 });
@@ -271,7 +271,9 @@ test('can view and edit assigned expense with create_expense', async ({
     page.getByText('Successfully updated expense', { exact: true })
   ).toBeVisible();
 
-  await checkDropdownActions(page, actions, 'expenseActionDropdown');
+  await page.locator('[data-cy="chevronDownButton"]').first().click();
+
+  await checkDropdownActions(page, actions, 'expenseActionDropdown', '', true);
 
   await logout(page);
 });
@@ -302,11 +304,7 @@ test('deleting expense with edit_expense', async ({ page }) => {
   if (!doRecordsExist) {
     await createExpense({ page });
 
-    await page
-      .locator('[data-cy="topNavbar"]')
-      .getByRole('button', { name: 'More Actions', exact: true })
-      .first()
-      .click();
+    await page.locator('[data-cy="chevronDownButton"]').first().click();
 
     await page.getByText('Delete').click();
   } else {
@@ -348,11 +346,7 @@ test('archiving expense with edit_expense', async ({ page }) => {
   if (!doRecordsExist) {
     await createExpense({ page });
 
-    await page
-      .locator('[data-cy="topNavbar"]')
-      .getByRole('button', { name: 'More Actions', exact: true })
-      .first()
-      .click();
+    await page.locator('[data-cy="chevronDownButton"]').first().click();
 
     await page.getByText('Archive').click();
 
@@ -499,7 +493,9 @@ test('all actions in dropdown displayed with admin permission', async ({
 
   await checkEditPage(page, true);
 
-  await checkDropdownActions(page, actions, 'expenseActionDropdown');
+  await page.locator('[data-cy="chevronDownButton"]').first().click();
+
+  await checkDropdownActions(page, actions, 'expenseActionDropdown', '', true);
 
   await logout(page);
 });
@@ -525,7 +521,9 @@ test('all clone actions displayed with creation permissions', async ({
 
   await checkEditPage(page, true);
 
-  await checkDropdownActions(page, actions, 'expenseActionDropdown');
+  await page.locator('[data-cy="chevronDownButton"]').first().click();
+
+  await checkDropdownActions(page, actions, 'expenseActionDropdown', '', true);
 
   await logout(page);
 });
@@ -559,18 +557,13 @@ test('cloning expense', async ({ page }) => {
   if (!doRecordsExist) {
     await createExpense({ page });
 
-    await page
-      .locator('[data-cy="topNavbar"]')
-      .getByRole('button', { name: 'More Actions', exact: true })
-      .first()
-      .click();
+    await page.locator('[data-cy="chevronDownButton"]').first().click();
   } else {
-    const moreActionsButton = tableRow
+    await tableRow
       .getByRole('button')
       .filter({ has: page.getByText('More Actions') })
-      .first();
-
-    await moreActionsButton.click();
+      .first()
+      .click();
   }
 
   await page.getByText('Clone').first().click();


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of a split button for the expense edit page, along with adjustments to tests regarding the changes. Screenshot:

![Screenshot 2024-02-05 at 19 28 23](https://github.com/invoiceninja/ui/assets/51542191/caf3780c-9ae1-4196-904c-d76436bd8792)

Let me know your thoughts.