### PR TITLE
[Bugfix] Purchase Order Custom Fields Labels | Invoice Design

### DIFF
--- a/src/pages/settings/invoice-design/pages/general-settings/components/PurchaseOrderDetails.tsx
+++ b/src/pages/settings/invoice-design/pages/general-settings/components/PurchaseOrderDetails.tsx
@@ -11,9 +11,11 @@
 import { Card } from '$app/components/cards';
 import { useTranslation } from 'react-i18next';
 import { SortableVariableList } from './SortableVariableList';
+import { useCustomField } from '$app/components/CustomField';
 
 export function PurchaseOrderDetails() {
   const [t] = useTranslation();
+  const customField = useCustomField();
 
   const defaultVariables = [
     { value: '$purchase_order.number', label: t('number') },
@@ -21,10 +23,22 @@ export function PurchaseOrderDetails() {
     { value: '$purchase_order.date', label: t('date') },
     { value: '$purchase_order.due_date', label: t('due_date') },
     { value: '$purchase_order.total', label: t('total') },
-    { value: '$purchase_order.custom1', label: t('custom1') },
-    { value: '$purchase_order.custom2', label: t('custom2') },
-    { value: '$purchase_order.custom3', label: t('custom3') },
-    { value: '$purchase_order.custom4', label: t('custom4') },
+    {
+      value: '$purchase_order.custom1',
+      label: customField('invoice1').label() || t('custom1'),
+    },
+    {
+      value: '$purchase_order.custom2',
+      label: customField('invoice2').label() || t('custom2'),
+    },
+    {
+      value: '$purchase_order.custom3',
+      label: customField('invoice3').label() || t('custom3'),
+    },
+    {
+      value: '$purchase_order.custom4',
+      label: customField('invoice4').label() || t('custom4'),
+    },
     { value: '$purchase_order.balance_due', label: t('balance_due') },
   ];
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for labels on the purchase_order_details card under the Invoice Design page. We had fixed translations for values like `custom1`, etc. However, we missed it when the custom field name is entered. Screenshot:

<img width="533" alt="Screenshot 2024-02-26 at 09 45 46" src="https://github.com/invoiceninja/ui/assets/51542191/3a729311-2e88-4d07-b2f5-90b9b2457f4a">

Let me know your thoughts.