### PR TITLE
[Bugfix] Adding Permission On new_expense_category Action In Dropdown On Category Status Badge && Additional Tests

### DIFF
--- a/src/common/queries/expense-categories.ts
+++ b/src/common/queries/expense-categories.ts
@@ -14,7 +14,7 @@ import { useQuery } from 'react-query';
 import { Params } from './common/params.interface';
 import { ExpenseCategory } from '$app/common/interfaces/expense-category';
 import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-api-response';
-import { useAdmin } from '$app/common/hooks/permissions/useHasPermission';
+import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 import { toast } from '$app/common/helpers/toast/toast';
 import { $refetch } from '../hooks/useRefetch';
 
@@ -79,7 +79,7 @@ export function useBulkAction() {
 }
 
 export function useBlankExpenseCategoryQuery() {
-  const { isAdmin, isOwner } = useAdmin();
+  const hasPermission = useHasPermission();
 
   return useQuery<ExpenseCategory>(
     '/api/v1/expense_categories/create',
@@ -88,6 +88,6 @@ export function useBlankExpenseCategoryQuery() {
         (response: GenericSingleResourceResponse<ExpenseCategory>) =>
           response.data.data
       ),
-    { staleTime: Infinity, enabled: isAdmin || isOwner }
+    { staleTime: Infinity, enabled: hasPermission('create_expense') }
   );
 }

