### PR TITLE
[Cleanup] Custom Templates Labels && Test Adjustment

### DIFF
--- a/src/pages/invoices/common/components/SendEmailModal.tsx
+++ b/src/pages/invoices/common/components/SendEmailModal.tsx
@@ -49,15 +49,24 @@ function useAvailableTypes() {
   ];
 
   if (company?.settings.email_subject_custom1) {
-    types.push({ label: 'first_custom', value: 'custom1' });
+    types.push({
+      label: company?.settings.email_subject_custom1,
+      value: 'custom1',
+    });
   }
 
   if (company?.settings.email_subject_custom2) {
-    types.push({ label: 'second_custom', value: 'custom2' });
+    types.push({
+      label: company?.settings.email_subject_custom2,
+      value: 'custom2',
+    });
   }
 
   if (company?.settings.email_subject_custom3) {
-    types.push({ label: 'third_custom', value: 'custom3' });
+    types.push({
+      label: company?.settings.email_subject_custom3,
+      value: 'custom3',
+    });
   }
 
   return types;

--- a/src/pages/invoices/email/components/Mailer.tsx
+++ b/src/pages/invoices/email/components/Mailer.tsx
@@ -136,19 +136,19 @@ export const Mailer = forwardRef<MailerComponent, Props>((props, ref) => {
 
               {company?.settings.email_subject_custom1 && (
                 <option value="email_template_custom1">
-                  {t('first_custom')}
+                  {company?.settings.email_subject_custom1}
                 </option>
               )}
 
               {company?.settings.email_subject_custom2 && (
                 <option value="email_template_custom2">
-                  {t('second_custom')}
+                  {company?.settings.email_subject_custom2}
                 </option>
               )}
 
               {company?.settings.email_subject_custom3 && (
                 <option value="email_template_custom3">
-                  {t('third_custom')}
+                  {company?.settings.email_subject_custom3}
                 </option>
               )}
             </SelectField>

--- a/tests/e2e/invoices.spec.ts
+++ b/tests/e2e/invoices.spec.ts
@@ -843,8 +843,8 @@ test('Second and Third Custom email sending template is displayed', async ({
 
   await page.getByRole('button', { name: 'Send Email', exact: true }).click();
 
-  await expect(page.getByText('Second Custom')).toBeVisible();
-  await expect(page.getByText('Third Custom')).toBeVisible();
+  await expect(page.getByText('testing subject second custom')).toBeVisible();
+  await expect(page.getByText('testing subject third custom')).toBeVisible();
 
   await logout(page);
 });


### PR DESCRIPTION
@beganovich @turbo124 The PR includes changing labels for custom templates when sending email. So, until now, the label will be entered in the subject on the templates_and_reminders page. Screenshots:

![Screenshot 2024-02-14 at 02 29 21](https://github.com/invoiceninja/ui/assets/51542191/56e588b0-d741-45fc-b70a-5951843244c9)

![Screenshot 2024-02-14 at 02 52 23](https://github.com/invoiceninja/ui/assets/51542191/dc2e4dda-4dd1-414a-b338-72782dad3a7f)

Let me know your thoughts.