### PR TITLE
[Cleanup] Adjusting Logic For Manipulation With Line Items Without Selecting Client/Vendor

### DIFF
--- a/src/common/helpers/country/country-resolver.ts
+++ b/src/common/helpers/country/country-resolver.ts
@@ -1,0 +1,27 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { useStaticsQuery } from '$app/common/queries/statics';
+
+export function useCountryResolver() {
+  const statics = useStaticsQuery();
+
+  const find = (id: string) => {
+    if (statics) {
+      return Promise.resolve(
+        statics.data?.countries.find((country) => country.id === id)
+      );
+    }
+
+    return Promise.resolve(undefined);
+  };
+
+  return { find };
+}

--- a/src/pages/invoices/common/components/ProductsTable.tsx
+++ b/src/pages/invoices/common/components/ProductsTable.tsx
@@ -22,7 +22,6 @@ import { resolveColumnWidth } from '../helpers/resolve-column-width';
 import { Invoice } from '$app/common/interfaces/invoice';
 import { InvoiceItem } from '$app/common/interfaces/invoice-item';
 import { RecurringInvoice } from '$app/common/interfaces/recurring-invoice';
-import { Fragment } from 'react';
 import { PurchaseOrder } from '$app/common/interfaces/purchase-order';
 import { atom, useSetAtom } from 'jotai';
 import classNames from 'classnames';
