### PR TITLE
[Bugfix] Expenses/Recurring Expenses Amount Calculation

### DIFF
--- a/src/common/interfaces/company.interface.ts
+++ b/src/common/interfaces/company.interface.ts
@@ -65,6 +65,8 @@ export interface Company {
   fill_products: boolean;
   convert_products: boolean;
   bank_integrations: BankAccount[];
+  calculate_expense_tax_by_amount: boolean;
+  expense_inclusive_taxes: boolean;
 }
 
 export interface Settings {

--- a/src/pages/expenses/common/hooks.tsx
+++ b/src/pages/expenses/common/hooks.tsx
@@ -52,6 +52,7 @@ import { Assigned } from '$app/components/Assigned';
 import { useDisableNavigation } from '$app/common/hooks/useDisableNavigation';
 import { DynamicLink } from '$app/components/DynamicLink';
 import { useFormatCustomFieldValue } from '$app/common/hooks/useFormatCustomFieldValue';
+import { useCalculateExpenseAmount } from './hooks/useCalculateExpenseAmount';
 
 export function useActions() {
   const [t] = useTranslation();
@@ -230,6 +231,7 @@ export function useExpenseColumns() {
   const formatMoney = useFormatMoney();
   const reactSettings = useReactSettings();
   const formatCustomFieldValue = useFormatCustomFieldValue();
+  const calculateExpenseAmount = useCalculateExpenseAmount();
 
   const expenseColumns = useAllExpenseColumns();
   type ExpenseColumns = (typeof expenseColumns)[number];
@@ -336,9 +338,9 @@ export function useExpenseColumns() {
       column: 'amount',
       id: 'amount',
       label: t('amount'),
-      format: (value, expense) =>
+      format: (_, expense) =>
         formatMoney(
-          value,
+          calculateExpenseAmount(expense),
           expense.client?.country_id,
           expense.currency_id || expense.client?.settings.currency_id
         ),

--- a/src/pages/expenses/common/hooks/useCalculateExpenseAmount.ts
+++ b/src/pages/expenses/common/hooks/useCalculateExpenseAmount.ts
@@ -13,6 +13,10 @@ import { RecurringExpense } from '$app/common/interfaces/recurring-expense';
 
 export function useCalculateExpenseAmount() {
   return (expense: Expense | RecurringExpense) => {
+    if (expense.uses_inclusive_taxes) {
+      return expense.amount;
+    }
+
     if (expense.calculate_tax_by_amount) {
       return (
         expense.amount +

--- a/src/pages/expenses/common/hooks/useCalculateExpenseAmount.ts
+++ b/src/pages/expenses/common/hooks/useCalculateExpenseAmount.ts
@@ -9,9 +9,10 @@
  */
 
 import { Expense } from '$app/common/interfaces/expense';
+import { RecurringExpense } from '$app/common/interfaces/recurring-expense';
 
 export function useCalculateExpenseAmount() {
-  return (expense: Expense) => {
+  return (expense: Expense | RecurringExpense) => {
     if (expense.calculate_tax_by_amount) {
       return (
         expense.amount +

--- a/src/pages/expenses/common/hooks/useCalculateExpenseAmount.ts
+++ b/src/pages/expenses/common/hooks/useCalculateExpenseAmount.ts
@@ -1,0 +1,40 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { Expense } from '$app/common/interfaces/expense';
+
+export function useCalculateExpenseAmount() {
+  return (expense: Expense) => {
+    if (expense.calculate_tax_by_amount) {
+      return (
+        expense.amount +
+        expense.tax_amount1 +
+        expense.tax_amount2 +
+        expense.tax_amount3
+      );
+    }
+
+    let finalAmount = expense.amount;
+
+    if (expense.tax_name1) {
+      finalAmount += expense.amount * (expense.tax_rate1 / 100);
+    }
+
+    if (expense.tax_name2) {
+      finalAmount += expense.amount * (expense.tax_rate2 / 100);
+    }
+
+    if (expense.tax_name3) {
+      finalAmount += expense.amount * (expense.tax_rate3 / 100);
+    }
+
+    return finalAmount;
+  };
+}

--- a/src/pages/expenses/create/Create.tsx
+++ b/src/pages/expenses/create/Create.tsx
@@ -94,8 +94,8 @@ export default function Create() {
             : '',
           should_be_invoiced: company?.mark_expenses_invoiceable,
           invoice_documents: company?.invoice_expense_documents,
-          calculate_tax_by_amount: taxInputType === 'by_amount' ? true : false,
-          uses_inclusive_taxes: company.expense_inclusive_taxes ? true : false,
+          calculate_tax_by_amount: taxInputType === 'by_amount',
+          uses_inclusive_taxes: company.expense_inclusive_taxes,
         };
       }
 

--- a/src/pages/expenses/create/Create.tsx
+++ b/src/pages/expenses/create/Create.tsx
@@ -57,7 +57,7 @@ export default function Create() {
   });
 
   const [taxInputType, setTaxInputType] = useState<'by_rate' | 'by_amount'>(
-    'by_rate'
+    company?.calculate_expense_tax_by_amount ? 'by_amount' : 'by_rate'
   );
 
   const [errors, setErrors] = useState<ValidationBag>();
@@ -94,6 +94,8 @@ export default function Create() {
             : '',
           should_be_invoiced: company?.mark_expenses_invoiceable,
           invoice_documents: company?.invoice_expense_documents,
+          calculate_tax_by_amount: taxInputType === 'by_amount' ? true : false,
+          uses_inclusive_taxes: company.expense_inclusive_taxes ? true : false,
         };
       }
 

--- a/src/pages/expenses/create/components/AdditionalInfo.tsx
+++ b/src/pages/expenses/create/components/AdditionalInfo.tsx
@@ -173,13 +173,18 @@ export function AdditionalInfo(props: ExpenseCardProps) {
           <Toggle
             checked={expense.should_be_invoiced}
             onChange={(value) => handleChange('should_be_invoiced', value)}
+            cypressRef="shouldBeInvoicedToggle"
           />
         </Element>
       )}
 
       {expense && (
         <Element leftSide={t('mark_paid')} leftSideHelp={t('mark_paid_help')}>
-          <Toggle checked={isMarkPaid()} onChange={onMarkPaid} />
+          <Toggle
+            checked={isMarkPaid()}
+            onChange={onMarkPaid}
+            cypressRef="markPaidToggle"
+          />
         </Element>
       )}
 
@@ -278,6 +283,7 @@ export function AdditionalInfo(props: ExpenseCardProps) {
           <Toggle
             checked={expense.invoice_documents}
             onChange={(value) => handleChange('invoice_documents', value)}
+            cypressRef="addDocumentsToInvoiceToggle"
           />
         </Element>
       )}

--- a/src/pages/expenses/create/components/AdditionalInfo.tsx
+++ b/src/pages/expenses/create/components/AdditionalInfo.tsx
@@ -229,6 +229,7 @@ export function AdditionalInfo(props: ExpenseCardProps) {
           <Toggle
             checked={convertCurrency || false}
             onChange={(value: boolean) => setConvertCurrency(value)}
+            cypressRef="convertCurrencyToggle"
           />
         </Element>
       )}

--- a/src/pages/expenses/create/components/Details.tsx
+++ b/src/pages/expenses/create/components/Details.tsx
@@ -157,6 +157,7 @@ export function Details(props: Props) {
                 value={expense.tax_name1}
                 onValueChange={(value) => handleChange('tax_name1', value)}
                 errorMessage={errors?.errors.tax_name1}
+                cypressRef="taxNameByAmount1"
               />
               <InputField
                 type="number"
@@ -166,6 +167,7 @@ export function Details(props: Props) {
                   handleChange('tax_amount1', parseFloat(value))
                 }
                 errorMessage={errors?.errors.tax_amount1}
+                cypressRef="taxRateByAmount1"
               />
             </div>
           </Element>
@@ -208,6 +210,7 @@ export function Details(props: Props) {
                 value={expense.tax_name2}
                 onValueChange={(value) => handleChange('tax_name2', value)}
                 errorMessage={errors?.errors.tax_name2}
+                cypressRef="taxNameByAmount2"
               />
               <InputField
                 type="number"
@@ -217,6 +220,7 @@ export function Details(props: Props) {
                   handleChange('tax_amount2', parseFloat(value))
                 }
                 errorMessage={errors?.errors.tax_amount2}
+                cypressRef="taxRateByAmount2"
               />
             </div>
           </Element>

--- a/src/pages/expenses/create/components/Taxes.tsx
+++ b/src/pages/expenses/create/components/Taxes.tsx
@@ -31,21 +31,8 @@ export function TaxSettings(props: Props) {
 
   const company = useCurrentCompany();
 
-  const handleResetTaxValues = () => {
-    handleChange('tax_name1', '');
-    handleChange('tax_name2', '');
-    handleChange('tax_name3', '');
-    handleChange('tax_rate1', 0);
-    handleChange('tax_rate2', 0);
-    handleChange('tax_rate3', 0);
-    handleChange('tax_amount1', 0);
-    handleChange('tax_amount2', 0);
-    handleChange('tax_amount3', 0);
-  };
-
   const taxTypeChange = (value: string) => {
     setTaxInputType(value as 'by_rate' | 'by_amount');
-    handleResetTaxValues();
     handleChange('calculate_tax_by_amount', value === 'by_amount');
   };
 

--- a/src/pages/expenses/create/components/Taxes.tsx
+++ b/src/pages/expenses/create/components/Taxes.tsx
@@ -72,6 +72,7 @@ export function TaxSettings(props: Props) {
             ]}
             defaultSelected={taxInputType}
             onValueChange={(value) => taxTypeChange(value)}
+            cypressRef="taxByRadio"
           />
         </Element>
       )}
@@ -89,6 +90,7 @@ export function TaxSettings(props: Props) {
           <Toggle
             onChange={(value) => handleChange('uses_inclusive_taxes', value)}
             checked={expense.uses_inclusive_taxes}
+            cypressRef="inclusiveTaxesToggle"
           />
         </Element>
       )}

--- a/src/pages/expenses/create/components/Taxes.tsx
+++ b/src/pages/expenses/create/components/Taxes.tsx
@@ -72,7 +72,6 @@ export function TaxSettings(props: Props) {
             ]}
             defaultSelected={taxInputType}
             onValueChange={(value) => taxTypeChange(value)}
-            cypressRef="taxByRadio"
           />
         </Element>
       )}

--- a/src/pages/expenses/create/components/Taxes.tsx
+++ b/src/pages/expenses/create/components/Taxes.tsx
@@ -31,8 +31,25 @@ export function TaxSettings(props: Props) {
 
   const company = useCurrentCompany();
 
+  const handleResetTaxValues = (value: 'by_rate' | 'by_amount') => {
+    if (value === 'by_amount') {
+      handleChange('tax_rate1', 0);
+      handleChange('tax_rate2', 0);
+      handleChange('tax_rate3', 0);
+    } else {
+      handleChange('tax_amount1', 0);
+      handleChange('tax_amount2', 0);
+      handleChange('tax_amount3', 0);
+    }
+
+    handleChange('tax_name1', '');
+    handleChange('tax_name2', '');
+    handleChange('tax_name3', '');
+  };
+
   const taxTypeChange = (value: string) => {
     setTaxInputType(value as 'by_rate' | 'by_amount');
+    handleResetTaxValues(value as 'by_rate' | 'by_amount');
     handleChange('calculate_tax_by_amount', value === 'by_amount');
   };
 

--- a/src/pages/expenses/create/components/Taxes.tsx
+++ b/src/pages/expenses/create/components/Taxes.tsx
@@ -31,8 +31,21 @@ export function TaxSettings(props: Props) {
 
   const company = useCurrentCompany();
 
+  const handleResetTaxValues = () => {
+    handleChange('tax_name1', '');
+    handleChange('tax_name2', '');
+    handleChange('tax_name3', '');
+    handleChange('tax_rate1', 0);
+    handleChange('tax_rate2', 0);
+    handleChange('tax_rate3', 0);
+    handleChange('tax_amount1', 0);
+    handleChange('tax_amount2', 0);
+    handleChange('tax_amount3', 0);
+  };
+
   const taxTypeChange = (value: string) => {
     setTaxInputType(value as 'by_rate' | 'by_amount');
+    handleResetTaxValues();
     handleChange('calculate_tax_by_amount', value === 'by_amount');
   };
 

--- a/src/pages/expenses/create/components/Taxes.tsx
+++ b/src/pages/expenses/create/components/Taxes.tsx
@@ -31,12 +31,22 @@ export function TaxSettings(props: Props) {
 
   const company = useCurrentCompany();
 
+  const handleResetTaxValues = () => {
+    handleChange('tax_name1', '');
+    handleChange('tax_name2', '');
+    handleChange('tax_name3', '');
+    handleChange('tax_rate1', 0);
+    handleChange('tax_rate2', 0);
+    handleChange('tax_rate3', 0);
+    handleChange('tax_amount1', 0);
+    handleChange('tax_amount2', 0);
+    handleChange('tax_amount3', 0);
+  };
+
   const taxTypeChange = (value: string) => {
     setTaxInputType(value as 'by_rate' | 'by_amount');
-    handleChange(
-      'calculate_tax_by_amount',
-      value === 'by_amount' ? true : false
-    );
+    handleResetTaxValues();
+    handleChange('calculate_tax_by_amount', value === 'by_amount');
   };
 
   return (

--- a/src/pages/recurring-expenses/common/hooks.tsx
+++ b/src/pages/recurring-expenses/common/hooks.tsx
@@ -55,6 +55,7 @@ import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission
 import { useDisableNavigation } from '$app/common/hooks/useDisableNavigation';
 import { DynamicLink } from '$app/components/DynamicLink';
 import { useFormatCustomFieldValue } from '$app/common/hooks/useFormatCustomFieldValue';
+import { useCalculateExpenseAmount } from '$app/pages/expenses/common/hooks/useCalculateExpenseAmount';
 
 export const defaultColumns: string[] = [
   'status',
@@ -131,6 +132,7 @@ export function useRecurringExpenseColumns() {
   const formatMoney = useFormatMoney();
   const reactSettings = useReactSettings();
   const formatCustomFieldValue = useFormatCustomFieldValue();
+  const calculateExpenseAmount = useCalculateExpenseAmount();
 
   const recurringExpenseColumns = useAllRecurringExpenseColumns();
   type RecurringExpenseColumns = (typeof recurringExpenseColumns)[number];
@@ -212,9 +214,9 @@ export function useRecurringExpenseColumns() {
       column: 'amount',
       id: 'amount',
       label: t('amount'),
-      format: (value, recurringExpense) =>
+      format: (_, recurringExpense) =>
         formatMoney(
-          value,
+          calculateExpenseAmount(recurringExpense),
           recurringExpense.client?.country_id,
           recurringExpense.currency_id ||
             recurringExpense.client?.settings.currency_id

--- a/src/pages/recurring-expenses/components/AdditionalInfo.tsx
+++ b/src/pages/recurring-expenses/components/AdditionalInfo.tsx
@@ -14,14 +14,18 @@ import { CurrencySelector } from '$app/components/CurrencySelector';
 import Toggle from '$app/components/forms/Toggle';
 import { PaymentTypeSelector } from '$app/components/payment-types/PaymentTypeSelector';
 import dayjs from 'dayjs';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { RecurringExpenseCardProps } from './Details';
+import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 
 export function AdditionalInfo(props: RecurringExpenseCardProps) {
   const [t] = useTranslation();
+  const company = useCurrentCompany();
 
   const { recurringExpense, handleChange, errors } = props;
+
+  const [convertCurrency, setConvertCurrency] = useState<boolean>();
 
   const isMarkPaid = () => {
     return (
@@ -43,13 +47,6 @@ export function AdditionalInfo(props: RecurringExpenseCardProps) {
     handleChange('payment_date', dayjs().format('YYYY-MM-DD'));
   };
 
-  const isConvertCurrency = () => {
-    return (
-      Boolean(recurringExpense?.exchange_rate) ||
-      Boolean(recurringExpense?.foreign_amount)
-    );
-  };
-
   const onConvertCurrency = (checked: boolean) => {
     if (!checked) {
       handleChange('invoice_currency_id', '');
@@ -64,7 +61,7 @@ export function AdditionalInfo(props: RecurringExpenseCardProps) {
   };
 
   useEffect(() => {
-    if (isConvertCurrency()) {
+    if (convertCurrency) {
       handleChange(
         'foreign_amount',
         recurringExpense!.amount * recurringExpense!.exchange_rate
@@ -90,6 +87,15 @@ export function AdditionalInfo(props: RecurringExpenseCardProps) {
       parseFloat(amount) / recurringExpense!.amount
     );
   };
+
+  useEffect(() => {
+    if (recurringExpense && typeof convertCurrency === 'undefined') {
+      setConvertCurrency(
+        Boolean(company?.convert_expense_currency) ||
+          Boolean(recurringExpense?.foreign_amount)
+      );
+    }
+  }, [recurringExpense]);
 
   return (
     <Card title={t('additional_info')} isLoading={!recurringExpense}>
@@ -154,38 +160,40 @@ export function AdditionalInfo(props: RecurringExpenseCardProps) {
           leftSide={t('convert_currency')}
           leftSideHelp={t('convert_currency_help')}
         >
-          <Toggle checked={isConvertCurrency()} onChange={onConvertCurrency} />
-        </Element>
-      )}
-
-      {recurringExpense && isConvertCurrency() && (
-        <Element leftSide={t('currency')}>
-          <CurrencySelector
-            value={recurringExpense.invoice_currency_id}
-            onChange={(id) => handleChange('invoice_currency_id', id)}
-            errorMessage={errors?.errors.invoice_currency_id}
+          <Toggle
+            checked={convertCurrency || false}
+            onChange={onConvertCurrency}
+            cypressRef="convertCurrencyToggle"
           />
         </Element>
       )}
 
-      {recurringExpense && isConvertCurrency() && (
-        <Element leftSide={t('exchange_rate')}>
-          <InputField
-            value={recurringExpense.exchange_rate}
-            onValueChange={onExchangeRateChange}
-            errorMessage={errors?.errors.exchange_rate}
-          />
-        </Element>
-      )}
+      {recurringExpense && convertCurrency && (
+        <>
+          <Element leftSide={t('currency')}>
+            <CurrencySelector
+              value={recurringExpense.invoice_currency_id}
+              onChange={(id) => handleChange('invoice_currency_id', id)}
+              errorMessage={errors?.errors.invoice_currency_id}
+            />
+          </Element>
 
-      {recurringExpense && isConvertCurrency() && (
-        <Element leftSide={t('converted_amount')}>
-          <InputField
-            value={recurringExpense.foreign_amount}
-            onValueChange={onConvertedAmountChange}
-            errorMessage={errors?.errors.foreign_amount}
-          />
-        </Element>
+          <Element leftSide={t('exchange_rate')}>
+            <InputField
+              value={recurringExpense.exchange_rate}
+              onValueChange={onExchangeRateChange}
+              errorMessage={errors?.errors.exchange_rate}
+            />
+          </Element>
+
+          <Element leftSide={t('converted_amount')}>
+            <InputField
+              value={recurringExpense.foreign_amount}
+              onValueChange={onConvertedAmountChange}
+              errorMessage={errors?.errors.foreign_amount}
+            />
+          </Element>
+        </>
       )}
 
       {recurringExpense && (

--- a/src/pages/recurring-expenses/components/AdditionalInfo.tsx
+++ b/src/pages/recurring-expenses/components/AdditionalInfo.tsx
@@ -101,13 +101,18 @@ export function AdditionalInfo(props: RecurringExpenseCardProps) {
           <Toggle
             checked={recurringExpense.should_be_invoiced}
             onChange={(value) => handleChange('should_be_invoiced', value)}
+            cypressRef="shouldBeInvoicedToggle"
           />
         </Element>
       )}
 
       {recurringExpense && (
         <Element leftSide={t('mark_paid')} leftSideHelp={t('mark_paid_help')}>
-          <Toggle checked={isMarkPaid()} onChange={onMarkPaid} />
+          <Toggle
+            checked={isMarkPaid()}
+            onChange={onMarkPaid}
+            cypressRef="markPaidToggle"
+          />
         </Element>
       )}
 
@@ -191,6 +196,7 @@ export function AdditionalInfo(props: RecurringExpenseCardProps) {
           <Toggle
             checked={recurringExpense.invoice_documents}
             onChange={(value) => handleChange('invoice_documents', value)}
+            cypressRef="addDocumentsToInvoiceToggle"
           />
         </Element>
       )}

--- a/src/pages/recurring-expenses/components/Details.tsx
+++ b/src/pages/recurring-expenses/components/Details.tsx
@@ -51,6 +51,8 @@ export function Details(props: Props) {
 
   const [searchParams] = useSearchParams();
 
+  console.log(recurringExpense);
+
   return (
     <Card title={t('details')} isLoading={!recurringExpense}>
       {recurringExpense && pageType === 'edit' && (

--- a/src/pages/recurring-expenses/components/Details.tsx
+++ b/src/pages/recurring-expenses/components/Details.tsx
@@ -51,8 +51,6 @@ export function Details(props: Props) {
 
   const [searchParams] = useSearchParams();
 
-  console.log(recurringExpense);
-
   return (
     <Card title={t('details')} isLoading={!recurringExpense}>
       {recurringExpense && pageType === 'edit' && (

--- a/src/pages/recurring-expenses/components/Details.tsx
+++ b/src/pages/recurring-expenses/components/Details.tsx
@@ -166,6 +166,7 @@ export function Details(props: Props) {
                 value={recurringExpense.tax_name1}
                 onValueChange={(value) => handleChange('tax_name1', value)}
                 errorMessage={errors?.errors.tax_name1}
+                cypressRef="taxNameByAmount1"
               />
               <InputField
                 type="number"
@@ -175,6 +176,7 @@ export function Details(props: Props) {
                   handleChange('tax_amount1', parseFloat(value))
                 }
                 errorMessage={errors?.errors.tax_amount1}
+                cypressRef="taxRateByAmount1"
               />
             </div>
           </Element>
@@ -217,6 +219,7 @@ export function Details(props: Props) {
                 value={recurringExpense.tax_name2}
                 onValueChange={(value) => handleChange('tax_name2', value)}
                 errorMessage={errors?.errors.tax_name2}
+                cypressRef="taxNameByAmount2"
               />
               <InputField
                 type="number"
@@ -226,6 +229,7 @@ export function Details(props: Props) {
                   handleChange('tax_amount2', parseFloat(value))
                 }
                 errorMessage={errors?.errors.tax_amount2}
+                cypressRef="taxRateByAmount2"
               />
             </div>
           </Element>

--- a/src/pages/recurring-expenses/components/Taxes.tsx
+++ b/src/pages/recurring-expenses/components/Taxes.tsx
@@ -32,8 +32,21 @@ export function TaxSettings(props: Props) {
   const { recurringExpense, handleChange, taxInputType, setTaxInputType } =
     props;
 
+  const handleResetTaxValues = () => {
+    handleChange('tax_name1', '');
+    handleChange('tax_name2', '');
+    handleChange('tax_name3', '');
+    handleChange('tax_rate1', 0);
+    handleChange('tax_rate2', 0);
+    handleChange('tax_rate3', 0);
+    handleChange('tax_amount1', 0);
+    handleChange('tax_amount2', 0);
+    handleChange('tax_amount3', 0);
+  };
+
   const taxTypeChange = (value: string) => {
     setTaxInputType(value as 'by_rate' | 'by_amount');
+    handleResetTaxValues();
     handleChange('calculate_tax_by_amount', value === 'by_amount');
   };
 

--- a/src/pages/recurring-expenses/components/Taxes.tsx
+++ b/src/pages/recurring-expenses/components/Taxes.tsx
@@ -90,6 +90,7 @@ export function TaxSettings(props: Props) {
           <Toggle
             checked={recurringExpense.uses_inclusive_taxes}
             onChange={(value) => handleChange('uses_inclusive_taxes', value)}
+            cypressRef="inclusiveTaxesToggle"
           />
         </Element>
       )}

--- a/src/pages/recurring-expenses/components/Taxes.tsx
+++ b/src/pages/recurring-expenses/components/Taxes.tsx
@@ -32,21 +32,8 @@ export function TaxSettings(props: Props) {
   const { recurringExpense, handleChange, taxInputType, setTaxInputType } =
     props;
 
-  const handleResetTaxValues = () => {
-    handleChange('tax_name1', '');
-    handleChange('tax_name2', '');
-    handleChange('tax_name3', '');
-    handleChange('tax_rate1', 0);
-    handleChange('tax_rate2', 0);
-    handleChange('tax_rate3', 0);
-    handleChange('tax_amount1', 0);
-    handleChange('tax_amount2', 0);
-    handleChange('tax_amount3', 0);
-  };
-
   const taxTypeChange = (value: string) => {
     setTaxInputType(value as 'by_rate' | 'by_amount');
-    handleResetTaxValues();
     handleChange('calculate_tax_by_amount', value === 'by_amount');
   };
 

--- a/src/pages/recurring-expenses/components/Taxes.tsx
+++ b/src/pages/recurring-expenses/components/Taxes.tsx
@@ -32,8 +32,25 @@ export function TaxSettings(props: Props) {
   const { recurringExpense, handleChange, taxInputType, setTaxInputType } =
     props;
 
+  const handleResetTaxValues = (value: 'by_rate' | 'by_amount') => {
+    if (value === 'by_amount') {
+      handleChange('tax_rate1', 0);
+      handleChange('tax_rate2', 0);
+      handleChange('tax_rate3', 0);
+    } else {
+      handleChange('tax_amount1', 0);
+      handleChange('tax_amount2', 0);
+      handleChange('tax_amount3', 0);
+    }
+
+    handleChange('tax_name1', '');
+    handleChange('tax_name2', '');
+    handleChange('tax_name3', '');
+  };
+
   const taxTypeChange = (value: string) => {
     setTaxInputType(value as 'by_rate' | 'by_amount');
+    handleResetTaxValues(value as 'by_rate' | 'by_amount');
     handleChange('calculate_tax_by_amount', value === 'by_amount');
   };
 

--- a/src/pages/recurring-expenses/create/Create.tsx
+++ b/src/pages/recurring-expenses/create/Create.tsx
@@ -32,9 +32,13 @@ import { useHandleChange } from '../common/hooks';
 import { RecurringExpensesFrequency } from '$app/common/enums/recurring-expense-frequency';
 import { cloneDeep } from 'lodash';
 import { $refetch } from '$app/common/hooks/useRefetch';
+import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
+import dayjs from 'dayjs';
 
 export default function Create() {
   const [t] = useTranslation();
+
+  const company = useCurrentCompany();
 
   const navigate = useNavigate();
 
@@ -48,7 +52,7 @@ export default function Create() {
   ];
 
   const [taxInputType, setTaxInputType] = useState<'by_rate' | 'by_amount'>(
-    'by_rate'
+    company?.calculate_expense_tax_by_amount ? 'by_amount' : 'by_rate'
   );
 
   const [recurringExpense, setRecurringExpense] = useAtom(recurringExpenseAtom);
@@ -87,7 +91,16 @@ export default function Create() {
           _recurringExpense.vendor_id = searchParams.get('vendor')!;
         }
 
-        value = _recurringExpense;
+        value = {
+          ..._recurringExpense,
+          payment_date: company?.mark_expenses_paid
+            ? dayjs().format('YYYY-MM-DD')
+            : '',
+          should_be_invoiced: company?.mark_expenses_invoiceable,
+          invoice_documents: company?.invoice_expense_documents,
+          calculate_tax_by_amount: taxInputType === 'by_amount' ? true : false,
+          uses_inclusive_taxes: company.expense_inclusive_taxes ? true : false,
+        };
       }
 
       return value;

--- a/src/pages/recurring-expenses/create/Create.tsx
+++ b/src/pages/recurring-expenses/create/Create.tsx
@@ -98,8 +98,8 @@ export default function Create() {
             : '',
           should_be_invoiced: company?.mark_expenses_invoiceable,
           invoice_documents: company?.invoice_expense_documents,
-          calculate_tax_by_amount: taxInputType === 'by_amount' ? true : false,
-          uses_inclusive_taxes: company.expense_inclusive_taxes ? true : false,
+          calculate_tax_by_amount: taxInputType === 'by_amount',
+          uses_inclusive_taxes: company.expense_inclusive_taxes,
         };
       }
 

--- a/src/pages/settings/expense-settings/ExpenseSettings.tsx
+++ b/src/pages/settings/expense-settings/ExpenseSettings.tsx
@@ -69,6 +69,7 @@ export function ExpenseSettings() {
             onChange={(value: boolean) =>
               handleToggleChange('mark_expenses_invoiceable', value)
             }
+            cypressRef="shouldBeInvoicedToggle"
           />
         </Element>
 
@@ -78,6 +79,7 @@ export function ExpenseSettings() {
             onChange={(value: boolean) =>
               handleToggleChange('mark_expenses_paid', value)
             }
+            cypressRef="markPaidToggle"
           />
         </Element>
 
@@ -102,6 +104,7 @@ export function ExpenseSettings() {
             onChange={(value: boolean) =>
               handleToggleChange('invoice_expense_documents', value)
             }
+            cypressRef="addDocumentsToInvoiceToggle"
           />
         </Element>
 
@@ -136,6 +139,7 @@ export function ExpenseSettings() {
             ]}
             name="calculate_expense_tax_by_amount"
             defaultSelected={companyChanges?.calculate_expense_tax_by_amount.toString()}
+            cypressRef="taxByRadio"
           />
         </Element>
 
@@ -153,6 +157,7 @@ export function ExpenseSettings() {
               handleToggleChange('expense_inclusive_taxes', value)
             }
             checked={companyChanges?.expense_inclusive_taxes || false}
+            cypressRef="inclusiveTaxesToggle"
           />
         </Element>
       </Card>

--- a/src/pages/settings/expense-settings/ExpenseSettings.tsx
+++ b/src/pages/settings/expense-settings/ExpenseSettings.tsx
@@ -92,6 +92,7 @@ export function ExpenseSettings() {
             onChange={(value: boolean) =>
               handleToggleChange('convert_expense_currency', value)
             }
+            cypressRef="convertCurrencyToggle"
           />
         </Element>
 

--- a/src/pages/settings/tax-settings/TaxSettings.tsx
+++ b/src/pages/settings/tax-settings/TaxSettings.tsx
@@ -141,6 +141,7 @@ export function TaxSettings() {
                     handleToggleChange('settings.inclusive_taxes', value)
                   }
                   checked={Boolean(companyChanges?.settings.inclusive_taxes)}
+                  cypressRef="inclusiveTaxToggle"
                 />
 
                 {companyChanges?.settings.inclusive_taxes ? (

--- a/tests/e2e/expenses.spec.ts
+++ b/tests/e2e/expenses.spec.ts
@@ -10,6 +10,7 @@ import {
 import test, { expect, Page } from '@playwright/test';
 import { Action } from './clients.spec';
 import { createExpenseCategory } from './expense-categories-helpers';
+import { createTaxRate } from './taxes-helpers';
 
 interface Params {
   permissions: Permission[];
@@ -758,6 +759,43 @@ test('Checking mark_paid expense settings value on expense creation page', async
   await logout(page);
 });
 
+test('Checking convert_currency expense settings value on expense creation page', async ({
+  page,
+}) => {
+  await login(page);
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Settings', exact: true })
+    .click();
+
+  await page
+    .getByRole('link', { name: 'Expense Settings', exact: true })
+    .click();
+
+  if (!(await page.locator('[data-cy="convertCurrencyToggle"]').isChecked())) {
+    await page.locator('[data-cy="convertCurrencyToggle"]').check();
+
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    await expect(page.getByText('Successfully updated settings')).toBeVisible();
+  }
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Expenses', exact: true })
+    .click();
+
+  await page
+    .getByRole('main')
+    .getByRole('link', { name: 'Enter Expense' })
+    .click();
+
+  await expect(page.locator('[data-cy="convertCurrencyToggle"]')).toBeChecked();
+
+  await logout(page);
+});
+
 test('Checking add_documents_to_invoice expense settings value on expense creation page', async ({
   page,
 }) => {
@@ -795,6 +833,165 @@ test('Checking add_documents_to_invoice expense settings value on expense creati
   await expect(
     page.locator('[data-cy="addDocumentsToInvoiceToggle"]')
   ).toBeChecked();
+
+  await logout(page);
+});
+
+test('Checking the gross amount by rate', async ({ page }) => {
+  await login(page);
+
+  await createTaxRate({ page, taxName: 'tax_rate_10', rate: 10 });
+
+  await createTaxRate({ page, taxName: 'tax_rate_20', rate: 20 });
+
+  await page
+    .getByRole('link', { name: 'Tax Settings', exact: true })
+    .first()
+    .click();
+
+  if ((await page.locator('#enabled_expense_tax_rates').inputValue()) !== '2') {
+    await page
+      .locator('#enabled_expense_tax_rates')
+      .selectOption({ label: 'Two Tax Rates' });
+
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    await expect(page.getByText('Successfully updated settings')).toBeVisible();
+  }
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Expenses', exact: true })
+    .click();
+
+  const tableBody = page.locator('tbody').first();
+
+  const tableRow = tableBody.getByRole('row').first();
+
+  await tableRow
+    .getByRole('button')
+    .filter({ has: page.getByText('More Actions') })
+    .first()
+    .click();
+
+  await page.getByText('Edit', { exact: true }).first().click();
+
+  await page.getByTestId('combobox-input-field').nth(5).click();
+  await page.getByText('tax_rate_10').click();
+  await page.getByTestId('combobox-input-field').nth(5).blur();
+
+  await page.getByTestId('combobox-input-field').nth(6).click();
+  await page.getByText('tax_rate_20').click();
+  await page.getByTestId('combobox-input-field').nth(6).blur();
+
+  await page.locator('[type="number"]').first().fill('12222');
+
+  await page
+    .locator('[data-cy="topNavbar"]')
+    .getByRole('button', { name: 'Save', exact: true })
+    .click();
+
+  await expect(
+    page.getByText('Successfully updated expense', { exact: true })
+  ).toBeVisible();
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Expenses', exact: true })
+    .click();
+
+  await expect(page.getByText('$ 15,888.60')).toBeVisible();
+
+  await logout(page);
+});
+
+test('Checking the gross amount with inclusive taxes turned on', async ({
+  page,
+}) => {
+  await login(page);
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Expenses', exact: true })
+    .click();
+
+  const tableBody = page.locator('tbody').first();
+
+  const tableRow = tableBody.getByRole('row').first();
+
+  await tableRow
+    .getByRole('button')
+    .filter({ has: page.getByText('More Actions') })
+    .first()
+    .click();
+
+  await page.getByText('Edit', { exact: true }).first().click();
+
+  await page.locator('[data-cy="inclusiveTaxesToggle"]').first().check();
+
+  await page
+    .locator('[data-cy="topNavbar"]')
+    .getByRole('button', { name: 'Save', exact: true })
+    .click();
+
+  await expect(
+    page.getByText('Successfully updated expense', { exact: true })
+  ).toBeVisible();
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Expenses', exact: true })
+    .click();
+
+  await expect(page.getByText('$ 12,222.00')).toBeVisible();
+
+  await logout(page);
+});
+
+test('Checking the gross amount by amount', async ({ page }) => {
+  await login(page);
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Expenses', exact: true })
+    .click();
+
+  const tableBody = page.locator('tbody').first();
+
+  const tableRow = tableBody.getByRole('row').first();
+
+  await tableRow
+    .getByRole('button')
+    .filter({ has: page.getByText('More Actions') })
+    .first()
+    .click();
+
+  await page.getByText('Edit', { exact: true }).first().click();
+
+  await page.locator('[data-cy="inclusiveTaxesToggle"]').first().uncheck();
+
+  await page.locator('#by_amount').click();
+
+  await page.locator('[data-cy="taxNameByAmount1"]').fill('tax_name_1');
+  await page.locator('[data-cy="taxRateByAmount1"]').fill('100');
+  await page.locator('[data-cy="taxNameByAmount2"]').fill('tax_name_2');
+  await page.locator('[data-cy="taxRateByAmount2"]').fill('200');
+
+  await page
+    .locator('[data-cy="topNavbar"]')
+    .getByRole('button', { name: 'Save', exact: true })
+    .click();
+
+  await expect(
+    page.getByText('Successfully updated expense', { exact: true })
+  ).toBeVisible();
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Expenses', exact: true })
+    .click();
+
+  await expect(page.getByText('$ 12,522.00')).toBeVisible();
 
   await logout(page);
 });

--- a/tests/e2e/expenses.spec.ts
+++ b/tests/e2e/expenses.spec.ts
@@ -720,3 +720,81 @@ test('Checking should_be_invoiced expense settings value on expense creation pag
 
   await logout(page);
 });
+
+test('Checking mark_paid expense settings value on expense creation page', async ({
+  page,
+}) => {
+  await login(page);
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Settings', exact: true })
+    .click();
+
+  await page
+    .getByRole('link', { name: 'Expense Settings', exact: true })
+    .click();
+
+  if (!(await page.locator('[data-cy="markPaidToggle"]').isChecked())) {
+    await page.locator('[data-cy="markPaidToggle"]').check();
+
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    await expect(page.getByText('Successfully updated settings')).toBeVisible();
+  }
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Expenses', exact: true })
+    .click();
+
+  await page
+    .getByRole('main')
+    .getByRole('link', { name: 'Enter Expense' })
+    .click();
+
+  await expect(page.locator('[data-cy="markPaidToggle"]')).toBeChecked();
+
+  await logout(page);
+});
+
+test('Checking add_documents_to_invoice expense settings value on expense creation page', async ({
+  page,
+}) => {
+  await login(page);
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Settings', exact: true })
+    .click();
+
+  await page
+    .getByRole('link', { name: 'Expense Settings', exact: true })
+    .click();
+
+  if (
+    !(await page.locator('[data-cy="addDocumentsToInvoiceToggle"]').isChecked())
+  ) {
+    await page.locator('[data-cy="addDocumentsToInvoiceToggle"]').check();
+
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    await expect(page.getByText('Successfully updated settings')).toBeVisible();
+  }
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Expenses', exact: true })
+    .click();
+
+  await page
+    .getByRole('main')
+    .getByRole('link', { name: 'Enter Expense' })
+    .click();
+
+  await expect(
+    page.locator('[data-cy="addDocumentsToInvoiceToggle"]')
+  ).toBeChecked();
+
+  await logout(page);
+});

--- a/tests/e2e/expenses.spec.ts
+++ b/tests/e2e/expenses.spec.ts
@@ -682,3 +682,41 @@ test('Expense categories endpoint contains with but not sort parameter', async (
 
   await logout(page);
 });
+test('Checking should_be_invoiced expense settings value on expense creation page', async ({
+  page,
+}) => {
+  await login(page);
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Settings', exact: true })
+    .click();
+
+  await page
+    .getByRole('link', { name: 'Expense Settings', exact: true })
+    .click();
+
+  if (!(await page.locator('[data-cy="shouldBeInvoicedToggle"]').isChecked())) {
+    await page.locator('[data-cy="shouldBeInvoicedToggle"]').check();
+
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    await expect(page.getByText('Successfully updated settings')).toBeVisible();
+  }
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Expenses', exact: true })
+    .click();
+
+  await page
+    .getByRole('main')
+    .getByRole('link', { name: 'Enter Expense' })
+    .click();
+
+  await expect(
+    page.locator('[data-cy="shouldBeInvoicedToggle"]')
+  ).toBeChecked();
+
+  await logout(page);
+});

--- a/tests/e2e/recurring-expense.spec.ts
+++ b/tests/e2e/recurring-expense.spec.ts
@@ -712,6 +712,43 @@ test('Checking mark_paid expense settings value on recurring_expense creation pa
   await logout(page);
 });
 
+test('Checking convert_currency expense settings value on recurring_expense creation page', async ({
+  page,
+}) => {
+  await login(page);
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Settings', exact: true })
+    .click();
+
+  await page
+    .getByRole('link', { name: 'Expense Settings', exact: true })
+    .click();
+
+  if (!(await page.locator('[data-cy="convertCurrencyToggle"]').isChecked())) {
+    await page.locator('[data-cy="convertCurrencyToggle"]').check();
+
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    await expect(page.getByText('Successfully updated settings')).toBeVisible();
+  }
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Recurring Expenses', exact: true })
+    .click();
+
+  await page
+    .getByRole('main')
+    .getByRole('link', { name: 'New Recurring Expense' })
+    .click();
+
+  await expect(page.locator('[data-cy="convertCurrencyToggle"]')).toBeChecked();
+
+  await logout(page);
+});
+
 test('Checking add_documents_to_invoice expense settings value on recurring_expense creation page', async ({
   page,
 }) => {
@@ -749,6 +786,146 @@ test('Checking add_documents_to_invoice expense settings value on recurring_expe
   await expect(
     page.locator('[data-cy="addDocumentsToInvoiceToggle"]')
   ).toBeChecked();
+
+  await logout(page);
+});
+
+test('Checking the gross amount by rate', async ({ page }) => {
+  await login(page);
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Recurring Expenses', exact: true })
+    .click();
+
+  const tableBody = page.locator('tbody').first();
+
+  const tableRow = tableBody.getByRole('row').first();
+
+  await tableRow
+    .getByRole('button')
+    .filter({ has: page.getByText('More Actions') })
+    .first()
+    .click();
+
+  await page.getByText('Edit', { exact: true }).first().click();
+
+  await page.getByTestId('combobox-input-field').nth(5).click();
+  await page.getByText('tax_rate_10').click();
+  await page.getByTestId('combobox-input-field').nth(5).blur();
+
+  await page.getByTestId('combobox-input-field').nth(6).click();
+  await page.getByText('tax_rate_20').click();
+  await page.getByTestId('combobox-input-field').nth(6).blur();
+
+  await page.locator('[type="number"]').first().fill('12222');
+
+  await page
+    .locator('[data-cy="topNavbar"]')
+    .getByRole('button', { name: 'Save', exact: true })
+    .click();
+
+  await expect(
+    page.getByText('Successfully updated recurring expense', { exact: true })
+  ).toBeVisible();
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Recurring Expenses', exact: true })
+    .click();
+
+  await expect(page.getByText('$ 15,888.60')).toBeVisible();
+
+  await logout(page);
+});
+
+test('Checking the gross amount with inclusive taxes turned on', async ({
+  page,
+}) => {
+  await login(page);
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Recurring Expenses', exact: true })
+    .click();
+
+  const tableBody = page.locator('tbody').first();
+
+  const tableRow = tableBody.getByRole('row').first();
+
+  await tableRow
+    .getByRole('button')
+    .filter({ has: page.getByText('More Actions') })
+    .first()
+    .click();
+
+  await page.getByText('Edit', { exact: true }).first().click();
+
+  await page.locator('[data-cy="inclusiveTaxesToggle"]').first().check();
+
+  await page
+    .locator('[data-cy="topNavbar"]')
+    .getByRole('button', { name: 'Save', exact: true })
+    .click();
+
+  await expect(
+    page.getByText('Successfully updated recurring expense', { exact: true })
+  ).toBeVisible();
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Recurring Expenses', exact: true })
+    .click();
+
+  await expect(page.getByText('$ 12,222.00')).toBeVisible();
+
+  await logout(page);
+});
+
+test('Checking the gross amount by amount', async ({ page }) => {
+  await login(page);
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Recurring Expenses', exact: true })
+    .click();
+
+  const tableBody = page.locator('tbody').first();
+
+  const tableRow = tableBody.getByRole('row').first();
+
+  await tableRow
+    .getByRole('button')
+    .filter({ has: page.getByText('More Actions') })
+    .first()
+    .click();
+
+  await page.getByText('Edit', { exact: true }).first().click();
+
+  await page.locator('[data-cy="inclusiveTaxesToggle"]').first().uncheck();
+
+  await page.locator('#by_amount').click();
+
+  await page.locator('[data-cy="taxNameByAmount1"]').fill('tax_name_1');
+  await page.locator('[data-cy="taxRateByAmount1"]').fill('100');
+  await page.locator('[data-cy="taxNameByAmount2"]').fill('tax_name_2');
+  await page.locator('[data-cy="taxRateByAmount2"]').fill('200');
+
+  await page
+    .locator('[data-cy="topNavbar"]')
+    .getByRole('button', { name: 'Save', exact: true })
+    .click();
+
+  await expect(
+    page.getByText('Successfully updated recurring expense', { exact: true })
+  ).toBeVisible();
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Recurring Expenses', exact: true })
+    .click();
+
+  await expect(page.getByText('$ 12,522.00')).toBeVisible();
 
   await logout(page);
 });

--- a/tests/e2e/recurring-expense.spec.ts
+++ b/tests/e2e/recurring-expense.spec.ts
@@ -674,3 +674,81 @@ test('Checking should_be_invoiced expense settings value on recurring expense cr
 
   await logout(page);
 });
+
+test('Checking mark_paid expense settings value on recurring_expense creation page', async ({
+  page,
+}) => {
+  await login(page);
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Settings', exact: true })
+    .click();
+
+  await page
+    .getByRole('link', { name: 'Expense Settings', exact: true })
+    .click();
+
+  if (!(await page.locator('[data-cy="markPaidToggle"]').isChecked())) {
+    await page.locator('[data-cy="markPaidToggle"]').check();
+
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    await expect(page.getByText('Successfully updated settings')).toBeVisible();
+  }
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Recurring Expenses', exact: true })
+    .click();
+
+  await page
+    .getByRole('main')
+    .getByRole('link', { name: 'New Recurring Expense' })
+    .click();
+
+  await expect(page.locator('[data-cy="markPaidToggle"]')).toBeChecked();
+
+  await logout(page);
+});
+
+test('Checking add_documents_to_invoice expense settings value on recurring_expense creation page', async ({
+  page,
+}) => {
+  await login(page);
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Settings', exact: true })
+    .click();
+
+  await page
+    .getByRole('link', { name: 'Expense Settings', exact: true })
+    .click();
+
+  if (
+    !(await page.locator('[data-cy="addDocumentsToInvoiceToggle"]').isChecked())
+  ) {
+    await page.locator('[data-cy="addDocumentsToInvoiceToggle"]').check();
+
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    await expect(page.getByText('Successfully updated settings')).toBeVisible();
+  }
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Recurring Expenses', exact: true })
+    .click();
+
+  await page
+    .getByRole('main')
+    .getByRole('link', { name: 'New Recurring Expense' })
+    .click();
+
+  await expect(
+    page.locator('[data-cy="addDocumentsToInvoiceToggle"]')
+  ).toBeChecked();
+
+  await logout(page);
+});

--- a/tests/e2e/recurring-expense.spec.ts
+++ b/tests/e2e/recurring-expense.spec.ts
@@ -635,3 +635,42 @@ test('cloning recurring expense', async ({ page }) => {
     page.getByRole('heading', { name: 'Edit Recurring Expense' }).first()
   ).toBeVisible();
 });
+
+test('Checking should_be_invoiced expense settings value on recurring expense creation page', async ({
+  page,
+}) => {
+  await login(page);
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Settings', exact: true })
+    .click();
+
+  await page
+    .getByRole('link', { name: 'Expense Settings', exact: true })
+    .click();
+
+  if (!(await page.locator('[data-cy="shouldBeInvoicedToggle"]').isChecked())) {
+    await page.locator('[data-cy="shouldBeInvoicedToggle"]').check();
+
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    await expect(page.getByText('Successfully updated settings')).toBeVisible();
+  }
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Recurring Expenses', exact: true })
+    .click();
+
+  await page
+    .getByRole('main')
+    .getByRole('link', { name: 'New Recurring Expense' })
+    .click();
+
+  await expect(
+    page.locator('[data-cy="shouldBeInvoicedToggle"]')
+  ).toBeChecked();
+
+  await logout(page);
+});

--- a/tests/e2e/taxes-helpers.ts
+++ b/tests/e2e/taxes-helpers.ts
@@ -1,0 +1,38 @@
+import { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+
+interface TaxCreateParams {
+  page: Page;
+  taxName: string;
+  rate: number;
+}
+export const createTaxRate = async (params: TaxCreateParams) => {
+  const { page, taxName, rate } = params;
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Settings', exact: true })
+    .click();
+
+  await page.getByRole('link', { name: 'Tax Settings', exact: true }).click();
+
+  await page
+    .getByRole('main')
+    .getByRole('link', { name: 'New Tax Rate' })
+    .click();
+
+  await page.waitForTimeout(300);
+
+  await page.getByRole('main').locator('[type="text"]').first().fill(taxName);
+  await page
+    .getByRole('main')
+    .locator('[type="number"]')
+    .first()
+    .fill(rate.toString());
+
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
+
+  await expect(
+    page.getByText('Successfully created tax rate', { exact: true })
+  ).toBeVisible();
+};


### PR DESCRIPTION
@beganovich @turbo124 The client reported the issue on Slack (https://invoiceninja.slack.com/archives/C9KSLL0TE/p1707207816191849) that the expense amount does not include entered taxes by rate or by amount. On the table, we had only been showing the pure `expense.amount` value, and we didn't do anything with taxes there. So, I included calculations for taxes by rate or by amount to show the gross amount rather than the net amount. After implementation, I compared the results with the Flutter app, which always gave me exactly the same result. 

The exactly same issue occurred with Recurring Expenses and their amounts, so that has also been fixed.

Let me know your thoughts.