### PR TITLE
[Feature] Payment Slider

### DIFF
--- a/src/common/interfaces/payment-activity.ts
+++ b/src/common/interfaces/payment-activity.ts
@@ -1,0 +1,28 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+export interface PaymentActivity {
+  user: Client;
+  contact: Client;
+  client: Client;
+  invoice: Client;
+  activity_type_id: number;
+  id: string;
+  hashed_id: string;
+  notes: string;
+  created_at: number;
+  ip: string;
+  payment_amount: number;
+}
+
+interface Client {
+  label: string;
+  hashed_id: string;
+}

--- a/src/common/interfaces/payment-activity.ts
+++ b/src/common/interfaces/payment-activity.ts
@@ -13,6 +13,7 @@ export interface PaymentActivity {
   contact: Client;
   client: Client;
   invoice: Client;
+  payment: Client;
   activity_type_id: number;
   id: string;
   hashed_id: string;

--- a/src/common/queries/payments.ts
+++ b/src/common/queries/payments.ts
@@ -29,7 +29,7 @@ interface PaymentParams {
 
 export function usePaymentQuery(params: PaymentParams) {
   return useQuery(
-    ['/api/v1/payments', params.id],
+    ['/api/v1/payments', params],
     () =>
       request(
         'GET',

--- a/src/common/queries/payments.ts
+++ b/src/common/queries/payments.ts
@@ -24,6 +24,7 @@ import { $refetch } from '../hooks/useRefetch';
 interface PaymentParams {
   id: string | undefined;
   enabled?: boolean;
+  include?: string;
 }
 
 export function usePaymentQuery(params: PaymentParams) {
@@ -32,9 +33,13 @@ export function usePaymentQuery(params: PaymentParams) {
     () =>
       request(
         'GET',
-        endpoint('/api/v1/payments/:id?include=client,invoices,paymentables', {
-          id: params.id,
-        })
+        endpoint(
+          '/api/v1/payments/:id?include=client,invoices,paymentables,:include',
+          {
+            id: params.id,
+            include: params.include || '',
+          }
+        )
       ).then(
         (response: GenericSingleResourceResponse<Payment>) => response.data.data
       ),

--- a/src/pages/payments/common/components/PaymentSlider.tsx
+++ b/src/pages/payments/common/components/PaymentSlider.tsx
@@ -22,7 +22,6 @@ import { useQuery } from 'react-query';
 import { request } from '$app/common/helpers/request';
 import { GenericManyResponse } from '$app/common/interfaces/generic-many-response';
 import { AxiosResponse } from 'axios';
-import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-api-response';
 import { NonClickableElement } from '$app/components/cards/NonClickableElement';
 import { Link } from '$app/components/forms';
 import dayjs from 'dayjs';
@@ -123,19 +122,6 @@ export function PaymentSlider() {
 
   const [payment, setPayment] = useAtom(paymentSliderAtom);
   const [isVisible, setIsSliderVisible] = useAtom(paymentSliderVisibilityAtom);
-
-  const { data: resource } = useQuery({
-    queryKey: ['/api/v1/payments', payment?.id, 'slider'],
-    queryFn: () =>
-      request(
-        'GET',
-        endpoint(`/api/v1/payments/${payment?.id}?include=invoices,credits`)
-      ).then(
-        (response: GenericSingleResourceResponse<Payment>) => response.data.data
-      ),
-    enabled: payment !== null && isVisible,
-    staleTime: Infinity,
-  });
 
   const { data: activities } = useQuery({
     queryKey: ['/api/v1/activities', payment?.id, 'payment'],
@@ -246,10 +232,10 @@ export function PaymentSlider() {
             ))}
           </div>
 
-          {resource?.credits?.length && <Divider withoutPadding />}
+          {Boolean(payment?.credits?.length) && <Divider withoutPadding />}
 
           <div className="flex flex-col space-y-2">
-            {resource?.credits?.map((credit, index) => (
+            {payment?.credits?.map((credit, index) => (
               <ClickableElement
                 key={index}
                 to={route('/credits/:id/edit', {

--- a/src/pages/payments/common/components/PaymentSlider.tsx
+++ b/src/pages/payments/common/components/PaymentSlider.tsx
@@ -1,0 +1,289 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { useFormatMoney } from '$app/common/hooks/money/useFormatMoney';
+import { Invoice } from '$app/common/interfaces/invoice';
+import { TabGroup } from '$app/components/TabGroup';
+import { ClickableElement, Element } from '$app/components/cards';
+import { Divider } from '$app/components/cards/Divider';
+import { Slider } from '$app/components/cards/Slider';
+import { atom, useAtom } from 'jotai';
+import { useTranslation } from 'react-i18next';
+import { useCurrentCompanyDateFormats } from '$app/common/hooks/useCurrentCompanyDateFormats';
+import { date, endpoint, trans } from '$app/common/helpers';
+import { ResourceActions } from '$app/components/ResourceActions';
+import { useQuery, useQueryClient } from 'react-query';
+import { request } from '$app/common/helpers/request';
+import { GenericManyResponse } from '$app/common/interfaces/generic-many-response';
+import { AxiosResponse } from 'axios';
+import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-api-response';
+import { NonClickableElement } from '$app/components/cards/NonClickableElement';
+import { Link } from '$app/components/forms';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import { route } from '$app/common/helpers/route';
+import reactStringReplace from 'react-string-replace';
+import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
+import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
+import { useDisableNavigation } from '$app/common/hooks/useDisableNavigation';
+import { DynamicLink } from '$app/components/DynamicLink';
+import { EmailRecord } from '$app/components/EmailRecord';
+import { useEffect, useState } from 'react';
+import { EmailRecord as EmailRecordType } from '$app/common/interfaces/email-history';
+import { QuoteActivity } from '$app/common/interfaces/quote-activity';
+import { Payment } from '$app/common/interfaces/payment';
+import { useActions } from '../hooks/useActions';
+import { PaymentStatus } from './PaymentStatus';
+
+export const paymentSliderAtom = atom<Payment | null>(null);
+export const paymentSliderVisibilityAtom = atom(false);
+
+dayjs.extend(relativeTime);
+
+function useGenerateActivityElement() {
+  const [t] = useTranslation();
+
+  return (activity: QuoteActivity) => {
+    let text = trans(`activity_${activity.activity_type_id}`, {});
+
+    const replacements = {
+      client: (
+        <Link to={route('/clients/:id', { id: activity.client?.hashed_id })}>
+          {activity.client?.label}
+        </Link>
+      ),
+      user: activity.user?.label ?? t('system'),
+      quote:
+        (
+          <Link
+            to={route('/quotes/:id/edit', {
+              id: activity.quote?.hashed_id,
+            })}
+          >
+            {activity?.quote?.label}
+          </Link>
+        ) ?? '',
+      contact:
+        (
+          <Link
+            to={route('/clients/:id/edit', {
+              id: activity?.contact?.hashed_id,
+            })}
+          >
+            {activity?.contact?.label}
+          </Link>
+        ) ?? '',
+    };
+    for (const [variable, value] of Object.entries(replacements)) {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      text = reactStringReplace(text, `:${variable}`, () => value);
+    }
+
+    return text;
+  };
+}
+
+export function PaymentSlider() {
+  const [t] = useTranslation();
+  const queryClient = useQueryClient();
+
+  const actions = useActions({
+    showCommonBulkAction: true,
+    showEditAction: true,
+  });
+  const { dateFormat } = useCurrentCompanyDateFormats();
+
+  const formatMoney = useFormatMoney();
+  const hasPermission = useHasPermission();
+  const entityAssigned = useEntityAssigned();
+  const disableNavigation = useDisableNavigation();
+  const activityElement = useGenerateActivityElement();
+
+  const [payment, setPayment] = useAtom(paymentSliderAtom);
+  const [isVisible, setIsSliderVisible] = useAtom(paymentSliderVisibilityAtom);
+
+  const [emailRecords, setEmailRecords] = useState<EmailRecordType[]>([]);
+
+  const { data: resource } = useQuery({
+    queryKey: ['/api/v1/quotes', payment?.id, 'slider'],
+    queryFn: () =>
+      request(
+        'GET',
+        endpoint(
+          `/api/v1/quotes/${payment?.id}?include=activities.history&reminder_schedule=true`
+        )
+      ).then(
+        (response: GenericSingleResourceResponse<Invoice>) => response.data.data
+      ),
+    enabled: payment !== null && isVisible,
+    staleTime: Infinity,
+  });
+
+  const { data: activities } = useQuery({
+    queryKey: ['/api/v1/activities', payment?.id, 'quote'],
+    queryFn: () =>
+      request('POST', endpoint('/api/v1/activities/entity'), {
+        entity: 'quote',
+        entity_id: payment?.id,
+      }).then(
+        (response: AxiosResponse<GenericManyResponse<QuoteActivity>>) =>
+          response.data.data
+      ),
+    enabled: payment !== null && isVisible,
+    staleTime: Infinity,
+  });
+
+  const fetchEmailHistory = async () => {
+    const response = await queryClient
+      .fetchQuery(
+        ['/api/v1/quotes', payment?.id, 'emailHistory'],
+        () =>
+          request('POST', endpoint('/api/v1/emails/entityHistory'), {
+            entity: 'quote',
+            entity_id: payment?.id,
+          }),
+        { staleTime: Infinity }
+      )
+      .then((response) => response.data);
+
+    setEmailRecords(response);
+  };
+
+  useEffect(() => {
+    if (payment) {
+      fetchEmailHistory();
+    }
+  }, [payment]);
+
+  return (
+    <Slider
+      size="regular"
+      visible={isVisible}
+      onClose={() => {
+        setIsSliderVisible(false);
+        setPayment(null);
+      }}
+      title={`${t('quote')} ${payment?.number}`}
+      topRight={
+        payment &&
+        (hasPermission('edit_quote') || entityAssigned(payment)) && (
+          <ResourceActions
+            label={t('more_actions')}
+            resource={payment}
+            actions={actions}
+          />
+        )
+      }
+      withoutActionContainer
+    >
+      <TabGroup
+        tabs={[t('overview'), t('history'), t('activity'), t('email_history')]}
+        width="full"
+      >
+        <div className="space-y-2">
+          <div>
+            <Element leftSide={t('payment_amount')}>
+              {payment
+                ? formatMoney(
+                    payment?.amount,
+                    payment.client?.country_id,
+                    payment.client?.settings.currency_id
+                  )
+                : null}
+            </Element>
+
+            <Element leftSide={t('applied')}>
+              {payment
+                ? formatMoney(
+                    payment.applied,
+                    payment.client?.country_id,
+                    payment.client?.settings.currency_id
+                  )
+                : null}
+            </Element>
+
+            <Element leftSide={t('date')}>
+              {payment ? date(payment?.date, dateFormat) : null}
+            </Element>
+
+            <Element leftSide={t('status')}>
+              {payment ? <PaymentStatus entity={payment} /> : null}
+            </Element>
+          </div>
+          <Divider withoutPadding />
+          Invoices
+        </div>
+
+        <div>
+          {resource?.activities &&
+            resource.activities.map((activity) => (
+              <ClickableElement
+                key={activity.id}
+                to={`/activities/${activity.id}`}
+              >
+                <div className="flex flex-col">
+                  <div className="flex space-x-1">
+                    <span>
+                      {payment?.client
+                        ? formatMoney(
+                            activity.history.amount,
+                            payment?.client?.country_id,
+                            payment?.client?.settings.currency_id
+                          )
+                        : null}
+                    </span>
+                    <span>&middot;</span>
+                    <DynamicLink
+                      to={`/clients/${activity.client_id}`}
+                      renderSpan={disableNavigation('client', payment?.client)}
+                    >
+                      {payment?.client?.display_name}
+                    </DynamicLink>
+                  </div>
+
+                  <div className="inline-flex items-center space-x-1">
+                    <p>
+                      {date(activity.created_at, `${dateFormat} h:mm:ss A`)}
+                    </p>
+                    <p>{dayjs.unix(activity.created_at).fromNow()}</p>
+                  </div>
+                </div>
+              </ClickableElement>
+            ))}
+        </div>
+
+        <div>
+          {activities?.map((activity) => (
+            <NonClickableElement key={activity.id} className="flex flex-col">
+              <p>{activityElement(activity)}</p>
+              <div className="inline-flex items-center space-x-1">
+                <p>{date(activity.created_at, `${dateFormat} h:mm:ss A`)}</p>
+                <p>&middot;</p>
+                <p>{activity.ip}</p>
+              </div>
+            </NonClickableElement>
+          ))}
+        </div>
+
+        <div className="flex flex-col">
+          {emailRecords?.map((emailRecord, index) => (
+            <EmailRecord
+              key={index}
+              className="py-4"
+              emailRecord={emailRecord}
+              index={index}
+            />
+          ))}
+        </div>
+      </TabGroup>
+    </Slider>
+  );
+}

--- a/src/pages/payments/common/components/PaymentSlider.tsx
+++ b/src/pages/payments/common/components/PaymentSlider.tsx
@@ -18,7 +18,7 @@ import { useTranslation } from 'react-i18next';
 import { useCurrentCompanyDateFormats } from '$app/common/hooks/useCurrentCompanyDateFormats';
 import { date, endpoint, trans } from '$app/common/helpers';
 import { ResourceActions } from '$app/components/ResourceActions';
-import { useQuery, useQueryClient } from 'react-query';
+import { useQuery } from 'react-query';
 import { request } from '$app/common/helpers/request';
 import { GenericManyResponse } from '$app/common/interfaces/generic-many-response';
 import { AxiosResponse } from 'axios';
@@ -37,10 +37,7 @@ import { useActions } from '../hooks/useActions';
 import { PaymentStatus } from './PaymentStatus';
 import { InvoiceStatus } from '$app/pages/invoices/common/components/InvoiceStatus';
 import { PaymentActivity } from '$app/common/interfaces/payment-activity';
-import { useEffect, useState } from 'react';
-import { EmailRecord as EmailRecordType } from '$app/common/interfaces/email-history';
 import { CreditStatus } from '$app/pages/credits/common/components/CreditStatus';
-import { EmailRecord } from '$app/components/EmailRecord';
 import paymentType from '$app/common/constants/payment-type';
 
 export const paymentSliderAtom = atom<Payment | null>(null);
@@ -111,7 +108,6 @@ function useGenerateActivityElement() {
 
 export function PaymentSlider() {
   const [t] = useTranslation();
-  const queryClient = useQueryClient();
 
   const actions = useActions({
     showCommonBulkAction: true,
@@ -127,8 +123,6 @@ export function PaymentSlider() {
 
   const [payment, setPayment] = useAtom(paymentSliderAtom);
   const [isVisible, setIsSliderVisible] = useAtom(paymentSliderVisibilityAtom);
-
-  const [emailRecords, setEmailRecords] = useState<EmailRecordType[]>([]);
 
   const { data: resource } = useQuery({
     queryKey: ['/api/v1/payments', payment?.id, 'slider'],
@@ -157,33 +151,6 @@ export function PaymentSlider() {
     staleTime: Infinity,
   });
 
-  const fetchEmailHistory = async () => {
-    const response = await queryClient
-      .fetchQuery(
-        ['/api/v1/payments', payment?.id, 'emailHistory'],
-        () =>
-          request('POST', endpoint('/api/v1/emails/entityHistory'), {
-            entity: 'payment',
-            entity_id: payment?.id,
-          }),
-        { staleTime: Infinity }
-      )
-      .then((response) => {
-        console.log(response.data);
-        return response.data;
-      });
-
-    setEmailRecords(response);
-  };
-
-  useEffect(() => {
-    if (payment) {
-      fetchEmailHistory();
-    }
-  }, [payment]);
-
-  console.log(resource);
-
   return (
     <Slider
       size="regular"
@@ -205,10 +172,7 @@ export function PaymentSlider() {
       }
       withoutActionContainer
     >
-      <TabGroup
-        tabs={[t('overview'), t('activity'), t('email_history')]}
-        width="full"
-      >
+      <TabGroup tabs={[t('overview'), t('activity')]} width="full">
         <div className="space-y-2">
           <div>
             <Element leftSide={t('payment_amount')} withoutWrappingLeftSide>
@@ -329,17 +293,6 @@ export function PaymentSlider() {
                 <p>{activity.ip}</p>
               </div>
             </NonClickableElement>
-          ))}
-        </div>
-
-        <div className="flex flex-col">
-          {emailRecords.map((emailRecord, index) => (
-            <EmailRecord
-              key={index}
-              className="py-4"
-              emailRecord={emailRecord}
-              index={index}
-            />
           ))}
         </div>
       </TabGroup>

--- a/src/pages/payments/common/hooks/useActions.tsx
+++ b/src/pages/payments/common/hooks/useActions.tsx
@@ -22,14 +22,21 @@ import { useTranslation } from 'react-i18next';
 import {
   MdArchive,
   MdDelete,
+  MdEdit,
   MdPayment,
   MdRestore,
   MdSend,
   MdSettingsBackupRestore,
 } from 'react-icons/md';
 
-export function useActions() {
+interface Params {
+  showEditAction?: boolean;
+  showCommonBulkAction?: boolean;
+}
+export function useActions(params?: Params) {
   const [t] = useTranslation();
+
+  const { showEditAction, showCommonBulkAction } = params || {};
 
   const { isEditPage } = useEntityPageIdentifier({
     entity: 'payment',
@@ -39,6 +46,16 @@ export function useActions() {
   const bulk = useBulk();
 
   const actions: Action<Payment>[] = [
+    (payment: Payment) =>
+      Boolean(showEditAction) && (
+        <DropdownElement
+          to={route('/payments/:id/edit', { id: payment.id })}
+          icon={<Icon element={MdEdit} />}
+        >
+          {t('edit')}
+        </DropdownElement>
+      ),
+    () => Boolean(showEditAction) && <Divider withoutPadding />,
     (resource: Payment) =>
       resource.amount - resource.applied > 0 &&
       !resource.is_deleted && (
@@ -68,13 +85,13 @@ export function useActions() {
       </DropdownElement>
     ),
     (payment: Payment) =>
-      isEditPage &&
+      (isEditPage || showCommonBulkAction) &&
       getEntityState(payment) !== EntityState.Deleted && (
         <Divider withoutPadding />
       ),
     (payment: Payment) =>
       getEntityState(payment) === EntityState.Active &&
-      isEditPage && (
+      (isEditPage || showCommonBulkAction) && (
         <DropdownElement
           onClick={() => bulk([payment.id], 'archive')}
           icon={<Icon element={MdArchive} />}
@@ -85,7 +102,7 @@ export function useActions() {
     (payment: Payment) =>
       getEntityState(payment) === EntityState.Archived &&
       getEntityState(payment) !== EntityState.Deleted &&
-      isEditPage && (
+      (isEditPage || showCommonBulkAction) && (
         <DropdownElement
           onClick={() => bulk([payment.id], 'restore')}
           icon={<Icon element={MdRestore} />}
@@ -96,7 +113,7 @@ export function useActions() {
     (payment: Payment) =>
       (getEntityState(payment) === EntityState.Active ||
         getEntityState(payment) === EntityState.Archived) &&
-      isEditPage && (
+      (isEditPage || showCommonBulkAction) && (
         <DropdownElement
           onClick={() => bulk([payment.id], 'delete')}
           icon={<Icon element={MdDelete} />}

--- a/src/pages/payments/index/Payments.tsx
+++ b/src/pages/payments/index/Payments.tsx
@@ -57,7 +57,10 @@ export default function Payments() {
     paymentSliderVisibilityAtom
   );
 
-  const { data: paymentResponse } = usePaymentQuery({ id: sliderPaymentId });
+  const { data: paymentResponse } = usePaymentQuery({
+    id: sliderPaymentId,
+    include: 'credits',
+  });
 
   useEffect(() => {
     if (paymentResponse && paymentSliderVisibility) {

--- a/src/pages/payments/index/Payments.tsx
+++ b/src/pages/payments/index/Payments.tsx
@@ -41,20 +41,15 @@ export default function Payments() {
   const [t] = useTranslation();
 
   const hasPermission = useHasPermission();
-
-  const pages: Page[] = [{ name: t('payments'), href: '/payments' }];
-
-  const columns = usePaymentColumns();
-
-  const actions = useActions();
-
-  const paymentColumns = useAllPaymentColumns();
-
-  const filters = usePaymentFilters();
-
   const disableNavigation = useDisableNavigation();
 
+  const actions = useActions();
+  const filters = usePaymentFilters();
+  const columns = usePaymentColumns();
+  const paymentColumns = useAllPaymentColumns();
   const customBulkActions = useCustomBulkActions();
+
+  const pages: Page[] = [{ name: t('payments'), href: '/payments' }];
 
   const [sliderPaymentId, setSliderPaymentId] = useState<string>('');
   const [paymentSlider, setPaymentSlider] = useAtom(paymentSliderAtom);


### PR DESCRIPTION
@beganovich @turbo124 The PR includes implementing the Payment slider. The main difference between this slider and others that we have implemented is that we do not have a `History` and `Email History` tabs here. I noticed that the response of the payment actually does not include the `activities` array that we used in other entities, even though I clearly included `activities.history` in the query, the same as for other entities. Is there any issue, or do we not support history for this entity?

Also, when I tried to pull `email_history`, I received a 422 error indicating that the passed `entity` is invalid. So, I assume that for payments, we also do not support the Email History tab here?

Screenshot:

![Screenshot 2024-02-16 at 18 52 31](https://github.com/invoiceninja/ui/assets/51542191/a3072130-d86a-4422-8bb0-8b5f35d9f112)

Let me know your thoughts.