### PR TITLE
[Bugfix] Classification Field Validation

### DIFF
--- a/src/pages/vendors/edit/components/Form.tsx
+++ b/src/pages/vendors/edit/components/Form.tsx
@@ -172,6 +172,7 @@ export function Form(props: Props) {
               id="classification"
               defaultValue={vendor.classification ?? ''}
               onValueChange={(value) => handleChange('classification', value)}
+              errorMessage={errors?.errors.classification}
             >
               <option value=""></option>
               <option value="individual">{t('individual')}</option>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the addition of missing validation to the `classification` vendor field. Screenshot:

![Screenshot 2024-02-12 at 19 34 50](https://github.com/invoiceninja/ui/assets/51542191/20f58106-3a5b-44b3-b4f1-79853a01ed10)

Note: I've checked out all the other vendor fields, and this is the only one that missed the errorMessage prop.

Let me know your thoughts.