@@ -110,115 +109,92 @@ export function ProductsTable(props: Props) {
         <Droppable droppableId="product-table">
           {(provided) => (
             <Tbody {...provided.droppableProps} innerRef={provided.innerRef}>
-              {resource?.[relationType] ? (
-                items.map((lineItem, index) => (
-                  <Draggable
-                    key={getLineItemIndex(lineItem)}
-                    draggableId={getLineItemIndex(lineItem).toString()}
-                    index={getLineItemIndex(lineItem)}
-                  >
-                    {(provided) => (
-                      <Tr
-                        innerRef={provided.innerRef}
-                        key={getLineItemIndex(lineItem)}
-                        tabIndex={index + 1}
-                        {...provided.draggableProps}
-                      >
-                        {columns.map((column, columnIndex, { length }) => (
-                          <Td
-                            width={resolveColumnWidth(column)}
-                            key={columnIndex}
-                          >
-                            {length - 1 !== columnIndex && (
-                              <div
-                                className={classNames({
-                                  'flex justify-between items-center space-x-3':
-                                    columnIndex === 0,
-                                })}
-                              >
-                                {columnIndex === 0 ? (
-                                  <button {...provided.dragHandleProps}>
-                                    <AlignJustify size={18} />
-                                  </button>
-                                ) : null}
+              {items.map((lineItem, index) => (
+                <Draggable
+                  key={getLineItemIndex(lineItem)}
+                  draggableId={getLineItemIndex(lineItem).toString()}
+                  index={getLineItemIndex(lineItem)}
+                >
+                  {(provided) => (
+                    <Tr
+                      innerRef={provided.innerRef}
+                      key={getLineItemIndex(lineItem)}
+                      tabIndex={index + 1}
+                      {...provided.draggableProps}
+                    >
+                      {columns.map((column, columnIndex, { length }) => (
+                        <Td
+                          width={resolveColumnWidth(column)}
+                          key={columnIndex}
+                        >
+                          {length - 1 !== columnIndex && (
+                            <div
+                              className={classNames({
+                                'flex justify-between items-center space-x-3':
+                                  columnIndex === 0,
+                              })}
+                            >
+                              {columnIndex === 0 ? (
+                                <button {...provided.dragHandleProps}>
+                                  <AlignJustify size={18} />
+                                </button>
+                              ) : null}
 
-                                {resolveInputField(
-                                  column,
-                                  getLineItemIndex(lineItem)
-                                )}
-                              </div>
-                            )}
+                              {resolveInputField(
+                                column,
+                                getLineItemIndex(lineItem)
+                              )}
+                            </div>
+                          )}
 
-                            {length - 1 === columnIndex && (
-                              <div className="flex justify-between items-center">
-                                {resolveInputField(
-                                  column,
-                                  getLineItemIndex(lineItem)
-                                )}
+                          {length - 1 === columnIndex && (
+                            <div className="flex justify-between items-center">
+                              {resolveInputField(
+                                column,
+                                getLineItemIndex(lineItem)
+                              )}
 
-                                {resource && (
-                                  <button
-                                    style={{ color: colors.$3 }}
-                                    className="ml-2 text-gray-600 hover:text-red-600"
-                                    onClick={() => {
-                                      setIsDeleteActionTriggered(true);
+                              {resource && (
+                                <button
+                                  style={{ color: colors.$3 }}
+                                  className="ml-2 text-gray-600 hover:text-red-600"
+                                  onClick={() => {
+                                    setIsDeleteActionTriggered(true);
 
-                                      props.onDeleteRowClick(
-                                        getLineItemIndex(lineItem)
-                                      );
-                                    }}
-                                  >
-                                    <Trash2 size={18} />
-                                  </button>
-                                )}
-                              </div>
-                            )}
-                          </Td>
-                        ))}
-                      </Tr>
-                    )}
-                  </Draggable>
-                ))
-              ) : (
-                <Fragment />
-              )}
+                                    props.onDeleteRowClick(
+                                      getLineItemIndex(lineItem)
+                                    );
+                                  }}
+                                >
+                                  <Trash2 size={18} />
+                                </button>
+                              )}
+                            </div>
+                          )}
+                        </Td>
+                      ))}
+                    </Tr>
+                  )}
+                </Draggable>
+              ))}
 
               {provided.placeholder}
 
-              {resource?.[relationType] ? (
-                <Tr className="bg-slate-100 hover:bg-slate-200">
-                  <Td colSpan={100}>
-                    <button
-                      onClick={() =>
-                        !isAnyLineItemEmpty() && props.onCreateItemClick()
-                      }
-                      className="w-full py-2 inline-flex justify-center items-center space-x-2"
-                    >
-                      <Plus size={18} />
-                      <span>
-                        {props.type === 'product'
-                          ? t('add_item')
-                          : t('add_line')}
-                      </span>
-                    </button>
-                  </Td>
-                </Tr>
-              ) : (
-                <Fragment />
-              )}
-
-              {!resource?.[relationType] ? (
-                <Tr>
-                  <Td colSpan={100}>
-                    {props.relationType === 'vendor_id'
-                      ? t('please_select_a_vendor')
-                      : t('please_select_a_client')}
-                    .
-                  </Td>
-                </Tr>
-              ) : (
-                <Fragment />
-              )}
+              <Tr className="bg-slate-100 hover:bg-slate-200">
+                <Td colSpan={100}>
+                  <button
+                    onClick={() =>
+                      !isAnyLineItemEmpty() && props.onCreateItemClick()
+                    }
+                    className="w-full py-2 inline-flex justify-center items-center space-x-2"
+                  >
+                    <Plus size={18} />
+                    <span>
+                      {props.type === 'product' ? t('add_item') : t('add_line')}
+                    </span>
+                  </button>
+                </Td>
+              </Tr>
             </Tbody>
           )}
         </Droppable>

--- a/src/pages/invoices/common/hooks/useFormatMoney.ts
+++ b/src/pages/invoices/common/hooks/useFormatMoney.ts
@@ -11,8 +11,6 @@
 import { Number as NumberHelper } from '$app/common/helpers/number';
 import { useClientResolver } from '$app/common/hooks/clients/useClientResolver';
 import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
-import { useResolveCountry } from '$app/common/hooks/useResolveCountry';
-import { useResolveCurrency } from '$app/common/hooks/useResolveCurrency';
 import { useVendorResolver } from '$app/common/hooks/vendors/useVendorResolver';
 import { Client } from '$app/common/interfaces/client';
 import { Country } from '$app/common/interfaces/country';
@@ -23,6 +21,8 @@ import {
   ProductTableResource,
   RelationType,
 } from '../components/ProductsTable';
+import { useCurrencyResolver } from '$app/common/helpers/currencies/currency-resolver';
+import { useCountryResolver } from '$app/common/helpers/country/country-resolver';
 
 interface Props {
   resource: ProductTableResource | undefined;
@@ -32,8 +32,8 @@ interface Props {
 export function useFormatMoney(props: Props) {
   const company = useCurrentCompany();
 
-  const currencyResolver = useResolveCurrency();
-  const countryResolver = useResolveCountry();
+  const currencyResolver = useCurrencyResolver();
+  const countryResolver = useCountryResolver();
   const vendorResolver = useVendorResolver();
   const clientResolver = useClientResolver();
 
@@ -64,30 +64,28 @@ export function useFormatMoney(props: Props) {
   }, [resource?.client_id, resource?.vendor_id]);
 
   useEffect(() => {
-    if (relation && relationType === 'client_id') {
-      const client = relation as Client;
+    if (relationType === 'client_id') {
+      const client = relation as Client | undefined;
 
-      setCurrency(
-        currencyResolver(
-          client.settings.currency_id || company?.settings.currency_id
-        )
-      );
+      currencyResolver
+        .find(client?.settings.currency_id || company?.settings.currency_id)
+        .then((currencyResponse) => setCurrency(currencyResponse));
 
-      setCountry(
-        countryResolver(client.country_id || company?.settings.country_id)
-      );
+      countryResolver
+        .find(client?.country_id || company?.settings.country_id)
+        .then((countryResponse) => setCountry(countryResponse));
     }
 
-    if (relation && relationType === 'vendor_id') {
-      const vendor = relation as Vendor;
+    if (relationType === 'vendor_id') {
+      const vendor = relation as Vendor | undefined;
 
-      setCurrency(
-        currencyResolver(vendor.currency_id || company?.settings.currency_id)
-      );
+      currencyResolver
+        .find(vendor?.currency_id || company?.settings.currency_id)
+        .then((currencyResponse) => setCurrency(currencyResponse));
 
-      setCountry(
-        countryResolver(vendor.country_id || company?.settings.country_id)
-      );
+      countryResolver
+        .find(vendor?.country_id || company?.settings.country_id)
+        .then((countryResponse) => setCountry(countryResponse));
     }
   }, [relation]);
 

--- a/src/pages/invoices/common/hooks/useResolveInputField.tsx
+++ b/src/pages/invoices/common/hooks/useResolveInputField.tsx
@@ -55,6 +55,12 @@ const numberInputs = [
 
 const taxInputs = ['tax_rate1', 'tax_rate2', 'tax_rate3'];
 
+const defaultCurrencySeparators: DecimalInputSeparators = {
+  decimalSeparator: '.',
+  precision: 2,
+  thousandSeparator: ',',
+};
+
 interface Props {
   resource: ProductTableResource;
   type: 'product' | 'task';
@@ -176,29 +182,28 @@ export function useResolveInputField(props: Props) {
     setIsDeleteActionTriggered(false);
 
     if (product && company && company.enabled_tax_rates === 0) {
-        product.tax_name1 = '';
-        product.tax_rate1 = 0;
-        product.tax_name2 = '';
-        product.tax_rate2 = 0;
-        product.tax_name3 = '';
-        product.tax_rate3 = 0;
+      product.tax_name1 = '';
+      product.tax_rate1 = 0;
+      product.tax_name2 = '';
+      product.tax_rate2 = 0;
+      product.tax_name3 = '';
+      product.tax_rate3 = 0;
     }
 
     if (product && company && company.enabled_tax_rates === 1) {
-        product.tax_name2 = '';
-        product.tax_rate2 = 0;
-        product.tax_name3 = '';
-        product.tax_rate3 = 0;
+      product.tax_name2 = '';
+      product.tax_rate2 = 0;
+      product.tax_name3 = '';
+      product.tax_rate3 = 0;
     }
 
     if (product && company && company.enabled_tax_rates === 2) {
-        product.tax_name3 = '';
-        product.tax_rate3 = 0;
+      product.tax_name3 = '';
+      product.tax_rate3 = 0;
     }
 
     await handleProductChange(index, value, product);
   };
-
 
   const formatMoney = useFormatMoney({
     resource: props.resource,
@@ -208,8 +213,11 @@ export function useResolveInputField(props: Props) {
   const getCurrency = useGetCurrencySeparators(setInputCurrencySeparators);
 
   useEffect(() => {
-    resource[props.relationType] &&
+    if (resource[props.relationType]) {
       getCurrency(resource[props.relationType], props.relationType);
+    } else {
+      setInputCurrencySeparators(defaultCurrencySeparators);
+    }
   }, [resource?.[props.relationType]]);
 
   useEffect(() => {


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adjusting the logic for manipulation with line_items on creation pages when the client/vendor is not selected. The only thing that is important to mention is that the formatting of money is done with company settings details (currency_id and country_id) instead of using client/vendor details for doing it. Once the user selects the client/vendor, formatting will be done using those details. Let me know your thoughts.