### PR TITLE
[Bugfix] Transaction Description 

### DIFF
--- a/src/pages/transactions/common/hooks/useCleanDescription.ts
+++ b/src/pages/transactions/common/hooks/useCleanDescription.ts
@@ -1,0 +1,23 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+export function useCleanDescriptionText() {
+  return (descriptionText: string) => {
+    if (descriptionText.includes('\\n ')) {
+      return descriptionText.replace('\\n', '');
+    }
+
+    if (descriptionText.includes('\\n')) {
+      return descriptionText.replace('\\n', ' ');
+    }
+
+    return descriptionText;
+  };
+}

--- a/src/pages/transactions/common/hooks/useTransactionColumns.tsx
+++ b/src/pages/transactions/common/hooks/useTransactionColumns.tsx
@@ -22,6 +22,7 @@ import { Link } from '$app/components/forms';
 import { useInvoicesQuery } from '$app/pages/invoices/common/queries';
 import { EntityStatus } from '$app/pages/transactions/components/EntityStatus';
 import { useTranslation } from 'react-i18next';
+import { useCleanDescriptionText } from './useCleanDescription';
 
 export function useTransactionColumns() {
   const { t } = useTranslation();
@@ -30,6 +31,7 @@ export function useTransactionColumns() {
 
   const formatMoney = useFormatMoney();
   const disableNavigation = useDisableNavigation();
+  const cleanDescriptionText = useCleanDescriptionText();
 
   const { data: invoices } = useInvoicesQuery({ perPage: 1000 });
 
@@ -91,9 +93,13 @@ export function useTransactionColumns() {
           size="regular"
           truncate
           containsUnsafeHTMLTags
-          message={value as string}
+          message={cleanDescriptionText(value as string)}
         >
-          <span dangerouslySetInnerHTML={{ __html: value as string }} />
+          <span
+            dangerouslySetInnerHTML={{
+              __html: cleanDescriptionText(value as string),
+            }}
+          />
         </Tooltip>
       ),
     },

--- a/src/pages/transactions/edit/Edit.tsx
+++ b/src/pages/transactions/edit/Edit.tsx
@@ -32,12 +32,14 @@ import { useTransactionQuery } from '$app/common/queries/transactions';
 import { $refetch } from '$app/common/hooks/useRefetch';
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
+import { useCleanDescriptionText } from '../common/hooks/useCleanDescription';
 
 export default function Edit() {
   const [t] = useTranslation();
 
   const hasPermission = useHasPermission();
   const entityAssigned = useEntityAssigned();
+  const cleanDescriptionText = useCleanDescriptionText();
 
   const { id } = useParams<string>();
 
@@ -100,7 +102,10 @@ export default function Edit() {
 
   useEffect(() => {
     if (data) {
-      setTransaction(data);
+      setTransaction({
+        ...data,
+        description: cleanDescriptionText(data.description),
+      });
     }
   }, [data]);
 


### PR DESCRIPTION
@beganovich  @turbo124 The PR includes the implementation for cleaning the value of transaction description in the edge case if the API returns it. The "\n" will be replaced with an empty string. For testing, you can force entering the "\n" in the description, and after saving, you will see that part of the description will be replaced. Let me know your thoughts.