### PR TITLE
[Cleanup] Adding Missing Classification Options For Client/Vendor/Company

### DIFF
--- a/src/pages/clients/edit/components/Details.tsx
+++ b/src/pages/clients/edit/components/Details.tsx
@@ -188,10 +188,11 @@ export function Details(props: Props) {
           id="classification"
           defaultValue={props.client?.classification ?? ''}
           onChange={handleChange}
+          withBlank
         >
-          <option value=""></option>
           <option value="individual">{t('individual')}</option>
           <option value="business">{t('business')}</option>
+          <option value="company">{t('company')}</option>
           <option value="partnership">{t('partnership')}</option>
           <option value="trust">{t('trust')}</option>
           <option value="charity">{t('charity')}</option>

--- a/src/pages/settings/company/components/Details.tsx
+++ b/src/pages/settings/company/components/Details.tsx
@@ -260,10 +260,11 @@ export function Details() {
                 handleChange('settings.classification', value.toString())
               }
               disabled={disableSettingsField('classification')}
+              withBlank
             >
-              <option value=""></option>
               <option value="individual">{t('individual')}</option>
               <option value="business">{t('business')}</option>
+              <option value="company">{t('company')}</option>
               <option value="partnership">{t('partnership')}</option>
               <option value="trust">{t('trust')}</option>
               <option value="charity">{t('charity')}</option>

--- a/src/pages/vendors/edit/components/Form.tsx
+++ b/src/pages/vendors/edit/components/Form.tsx
@@ -173,14 +173,16 @@ export function Form(props: Props) {
               defaultValue={vendor.classification ?? ''}
               onValueChange={(value) => handleChange('classification', value)}
               errorMessage={errors?.errors.classification}
+              withBlank
             >
-              <option value=""></option>
               <option value="individual">{t('individual')}</option>
               <option value="business">{t('business')}</option>
+              <option value="company">{t('company')}</option>
               <option value="partnership">{t('partnership')}</option>
               <option value="trust">{t('trust')}</option>
               <option value="charity">{t('charity')}</option>
               <option value="government">{t('government')}</option>
+              <option value="other">{t('other')}</option>
             </SelectField>
           </Element>
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adding missing classification options for Client/Vendor/Company entities. So, currently, we have `individual`, `business`, `company`, `partnership`, `trust`, `charity`, `government`, and `other` options available. Screenshot:

![Screenshot 2024-02-13 at 19 54 53](https://github.com/invoiceninja/ui/assets/51542191/f358625b-6173-4143-b8fc-0066f2e1ed13)

Let me know your thoughts.