### PR TITLE
[Feature] Document Counter In Tabs && Tests Adjustment

### DIFF
--- a/src/common/interfaces/company.interface.ts
+++ b/src/common/interfaces/company.interface.ts
@@ -9,6 +9,7 @@
  */
 
 import { BankAccount } from './bank-accounts';
+import { Document } from './document.interface';
 
 export interface Company {
   id: string;
@@ -65,6 +66,7 @@ export interface Company {
   fill_products: boolean;
   convert_products: boolean;
   bank_integrations: BankAccount[];
+  documents: Document[];
 }
 
 export interface Settings {

--- a/src/components/DocumentsTabLabel.tsx
+++ b/src/components/DocumentsTabLabel.tsx
@@ -1,0 +1,27 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { useTranslation } from 'react-i18next';
+
+interface Props {
+  numberOfDocuments: number | undefined;
+}
+export function DocumentsTabLabel(props: Props) {
+  const [t] = useTranslation();
+
+  const { numberOfDocuments } = props;
+
+  return (
+    <div className="flex space-x-1">
+      <span>{t('documents')}</span>
+      <span className="font-bold">({numberOfDocuments ?? 0})</span>
+    </div>
+  );
+}

--- a/src/components/DocumentsTabLabel.tsx
+++ b/src/components/DocumentsTabLabel.tsx
@@ -21,7 +21,9 @@ export function DocumentsTabLabel(props: Props) {
   return (
     <div className="flex space-x-1">
       <span>{t('documents')}</span>
-      <span className="font-bold">({numberOfDocuments ?? 0})</span>
+      {Boolean(numberOfDocuments) && (
+        <span className="font-bold">({numberOfDocuments})</span>
+      )}
     </div>
   );
 }

--- a/src/components/TabGroup.tsx
+++ b/src/components/TabGroup.tsx
@@ -10,7 +10,7 @@
 
 import classNames from 'classnames';
 import { useAccentColor } from '$app/common/hooks/useAccentColor';
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { ReactElement, ReactNode, useEffect, useState } from 'react';
 import { useColorScheme } from '$app/common/colors';
 
 interface Props {
@@ -23,6 +23,7 @@ interface Props {
   childrenClassName?: string;
   withScrollableContent?: boolean;
   onTabChange?: (index: number) => void;
+  formatTabLabel?: (index: number) => ReactNode | undefined;
 }
 
 export function TabGroup(props: Props) {
@@ -66,7 +67,7 @@ export function TabGroup(props: Props) {
                 { 'w-full': props.width === 'full' }
               )}
             >
-              {tab}
+              {props.formatTabLabel?.(index) || tab}
             </button>
           </div>
         ))}

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -11,7 +11,7 @@
 import { useColorScheme } from '$app/common/colors';
 import { route } from '$app/common/helpers/route';
 import { useAccentColor } from '$app/common/hooks/useAccentColor';
-import { MouseEvent, useEffect, useRef } from 'react';
+import { MouseEvent, ReactNode, useEffect, useRef } from 'react';
 import {
   Link,
   Params,
@@ -32,6 +32,7 @@ export type Tab = {
   href: string;
   matcher?: Matcher[];
   enabled?: boolean;
+  formatName?: () => ReactNode | undefined;
 };
 export type Matcher = (params: Readonly<Params<string>>) => string;
 
@@ -104,7 +105,7 @@ export function Tabs(props: Props) {
           {props.tabs.map(
             (tab) =>
               (typeof tab.enabled === 'undefined' || tab.enabled) && (
-                <option key={tab.name}>{tab.name}</option>
+                <option key={tab.name}>{tab.formatName?.() || tab.name}</option>
               )
           )}
         </select>
@@ -131,7 +132,7 @@ export function Tabs(props: Props) {
                     className="whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm"
                     aria-current={isActive(tab) ? 'page' : undefined}
                   >
-                    {tab.name}
+                    {tab.formatName?.() || tab.name}
                   </Link>
                 )
             )}