--- a/src/components/DataTableColumnsPicker.tsx
+++ b/src/components/DataTableColumnsPicker.tsx
@@ -149,6 +149,7 @@ export function DataTableColumnsPicker(props: Props) {
           onValueChange={handleSelectChange}
           value=""
           withBlank
+          cypressRef="columSelector"
         >
           {filteredColumns.map((column, index) => (
             <option key={index} value={column}>

--- a/src/components/dropdown/DropdownElement.tsx
+++ b/src/components/dropdown/DropdownElement.tsx
@@ -19,6 +19,7 @@ interface Props extends CommonProps {
   to?: string;
   setVisible?: (value: boolean) => any;
   icon?: ReactElement;
+  cypressRef?: string;
 }
 
 const Button = styled.button`
@@ -83,6 +84,7 @@ export function DropdownElement(props: Props) {
         },
         `w-full text-left z-50 block px-4 py-2 text-sm rounded-lg ${props.className} `
       )}
+      data-cy={props.cypressRef}
     >
       {props.icon}
       <div

--- a/src/components/expense-categories/ExpenseCategorySelector.tsx
+++ b/src/components/expense-categories/ExpenseCategorySelector.tsx
@@ -15,7 +15,7 @@ import { Dispatch, SetStateAction, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ComboboxAsync, Entry } from '../forms/Combobox';
 import { endpoint } from '$app/common/helpers';
-import { useAdmin } from '$app/common/hooks/permissions/useHasPermission';
+import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 
 export interface ExpenseCategorySelectorProps
   extends GenericSelectorProps<ExpenseCategory> {
@@ -30,7 +30,7 @@ export function ExpenseCategorySelector(props: ExpenseCategorySelectorProps) {
 
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const { isAdmin, isOwner } = useAdmin();
+  const hasPermission = useHasPermission();
 
   const perPageParameter =
     import.meta.env.VITE_IS_TEST === 'true' ? '&per_page=1' : '';
@@ -66,7 +66,7 @@ export function ExpenseCategorySelector(props: ExpenseCategorySelectorProps) {
           action={{
             label: t('new_expense_category'),
             onClick: () => setIsModalOpen(true),
-            visible: isAdmin || isOwner,
+            visible: hasPermission('create_expense'),
           }}
           readonly={props.readonly}
           onDismiss={props.onClearButtonClick}

--- a/src/pages/expenses/common/components/ExpenseCategory.tsx
+++ b/src/pages/expenses/common/components/ExpenseCategory.tsx
@@ -26,7 +26,7 @@ import { useSave } from '../../edit/hooks/useSave';
 import { useTranslation } from 'react-i18next';
 import { CreateExpenseCategoryModal } from '$app/pages/settings/expense-categories/components/CreateExpenseCategoryModal';
 import { ExpenseCategory as ExpenseCategoryType } from '$app/common/interfaces/expense-category';
-import { useAdmin } from '$app/common/hooks/permissions/useHasPermission';
+import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 
 interface DropdownProps {
   visible: boolean;
@@ -40,7 +40,7 @@ function ExpenseCategoriesDropdown(props: DropdownProps) {
   const [t] = useTranslation();
   const colors = useColorScheme();
 
-  const { isAdmin, isOwner } = useAdmin();
+  const hasPermission = useHasPermission();
 
   const adjustColorDarkness = useAdjustColorDarkness();
 
@@ -73,7 +73,7 @@ function ExpenseCategoriesDropdown(props: DropdownProps) {
               maxWidth: '20rem',
             }}
           >
-            {(isAdmin || isOwner) && (
+            {hasPermission('create_expense') && (
               <DropdownElement
                 className="font-medium text-center py-3"
                 onClick={() => {

--- a/src/pages/expenses/common/components/ExpenseCategory.tsx
+++ b/src/pages/expenses/common/components/ExpenseCategory.tsx
@@ -26,6 +26,7 @@ import { useSave } from '../../edit/hooks/useSave';
 import { useTranslation } from 'react-i18next';
 import { CreateExpenseCategoryModal } from '$app/pages/settings/expense-categories/components/CreateExpenseCategoryModal';
 import { ExpenseCategory as ExpenseCategoryType } from '$app/common/interfaces/expense-category';
+import { useAdmin } from '$app/common/hooks/permissions/useHasPermission';
 
 interface DropdownProps {
   visible: boolean;
@@ -38,6 +39,8 @@ interface DropdownProps {
 function ExpenseCategoriesDropdown(props: DropdownProps) {
   const [t] = useTranslation();
   const colors = useColorScheme();
+
+  const { isAdmin, isOwner } = useAdmin();
 
   const adjustColorDarkness = useAdjustColorDarkness();
 
@@ -70,15 +73,18 @@ function ExpenseCategoriesDropdown(props: DropdownProps) {
               maxWidth: '20rem',
             }}
           >
-            <DropdownElement
-              className="font-medium text-center py-3"
-              onClick={() => {
-                setIsModalOpen(true);
-                setVisible(false);
-              }}
-            >
-              {t('new_expense_category')}
-            </DropdownElement>
+            {(isAdmin || isOwner) && (
+              <DropdownElement
+                className="font-medium text-center py-3"
+                onClick={() => {
+                  setIsModalOpen(true);
+                  setVisible(false);
+                }}
+                cypressRef="newExpenseCategoryAction"
+              >
+                {t('new_expense_category')}
+              </DropdownElement>
+            )}
 
             <div className="flex flex-col max-h-80 overflow-y-auto">
               {expenseCategories?.map(
@@ -100,7 +106,7 @@ function ExpenseCategoriesDropdown(props: DropdownProps) {
         )}
         visible={visible}
       >
-        <div className="cursor-pointer">
+        <div className="cursor-pointer" data-cy="expenseCategoryBadge">
           <StatusBadge
             for={{}}
             code={expense.category?.name || (t('uncategorized') as string)}

--- a/src/pages/expenses/common/components/ExpenseCategory.tsx
+++ b/src/pages/expenses/common/components/ExpenseCategory.tsx
@@ -106,11 +106,7 @@ function ExpenseCategoriesDropdown(props: DropdownProps) {
         )}
         visible={visible}
       >
-        <div
-          className="cursor-pointer"
-          onClick={(event) => event.stopPropagation()}
-          data-cy="expenseCategoryBadge"
-        >
+        <div className="cursor-pointer" data-cy="expenseCategoryBadge">
           <StatusBadge
             for={{}}
             code={expense.category?.name || (t('uncategorized') as string)}

--- a/src/pages/expenses/common/components/ExpenseCategory.tsx
+++ b/src/pages/expenses/common/components/ExpenseCategory.tsx
@@ -59,7 +59,7 @@ function ExpenseCategoriesDropdown(props: DropdownProps) {
   const darknessAmount = isColorLight(red, green, blue) ? -220 : 220;
 
   return (
-    <>
+    <div onClick={(event) => event.stopPropagation()}>
       <Tippy
         placement="bottom"
         interactive={true}
@@ -106,7 +106,11 @@ function ExpenseCategoriesDropdown(props: DropdownProps) {
         )}
         visible={visible}
       >
-        <div className="cursor-pointer" data-cy="expenseCategoryBadge">
+        <div
+          className="cursor-pointer"
+          onClick={(event) => event.stopPropagation()}
+          data-cy="expenseCategoryBadge"
+        >
           <StatusBadge
             for={{}}
             code={expense.category?.name || (t('uncategorized') as string)}
@@ -114,7 +118,10 @@ function ExpenseCategoriesDropdown(props: DropdownProps) {
               color: adjustColorDarkness(hex, darknessAmount),
               backgroundColor: expense.category?.color || '',
             }}
-            onClick={() => !isFormBusy && setVisible(true)}
+            onClick={() =>
+              !isFormBusy &&
+              setVisible((currentVisibility) => !currentVisibility)
+            }
           />
         </div>
       </Tippy>
@@ -126,7 +133,7 @@ function ExpenseCategoriesDropdown(props: DropdownProps) {
           save({ ...expense, category_id: category.id })
         }
       />
-    </>
+    </div>
   );
 }
 

--- a/tests/e2e/expenses.spec.ts
+++ b/tests/e2e/expenses.spec.ts
@@ -673,3 +673,79 @@ test('Expense categories endpoint contains with but not sort parameter', async (
 
   await logout(page);
 });
+
+test('The new_expense_category action is not shown on the badge dropdown', async ({
+  page,
+}) => {
+  const { clear, save, set } = permissions(page);
+
+  await login(page);
+  await clear('expenses@example.com');
+  await set('edit_expense');
+  await save();
+
+  await logout(page);
+
+  await login(page, 'expenses@example.com', 'password');
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Expenses', exact: true })
+    .click();
+
+  await page.waitForTimeout(200);
+
+  await page.getByRole('button', { name: 'Columns', exact: true }).click();
+
+  await page.waitForTimeout(100);
+
+  await page
+    .locator('[data-cy="columSelector"]')
+    .selectOption({ label: 'Category' });
+
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
+
+  await expect(
+    page.getByText('Successfully saved settings').first()
+  ).toBeVisible();
+
+  await page.waitForTimeout(200);
+
+  await page.locator('[data-cy="expenseCategoryBadge"]').first().click();
+
+  await expect(
+    page.locator('[data-cy="newExpenseCategoryAction"]').first()
+  ).not.toBeVisible();
+
+  await logout(page);
+});
+
+test('The new_expense_category action is shown on the badge dropdown', async ({
+  page,
+}) => {
+  const { clear, save, set } = permissions(page);
+
+  await login(page);
+  await clear('expenses@example.com');
+  await set('admin');
+  await save();
+
+  await logout(page);
+
+  await login(page, 'expenses@example.com', 'password');
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Expenses', exact: true })
+    .click();
+
+  await page.waitForTimeout(200);
+
+  await page.locator('[data-cy="expenseCategoryBadge"]').first().click();
+
+  await expect(
+    page.locator('[data-cy="newExpenseCategoryAction"]').first()
+  ).toBeVisible();
+
+  await logout(page);
+});

--- a/tests/e2e/expenses.spec.ts
+++ b/tests/e2e/expenses.spec.ts
@@ -749,3 +749,33 @@ test('The new_expense_category action is shown on the badge dropdown', async ({
 
   await logout(page);
 });
+
+test('The new_expense_category action is shown on the badge dropdown with only create_expense permission', async ({
+  page,
+}) => {
+  const { clear, save, set } = permissions(page);
+
+  await login(page);
+  await clear('expenses@example.com');
+  await set('create_expense');
+  await save();
+
+  await logout(page);
+
+  await login(page, 'expenses@example.com', 'password');
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Expenses', exact: true })
+    .click();
+
+  await page.waitForTimeout(200);
+
+  await page.locator('[data-cy="expenseCategoryBadge"]').first().click();
+
+  await expect(
+    page.locator('[data-cy="newExpenseCategoryAction"]').first()
+  ).toBeVisible();
+
+  await logout(page);
+});


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adding permission for the `new_expense_category` action in the dropdown on the category status badge. So, this action should only be displayed if the user is an `admin` or `owner` because it is the only permission that can create the expense category. Additionally, I've added two tests to check the visibility of the action. Screenshot:

![Screenshot 2024-02-09 at 16 45 26](https://github.com/invoiceninja/ui/assets/51542191/f4acb45e-0d06-4557-9213-2618554e52f3)

Let me know your thoughts.