### PR TITLE
[Bugfix] Webhook URL Text Wrapping

### DIFF
--- a/src/pages/settings/gateways/edit/components/WebhookConfiguration.tsx
+++ b/src/pages/settings/gateways/edit/components/WebhookConfiguration.tsx
@@ -30,6 +30,7 @@ export function WebhookConfiguration(props: Props) {
     <Card title={t('webhooks')}>
       <Element leftSide={t('webhook_url')}>
         <CopyToClipboard
+          className="break-all"
           text={`${apiEndpoint()}/payment_webhook/${company.company_key}/${
             props.companyGateway.id
           }`}


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for the webhook URL text wrapping issue. Screenshot:

<img width="810" alt="Screenshot 2024-02-11 at 18 44 57" src="https://github.com/invoiceninja/ui/assets/51542191/0374a4ac-b640-494d-bb22-d3ee1ed04ec3">

Let me know your thoughts.