--- a/src/pages/clients/edit/components/AdditionalInfo.tsx
+++ b/src/pages/clients/edit/components/AdditionalInfo.tsx
@@ -98,7 +98,22 @@ export function AdditionalInfo({ client, errors, setClient }: Props) {
 
   return (
     <Card title={t('additional_info')}>
-      <TabGroup className="px-5" tabs={tabs}>
+      <TabGroup
+        className="px-5"
+        tabs={tabs}
+        formatTabLabel={(tabIndex) => {
+          if (tabIndex === 3) {
+            return (
+              <div className="flex space-x-1">
+                <span>{t('documents')}</span>
+                <span className="font-bold text-xs mt-1">
+                  ({client?.documents.length || 0})
+                </span>
+              </div>
+            );
+          }
+        }}
+      >
         <div className="-mx-5">
           {currencies.length > 1 && (
             <Element leftSide={t('currency')}>

--- a/src/pages/clients/edit/components/AdditionalInfo.tsx
+++ b/src/pages/clients/edit/components/AdditionalInfo.tsx
@@ -30,6 +30,7 @@ import { LanguageSelector } from '$app/components/LanguageSelector';
 import { $refetch } from '$app/common/hooks/useRefetch';
 import { usePaymentTermsQuery } from '$app/common/queries/payment-terms';
 import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
+import { DocumentsTabLabel } from '$app/components/DocumentsTabLabel';
 
 interface Props {
   client: Client | undefined;
@@ -104,12 +105,7 @@ export function AdditionalInfo({ client, errors, setClient }: Props) {
         formatTabLabel={(tabIndex) => {
           if (tabIndex === 3) {
             return (
-              <div className="flex space-x-1">
-                <span>{t('documents')}</span>
-                <span className="font-bold text-xs mt-1">
-                  ({client?.documents.length || 0})
-                </span>
-              </div>
+              <DocumentsTabLabel numberOfDocuments={client?.documents.length} />
             );
           }
         }}

--- a/src/pages/credits/common/components/CreditFooter.tsx
+++ b/src/pages/credits/common/components/CreditFooter.tsx
@@ -68,7 +68,21 @@ export function CreditFooter(props: Props) {
 
   return (
     <Card className="col-span-12 xl:col-span-8 h-max px-6">
-      <TabGroup tabs={tabs}>
+      <TabGroup
+        tabs={tabs}
+        formatTabLabel={(tabIndex) => {
+          if (tabIndex === 4) {
+            return (
+              <div className="flex space-x-1">
+                <span>{t('documents')}</span>
+                <span className="font-bold text-xs mt-1">
+                  ({credit?.documents.length || 0})
+                </span>
+              </div>
+            );
+          }
+        }}
+      >
         <div>
           <MarkdownEditor
             value={credit?.terms || ''}

--- a/src/pages/credits/common/components/CreditFooter.tsx
+++ b/src/pages/credits/common/components/CreditFooter.tsx
@@ -32,6 +32,7 @@ import {
   useHasPermission,
 } from '$app/common/hooks/permissions/useHasPermission';
 import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
+import { DocumentsTabLabel } from '$app/components/DocumentsTabLabel';
 
 interface Props {
   handleChange: ChangeHandler;
@@ -73,12 +74,7 @@ export function CreditFooter(props: Props) {
         formatTabLabel={(tabIndex) => {
           if (tabIndex === 4) {
             return (
-              <div className="flex space-x-1">
-                <span>{t('documents')}</span>
-                <span className="font-bold text-xs mt-1">
-                  ({credit?.documents.length || 0})
-                </span>
-              </div>
+              <DocumentsTabLabel numberOfDocuments={credit?.documents.length} />
             );
           }
         }}

--- a/src/pages/expenses/Expense.tsx
+++ b/src/pages/expenses/Expense.tsx
@@ -25,6 +25,7 @@ import { useSave } from './edit/hooks/useSave';
 import { Spinner } from '$app/components/Spinner';
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
+import { DocumentsTabLabel } from '$app/components/DocumentsTabLabel';
 
 export default function Expense() {
   const [t] = useTranslation();
@@ -51,6 +52,9 @@ export default function Expense() {
     {
       name: t('documents'),
       href: route('/expenses/:id/documents', { id }),
+      formatName: () => (
+        <DocumentsTabLabel numberOfDocuments={expense?.documents.length} />
+      ),
     },
   ];
 

--- a/src/pages/invoices/common/components/InvoiceFooter.tsx
+++ b/src/pages/invoices/common/components/InvoiceFooter.tsx
@@ -31,6 +31,7 @@ import {
   useHasPermission,
 } from '$app/common/hooks/permissions/useHasPermission';
 import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
+import { DocumentsTabLabel } from '$app/components/DocumentsTabLabel';
 
 interface Props {
   invoice?: Invoice;
@@ -67,7 +68,18 @@ export function InvoiceFooter(props: Props) {
 
   return (
     <Card className="col-span-12 xl:col-span-8 h-max px-6">
-      <TabGroup tabs={tabs}>
+      <TabGroup
+        tabs={tabs}
+        formatTabLabel={(tabIndex) => {
+          if (tabIndex === 4) {
+            return (
+              <DocumentsTabLabel
+                numberOfDocuments={invoice?.documents.length}
+              />
+            );
+          }
+        }}
+      >
         <div>
           <MarkdownEditor
             value={invoice?.public_notes || ''}

--- a/src/pages/payments/edit/hooks/useTabs.tsx
+++ b/src/pages/payments/edit/hooks/useTabs.tsx
@@ -15,6 +15,7 @@ import {
 } from '$app/common/hooks/permissions/useHasPermission';
 import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
 import { Payment } from '$app/common/interfaces/payment';
+import { DocumentsTabLabel } from '$app/components/DocumentsTabLabel';
 import { Tab } from '$app/components/Tabs';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
@@ -60,6 +61,9 @@ export function useTabs(params: Params) {
       name: t('documents'),
       href: route('/payments/:id/documents', { id }),
       enabled: canEditAndView,
+      formatName: () => (
+        <DocumentsTabLabel numberOfDocuments={payment?.documents?.length} />
+      ),
     },
     {
       name: t('custom_fields'),

--- a/src/pages/products/Product.tsx
+++ b/src/pages/products/Product.tsx
@@ -21,7 +21,7 @@ import { Container } from '$app/components/Container';
 import { Default } from '$app/components/layouts/Default';
 import { ResourceActions } from '$app/components/ResourceActions';
 import { Tabs } from '$app/components/Tabs';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Outlet, useParams, useSearchParams } from 'react-router-dom';
 import { useActions } from './common/hooks';
@@ -59,7 +59,7 @@ export default function Product() {
     },
   ];
 
-  const tabs = useTabs({ product: productValue });
+  const tabs = useTabs({ product: productData?.data.data });
 
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -94,6 +94,12 @@ export default function Product() {
         .finally(() => setIsFormBusy(false));
     }
   };
+
+  useEffect(() => {
+    if (productData) {
+      setProductValue(productData.data.data);
+    }
+  }, [productData]);
 
   return (
     <Default

--- a/src/pages/products/common/hooks/useTabs.tsx
+++ b/src/pages/products/common/hooks/useTabs.tsx
@@ -15,6 +15,7 @@ import {
 } from '$app/common/hooks/permissions/useHasPermission';
 import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
 import { Product } from '$app/common/interfaces/product';
+import { DocumentsTabLabel } from '$app/components/DocumentsTabLabel';
 import { Tab } from '$app/components/Tabs';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
@@ -49,6 +50,9 @@ export function useTabs(params: Params) {
       name: t('documents'),
       href: route('/products/:id/documents', { id }),
       enabled: canEditAndView,
+      formatName: () => (
+        <DocumentsTabLabel numberOfDocuments={product?.documents?.length} />
+      ),
     },
     {
       name: t('product_fields'),

--- a/src/pages/projects/Project.tsx
+++ b/src/pages/projects/Project.tsx
@@ -49,6 +49,10 @@ export default function Project() {
 
   useEffect(() => {
     data?.name && setDocumentTitle(data.name);
+
+    if (data) {
+      setProjectValue(data);
+    }
   }, [data]);
 
   const pages: Page[] = [

--- a/src/pages/projects/Project.tsx
+++ b/src/pages/projects/Project.tsx
@@ -29,6 +29,7 @@ import { useActions } from './common/hooks';
 import { $refetch } from '$app/common/hooks/useRefetch';
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
+import { DocumentsTabLabel } from '$app/components/DocumentsTabLabel';
 
 export default function Project() {
   const { documentTitle, setDocumentTitle } = useTitle('project');
@@ -70,6 +71,11 @@ export default function Project() {
         hasPermission('view_project') ||
         hasPermission('edit_project') ||
         entityAssigned(projectValue),
+      formatName: () => (
+        <DocumentsTabLabel
+          numberOfDocuments={projectValue?.documents?.length}
+        />
+      ),
     },
   ];
 

--- a/src/pages/purchase-orders/edit/components/Footer.tsx
+++ b/src/pages/purchase-orders/edit/components/Footer.tsx
@@ -25,6 +25,7 @@ import { PurchaseOrderCardProps } from './Details';
 import { $refetch } from '$app/common/hooks/useRefetch';
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
+import { DocumentsTabLabel } from '$app/components/DocumentsTabLabel';
 
 export function Footer(props: PurchaseOrderCardProps) {
   const [t] = useTranslation();
@@ -53,7 +54,18 @@ export function Footer(props: PurchaseOrderCardProps) {
 
   return (
     <Card className="col-span-12 xl:col-span-8 h-max px-6">
-      <TabGroup tabs={tabs}>
+      <TabGroup
+        tabs={tabs}
+        formatTabLabel={(tabIndex) => {
+          if (tabIndex === 5) {
+            return (
+              <DocumentsTabLabel
+                numberOfDocuments={purchaseOrder?.documents.length}
+              />
+            );
+          }
+        }}
+      >
         <div>
           <MarkdownEditor
             value={purchaseOrder.terms || ''}

--- a/src/pages/quotes/common/components/QuoteFooter.tsx
+++ b/src/pages/quotes/common/components/QuoteFooter.tsx
@@ -32,6 +32,7 @@ import {
   useHasPermission,
 } from '$app/common/hooks/permissions/useHasPermission';
 import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
+import { DocumentsTabLabel } from '$app/components/DocumentsTabLabel';
 
 interface Props {
   handleChange: ChangeHandler;
@@ -68,7 +69,16 @@ export function QuoteFooter(props: Props) {
 
   return (
     <Card className="col-span-12 xl:col-span-8 h-max px-6">
-      <TabGroup tabs={tabs}>
+      <TabGroup
+        tabs={tabs}
+        formatTabLabel={(tabIndex) => {
+          if (tabIndex === 4) {
+            return (
+              <DocumentsTabLabel numberOfDocuments={quote?.documents.length} />
+            );
+          }
+        }}
+      >
         <div>
           <MarkdownEditor
             value={quote?.terms || ''}

--- a/src/pages/recurring-expenses/RecurringExpense.tsx
+++ b/src/pages/recurring-expenses/RecurringExpense.tsx
@@ -29,6 +29,7 @@ import { Spinner } from '$app/components/Spinner';
 import { $refetch } from '$app/common/hooks/useRefetch';
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
+import { DocumentsTabLabel } from '$app/components/DocumentsTabLabel';
 
 export default function RecurringExpense() {
   const [t] = useTranslation();
@@ -60,6 +61,11 @@ export default function RecurringExpense() {
     {
       name: t('documents'),
       href: route('/recurring_expenses/:id/documents', { id }),
+      formatName: () => (
+        <DocumentsTabLabel
+          numberOfDocuments={recurringExpense?.documents.length}
+        />
+      ),
     },
   ];
 

--- a/src/pages/recurring-invoices/common/components/InvoiceFooter.tsx
+++ b/src/pages/recurring-invoices/common/components/InvoiceFooter.tsx
@@ -29,6 +29,7 @@ import { ValidationBag } from '$app/common/interfaces/validation-bag';
 import { $refetch } from '$app/common/hooks/useRefetch';
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
+import { DocumentsTabLabel } from '$app/components/DocumentsTabLabel';
 
 interface Props {
   handleChange: ChangeHandler;
@@ -62,7 +63,18 @@ export function InvoiceFooter(props: Props) {
 
   return (
     <Card className="col-span-12 xl:col-span-8 h-max px-6">
-      <TabGroup tabs={tabs}>
+      <TabGroup
+        tabs={tabs}
+        formatTabLabel={(tabIndex) => {
+          if (tabIndex === 4) {
+            return (
+              <DocumentsTabLabel
+                numberOfDocuments={recurringInvoice?.documents.length}
+              />
+            );
+          }
+        }}
+      >
         <div>
           <MarkdownEditor
             value={recurringInvoice?.public_notes}

--- a/src/pages/settings/company/common/hooks/useCompanyDetailsTabs.tsx
+++ b/src/pages/settings/company/common/hooks/useCompanyDetailsTabs.tsx
@@ -8,8 +8,8 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
-import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { useCurrentSettingsLevel } from '$app/common/hooks/useCurrentSettingsLevel';
+import { useDocumentsQuery } from '$app/common/queries/documents';
 import { DocumentsTabLabel } from '$app/components/DocumentsTabLabel';
 import { Tab } from '$app/components/Tabs';
 import { useTranslation } from 'react-i18next';
@@ -17,7 +17,9 @@ import { useTranslation } from 'react-i18next';
 export function useCompanyDetailsTabs() {
   const { t } = useTranslation();
 
-  const currentCompany = useCurrentCompany();
+  const { data } = useDocumentsQuery({
+    companyDocuments: 'true',
+  });
 
   const { isGroupSettingsActive, isClientSettingsActive } =
     useCurrentSettingsLevel();
@@ -38,7 +40,7 @@ export function useCompanyDetailsTabs() {
       href: '/settings/company_details/documents',
       formatName: () => (
         <DocumentsTabLabel
-          numberOfDocuments={currentCompany?.documents.length}
+          numberOfDocuments={data?.data?.meta.pagination.total}
         />
       ),
     },

--- a/src/pages/settings/company/common/hooks/useCompanyDetailsTabs.tsx
+++ b/src/pages/settings/company/common/hooks/useCompanyDetailsTabs.tsx
@@ -8,12 +8,16 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
+import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { useCurrentSettingsLevel } from '$app/common/hooks/useCurrentSettingsLevel';
+import { DocumentsTabLabel } from '$app/components/DocumentsTabLabel';
 import { Tab } from '$app/components/Tabs';
 import { useTranslation } from 'react-i18next';
 
 export function useCompanyDetailsTabs() {
   const { t } = useTranslation();
+
+  const currentCompany = useCurrentCompany();
 
   const { isGroupSettingsActive, isClientSettingsActive } =
     useCurrentSettingsLevel();
@@ -32,6 +36,11 @@ export function useCompanyDetailsTabs() {
     {
       name: t('documents'),
       href: '/settings/company_details/documents',
+      formatName: () => (
+        <DocumentsTabLabel
+          numberOfDocuments={currentCompany?.documents.length}
+        />
+      ),
     },
     {
       name: t('custom_fields'),

--- a/src/pages/settings/group-settings/edit/Edit.tsx
+++ b/src/pages/settings/group-settings/edit/Edit.tsx
@@ -33,6 +33,7 @@ import { Icon } from '$app/components/icons/Icon';
 import { Settings as SettingsIcon } from 'react-feather';
 import { useConfigureGroupSettings } from '../common/hooks/useConfigureGroupSettings';
 import { $refetch } from '$app/common/hooks/useRefetch';
+import { DocumentsTabLabel } from '$app/components/DocumentsTabLabel';
 
 export function Edit() {
   const [t] = useTranslation();
@@ -97,7 +98,18 @@ export function Edit() {
         )
       }
     >
-      <TabGroup tabs={[t('overview'), t('clients'), t('documents')]}>
+      <TabGroup
+        tabs={[t('overview'), t('clients'), t('documents')]}
+        formatTabLabel={(tabIndex) => {
+          if (tabIndex === 2) {
+            return (
+              <DocumentsTabLabel
+                numberOfDocuments={groupSettings?.documents.length}
+              />
+            );
+          }
+        }}
+      >
         <div>
           {groupSettings && groupSettingsResponse && (
             <Card

--- a/src/pages/tasks/kanban/components/ViewSlider.tsx
+++ b/src/pages/tasks/kanban/components/ViewSlider.tsx
@@ -33,6 +33,7 @@ import { useCurrentCompanyDateFormats } from '$app/common/hooks/useCurrentCompan
 import { $refetch } from '$app/common/hooks/useRefetch';
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
+import { DocumentsTabLabel } from '$app/components/DocumentsTabLabel';
 
 export function ViewSlider() {
   const [t] = useTranslation();
@@ -57,7 +58,19 @@ export function ViewSlider() {
   };
 
   return (
-    <TabGroup tabs={[t('overview'), t('documents')]} width="full">
+    <TabGroup
+      tabs={[t('overview'), t('documents')]}
+      width="full"
+      formatTabLabel={(tabIndex) => {
+        if (tabIndex === 1) {
+          return (
+            <DocumentsTabLabel
+              numberOfDocuments={currentTask?.documents.length}
+            />
+          );
+        }
+      }}
+    >
       <div>
         {currentTask && (
           <>

--- a/src/pages/vendors/Vendor.tsx
+++ b/src/pages/vendors/Vendor.tsx
@@ -58,7 +58,7 @@ export default function Vendor() {
     { name: documentTitle || '', href: route('/vendors/:id', { id }) },
   ];
 
-  const tabs = useTabs();
+  const tabs = useTabs({ vendor });
   const { dateFormat } = useCurrentCompanyDateFormats();
 
   const lastLogin = (last_login: number | undefined) => {

--- a/src/pages/vendors/show/hooks/useTabs.tsx
+++ b/src/pages/vendors/show/hooks/useTabs.tsx
@@ -10,14 +10,21 @@
 
 import { useEnabled } from '$app/common/guards/guards/enabled';
 import { route } from '$app/common/helpers/route';
+import { Vendor } from '$app/common/interfaces/vendor';
+import { DocumentsTabLabel } from '$app/components/DocumentsTabLabel';
 import { Tab } from '$app/components/Tabs';
 import { modules } from '$app/pages/settings';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 
-export function useTabs() {
+interface Params {
+  vendor: Vendor | undefined;
+}
+export function useTabs(params: Params) {
   const [t] = useTranslation();
   const enabled = useEnabled();
+
+  const { vendor } = params;
 
   const { id } = useParams();
 
@@ -37,6 +44,9 @@ export function useTabs() {
     {
       name: t('documents'),
       href: route('/vendors/:id/documents', { id }),
+      formatName: () => (
+        <DocumentsTabLabel numberOfDocuments={vendor?.documents.length} />
+      ),
     },
   ];
 

--- a/tests/e2e/clients.spec.ts
+++ b/tests/e2e/clients.spec.ts
@@ -608,7 +608,6 @@ test('client documents preview with edit_client', async ({ page }) => {
   await page
     .getByRole('button', {
       name: 'Documents',
-      exact: true,
     })
     .click();
 
@@ -661,7 +660,6 @@ test('client documents uploading with edit_client', async ({ page }) => {
   await page
     .getByRole('button', {
       name: 'Documents',
-      exact: true,
     })
     .click();
 

--- a/tests/e2e/credits.spec.ts
+++ b/tests/e2e/credits.spec.ts
@@ -457,7 +457,6 @@ test('credit documents preview with edit_credit', async ({ page }) => {
   await page
     .getByRole('button', {
       name: 'Documents',
-      exact: true,
     })
     .click();
 
@@ -505,7 +504,6 @@ test('credit documents uploading with edit_credit', async ({ page }) => {
   await page
     .getByRole('button', {
       name: 'Documents',
-      exact: true,
     })
     .click();
 

--- a/tests/e2e/expenses.spec.ts
+++ b/tests/e2e/expenses.spec.ts
@@ -412,7 +412,6 @@ test('expense documents preview with edit_expense', async ({ page }) => {
   await page
     .getByRole('link', {
       name: 'Documents',
-      exact: true,
     })
     .click();
 
@@ -461,7 +460,6 @@ test('expense documents uploading with edit_expense', async ({ page }) => {
   await page
     .getByRole('link', {
       name: 'Documents',
-      exact: true,
     })
     .click();
 

--- a/tests/e2e/invoices.spec.ts
+++ b/tests/e2e/invoices.spec.ts
@@ -476,7 +476,6 @@ test('invoice documents preview with edit_invoice', async ({ page }) => {
   await page
     .getByRole('button', {
       name: 'Documents',
-      exact: true,
     })
     .click();
 
@@ -526,7 +525,6 @@ test('invoice documents uploading with edit_invoice', async ({ page }) => {
   await page
     .getByRole('button', {
       name: 'Documents',
-      exact: true,
     })
     .click();
 

--- a/tests/e2e/payments.spec.ts
+++ b/tests/e2e/payments.spec.ts
@@ -71,9 +71,7 @@ const checkEditPage = async (
   }
 
   await expect(
-    page
-      .locator('[data-cy="tabs"]')
-      .getByRole('link', { name: 'Documents', exact: true })
+    page.locator('[data-cy="tabs"]').getByRole('link', { name: 'Documents' })
   ).toBeVisible();
 
   if (!isAdmin) {
@@ -359,7 +357,6 @@ test('payment documents preview with edit_payment', async ({ page }) => {
   await page
     .getByRole('link', {
       name: 'Documents',
-      exact: true,
     })
     .click();
 
@@ -409,7 +406,6 @@ test('payment documents uploading with edit_payment', async ({ page }) => {
   await page
     .getByRole('link', {
       name: 'Documents',
-      exact: true,
     })
     .click();
 
@@ -435,7 +431,7 @@ test('rendering documents and custom_fields tabs with admin permission', async (
 
   await page
     .locator('[data-cy="tabs"]')
-    .getByRole('link', { name: 'Documents', exact: true })
+    .getByRole('link', { name: 'Documents' })
     .click();
 
   await page.waitForURL('**/payments/**/documents');
@@ -459,9 +455,7 @@ test('rendering documents and custom_fields tabs with admin permission', async (
     page.getByRole('link', { name: 'Edit', exact: true })
   ).toBeVisible();
 
-  await expect(
-    page.getByRole('link', { name: 'Documents', exact: true })
-  ).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Documents' })).toBeVisible();
 
   await logout(page);
 });

--- a/tests/e2e/product.spec.ts
+++ b/tests/e2e/product.spec.ts
@@ -111,9 +111,7 @@ const checkEditPage = async (
     await expect(page.locator('[data-cy="chevronDownButton"]')).toBeVisible();
 
     await expect(
-      page
-        .locator('[data-cy="tabs"]')
-        .getByRole('link', { name: 'Documents', exact: true })
+      page.locator('[data-cy="tabs"]').getByRole('link', { name: 'Documents' })
     ).toBeVisible();
   } else {
     await expect(
@@ -430,7 +428,6 @@ test('product documents preview with edit_product', async ({ page }) => {
   await page
     .getByRole('link', {
       name: 'Documents',
-      exact: true,
     })
     .click();
 
@@ -480,7 +477,6 @@ test('product documents uploading with edit_product', async ({ page }) => {
   await page
     .getByRole('link', {
       name: 'Documents',
-      exact: true,
     })
     .click();
 
@@ -715,7 +711,7 @@ test('rendering documents and product_fields tabs with admin permission', async 
 
   await page
     .locator('[data-cy="tabs"]')
-    .getByRole('link', { name: 'Documents', exact: true })
+    .getByRole('link', { name: 'Documents' })
     .click();
 
   await page.waitForURL('**/products/**/documents');
@@ -739,9 +735,7 @@ test('rendering documents and product_fields tabs with admin permission', async 
     page.getByRole('link', { name: 'Edit', exact: true })
   ).toBeVisible();
 
-  await expect(
-    page.getByRole('link', { name: 'Documents', exact: true })
-  ).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Documents' })).toBeVisible();
 
   await logout(page);
 });

--- a/tests/e2e/projects.spec.ts
+++ b/tests/e2e/projects.spec.ts
@@ -485,7 +485,6 @@ test('project documents preview with edit_project', async ({ page }) => {
   await page
     .getByRole('link', {
       name: 'Documents',
-      exact: true,
     })
     .click();
 
@@ -533,7 +532,6 @@ test('project documents uploading with edit_project', async ({ page }) => {
   await page
     .getByRole('link', {
       name: 'Documents',
-      exact: true,
     })
     .click();
 

--- a/tests/e2e/purchase-orders.spec.ts
+++ b/tests/e2e/purchase-orders.spec.ts
@@ -482,7 +482,6 @@ test('purchase_order documents preview with edit_purchase_order', async ({
   await page
     .getByRole('button', {
       name: 'Documents',
-      exact: true,
     })
     .click();
 
@@ -538,7 +537,6 @@ test('purchase_order documents uploading with edit_purchase_order', async ({
   await page
     .getByRole('button', {
       name: 'Documents',
-      exact: true,
     })
     .click();
 

--- a/tests/e2e/quotes.spec.ts
+++ b/tests/e2e/quotes.spec.ts
@@ -477,7 +477,6 @@ test('quote documents preview with edit_quote', async ({ page }) => {
   await page
     .getByRole('button', {
       name: 'Documents',
-      exact: true,
     })
     .click();
 
@@ -525,7 +524,6 @@ test('quote documents uploading with edit_quote', async ({ page }) => {
   await page
     .getByRole('button', {
       name: 'Documents',
-      exact: true,
     })
     .click();
 

--- a/tests/e2e/recurring-expense.spec.ts
+++ b/tests/e2e/recurring-expense.spec.ts
@@ -443,7 +443,6 @@ test('recurring expense documents preview with edit_recurring_expense', async ({
   await page
     .getByRole('link', {
       name: 'Documents',
-      exact: true,
     })
     .click();
 
@@ -496,7 +495,6 @@ test('recurring expense documents uploading with edit_recurring_expense', async 
   await page
     .getByRole('link', {
       name: 'Documents',
-      exact: true,
     })
     .click();
 

--- a/tests/e2e/recurring-invoices.spec.ts
+++ b/tests/e2e/recurring-invoices.spec.ts
@@ -506,7 +506,6 @@ test('invoice documents preview with edit_recurring_invoice', async ({
   await page
     .getByRole('button', {
       name: 'Documents',
-      exact: true,
     })
     .click();
 
@@ -563,7 +562,6 @@ test('invoice documents uploading with edit_recurring_invoice', async ({
   await page
     .getByRole('button', {
       name: 'Documents',
-      exact: true,
     })
     .click();
 

--- a/tests/e2e/vendors.spec.ts
+++ b/tests/e2e/vendors.spec.ts
@@ -458,7 +458,6 @@ test('vendor documents preview with view_vendor', async ({ page }) => {
   await page
     .getByRole('link', {
       name: 'Documents',
-      exact: true,
     })
     .click();
 
@@ -501,7 +500,6 @@ test('vendor documents uploading with edit_vendor', async ({ page }) => {
   await page
     .getByRole('link', {
       name: 'Documents',
-      exact: true,
     })
     .click();
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of a counter in the labels of the Documents tab, along with adjustments to tests regarding these changes. Screenshot:

<img width="1262" alt="Screenshot 2024-02-06 at 16 07 15" src="https://github.com/invoiceninja/ui/assets/51542191/48eef4a3-2b3a-4d37-a779-6386784914b1">

<img width="1261" alt="Screenshot 2024-02-06 at 16 07 47" src="https://github.com/invoiceninja/ui/assets/51542191/408e4cae-aa37-46ba-b5bf-64061e4d6f9b">

Let me know your thoughts.