### PR TITLE
[Cleanup] Client/Vendor Column Hidding On Client and Vendor Show Page

### DIFF
--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -126,6 +126,7 @@ interface Props<T> extends CommonProps {
   ) => void;
   hideEditableOptions?: boolean;
   dateRangeColumns?: DateRangeColumn[];
+  excludeColumns?: string[];
 }
 
 export type ResourceAction<T> = (resource: T) => ReactElement;
@@ -154,6 +155,7 @@ export function DataTable<T extends object>(props: Props<T>) {
     onBulkActionCall,
     hideEditableOptions = false,
     dateRangeColumns = [],
+    excludeColumns = [],
   } = props;
 
   const companyUpdateTimeOut = useRef<NodeJS.Timeout | undefined>(undefined);
@@ -516,31 +518,34 @@ export function DataTable<T extends object>(props: Props<T>) {
             </Th>
           )}
 
-          {props.columns.map((column, index) => (
-            <Th
-              id={column.id}
-              key={index}
-              className={styleOptions?.thClassName}
-              isCurrentlyUsed={sortedBy === column.id}
-              onColumnClick={(data: ColumnSortPayload) => {
-                setSortedBy(data.field);
-                setSort(data.sort);
-              }}
-              childrenClassName={styleOptions?.thChildrenClassName}
-            >
-              <div className="flex items-center space-x-3">
-                {dateRangeColumns.some(
-                  (dateRangeColumn) => column.id === dateRangeColumn.column
-                ) && (
-                  <DateRangePicker
-                    setDateRange={setDateRange}
-                    onClick={() => handleDateRangeColumnClick(column.id)}
-                  />
-                )}
-                <span>{column.label}</span>
-              </div>
-            </Th>
-          ))}
+          {props.columns.map(
+            (column, index) =>
+              Boolean(!excludeColumns.includes(column.id)) && (
+                <Th
+                  id={column.id}
+                  key={index}
+                  className={styleOptions?.thClassName}
+                  isCurrentlyUsed={sortedBy === column.id}
+                  onColumnClick={(data: ColumnSortPayload) => {
+                    setSortedBy(data.field);
+                    setSort(data.sort);
+                  }}
+                  childrenClassName={styleOptions?.thChildrenClassName}
+                >
+                  <div className="flex items-center space-x-3">
+                    {dateRangeColumns.some(
+                      (dateRangeColumn) => column.id === dateRangeColumn.column
+                    ) && (
+                      <DateRangePicker
+                        setDateRange={setDateRange}
+                        onClick={() => handleDateRangeColumnClick(column.id)}
+                      />
+                    )}
+                    <span>{column.label}</span>
+                  </div>
+                </Th>
+              )
+          )}
 
           {props.withResourcefulActions && !hideEditableOptions && <Th></Th>}
         </Thead>
@@ -615,29 +620,32 @@ export function DataTable<T extends object>(props: Props<T>) {
                   </Td>
                 )}
 
-                {props.columns.map((column, index) => (
-                  <Td
-                    key={index}
-                    className={classNames(
-                      {
-                        'cursor-pointer': index < 3,
-                        'py-4': hideEditableOptions,
-                      },
-                      styleOptions?.tdClassName
-                    )}
-                    onClick={() => {
-                      if (index < 3) {
-                        props.onTableRowClick
-                          ? props.onTableRowClick(resource)
-                          : document.getElementById(resource.id)?.click();
-                      }
-                    }}
-                  >
-                    {column.format
-                      ? column.format(resource[column.id], resource)
-                      : resource[column.id]}
-                  </Td>
-                ))}
+                {props.columns.map(
+                  (column, index) =>
+                    Boolean(!excludeColumns.includes(column.id)) && (
+                      <Td
+                        key={index}
+                        className={classNames(
+                          {
+                            'cursor-pointer': index < 3,
+                            'py-4': hideEditableOptions,
+                          },
+                          styleOptions?.tdClassName
+                        )}
+                        onClick={() => {
+                          if (index < 3) {
+                            props.onTableRowClick
+                              ? props.onTableRowClick(resource)
+                              : document.getElementById(resource.id)?.click();
+                          }
+                        }}
+                      >
+                        {column.format
+                          ? column.format(resource[column.id], resource)
+                          : resource[column.id]}
+                      </Td>
+                    )
+                )}
 
                 {props.withResourcefulActions && !hideEditableOptions && (
                   <Td>

--- a/src/pages/clients/show/pages/Credits.tsx
+++ b/src/pages/clients/show/pages/Credits.tsx
@@ -41,6 +41,7 @@ export default function Credits() {
       bulkRoute="/api/v1/credits/bulk"
       linkToCreate={route('/credits/create?client=:id', { id })}
       linkToEdit="/credits/:id/edit"
+      excludeColumns={['client_id']}
       linkToCreateGuards={[permission('create_credit')]}
       hideEditableOptions={!hasPermission('edit_credit')}
     />

--- a/src/pages/clients/show/pages/Expenses.tsx
+++ b/src/pages/clients/show/pages/Expenses.tsx
@@ -19,8 +19,6 @@ import {
 } from '$app/pages/expenses/common/hooks';
 import { useParams } from 'react-router-dom';
 
-export const dataTableStaleTime = 50;
-
 export default function Expenses() {
   const { id } = useParams();
 
@@ -49,6 +47,7 @@ export default function Expenses() {
       bulkRoute="/api/v1/expenses/bulk"
       linkToCreate={route('/expenses/create?client=:id', { id })}
       linkToEdit="/expenses/:id/edit"
+      excludeColumns={['client_id']}
       linkToCreateGuards={[permission('create_expense')]}
       hideEditableOptions={!hasPermission('edit_expense')}
     />

--- a/src/pages/clients/show/pages/Invoices.tsx
+++ b/src/pages/clients/show/pages/Invoices.tsx
@@ -17,17 +17,13 @@ import { useCustomBulkActions } from '$app/pages/invoices/common/hooks/useCustom
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 import { permission } from '$app/common/guards/guards/permission';
 
-export const dataTableStaleTime = 50;
-
 export default function Invoices() {
   const { id } = useParams();
 
   const hasPermission = useHasPermission();
 
-  const columns = useInvoiceColumns();
-
   const actions = useActions();
-
+  const columns = useInvoiceColumns();
   const customBulkActions = useCustomBulkActions();
 
   return (
@@ -44,6 +40,7 @@ export default function Invoices() {
       bulkRoute="/api/v1/invoices/bulk"
       linkToCreate={route('/invoices/create?client=:id', { id })}
       linkToEdit="/invoices/:id/edit"
+      excludeColumns={['client_id']}
       linkToCreateGuards={[permission('create_invoice')]}
       hideEditableOptions={!hasPermission('edit_invoice')}
     />

--- a/src/pages/clients/show/pages/Payments.tsx
+++ b/src/pages/clients/show/pages/Payments.tsx
@@ -39,6 +39,7 @@ export default function Payments() {
       bulkRoute="/api/v1/payments/bulk"
       linkToCreate={route('/payments/create?client=:id', { id })}
       linkToEdit="/payments/:id/edit"
+      excludeColumns={['client_id']}
       showRestore={(resource: Payment) => !resource.is_deleted}
       linkToCreateGuards={[permission('create_payment')]}
       hideEditableOptions={!hasPermission('edit_payment')}

--- a/src/pages/clients/show/pages/Projects.tsx
+++ b/src/pages/clients/show/pages/Projects.tsx
@@ -44,6 +44,7 @@ export default function Projects() {
       bulkRoute="/api/v1/projects/bulk"
       linkToCreate={route('/projects/create?client=:id', { id: id })}
       linkToEdit="/projects/:id/edit"
+      excludeColumns={['client_id']}
       linkToCreateGuards={[permission('create_project')]}
       hideEditableOptions={!hasPermission('edit_project')}
     />

--- a/src/pages/clients/show/pages/Quotes.tsx
+++ b/src/pages/clients/show/pages/Quotes.tsx
@@ -41,6 +41,7 @@ export default function Quotes() {
       bulkRoute="/api/v1/quotes/bulk"
       linkToCreate={route('/quotes/create?client=:id', { id })}
       linkToEdit="/quotes/:id/edit"
+      excludeColumns={['client_id']}
       linkToCreateGuards={[permission('create_quote')]}
       hideEditableOptions={!hasPermission('edit_quote')}
     />

--- a/src/pages/clients/show/pages/RecurringExpenses.tsx
+++ b/src/pages/clients/show/pages/RecurringExpenses.tsx
@@ -40,6 +40,7 @@ export default function RecurringExpenses() {
       bulkRoute="/api/v1/recurring_expenses/bulk"
       linkToCreate={route('/recurring_expenses/create?client=:id', { id })}
       linkToEdit="/recurring_expenses/:id/edit"
+      excludeColumns={['client_id']}
       linkToCreateGuards={[permission('create_recurring_expense')]}
       hideEditableOptions={!hasPermission('edit_recurring_expense')}
     />

--- a/src/pages/clients/show/pages/RecurringInvoices.tsx
+++ b/src/pages/clients/show/pages/RecurringInvoices.tsx
@@ -44,6 +44,7 @@ export default function RecurringInvoices() {
         id,
       })}
       linkToEdit="/recurring_invoices/:id/edit"
+      excludeColumns={['client_id']}
       linkToCreateGuards={[permission('create_recurring_invoice')]}
       hideEditableOptions={!hasPermission('edit_recurring_invoice')}
     />

--- a/src/pages/clients/show/pages/Tasks.tsx
+++ b/src/pages/clients/show/pages/Tasks.tsx
@@ -23,8 +23,6 @@ import {
 import { useShowEditOption } from '$app/pages/tasks/common/hooks/useShowEditOption';
 import { useParams } from 'react-router-dom';
 
-export const dataTableStaleTime = 50;
-
 export default function Tasks() {
   const { id } = useParams();
 
@@ -63,6 +61,7 @@ export default function Tasks() {
         rate: client?.settings?.default_task_rate || '',
       })}
       linkToEdit="/tasks/:id/edit"
+      excludeColumns={['client_id']}
       showEdit={(task: Task) => showEditOption(task)}
       linkToCreateGuards={[permission('create_task')]}
       hideEditableOptions={!hasPermission('edit_task')}

--- a/src/pages/vendors/show/pages/Expenses.tsx
+++ b/src/pages/vendors/show/pages/Expenses.tsx
@@ -47,6 +47,7 @@ export default function Expenses() {
       bulkRoute="/api/v1/expenses/bulk"
       linkToCreate={route('/expenses/create?vendor=:id', { id })}
       linkToEdit="/expenses/:id/edit"
+      excludeColumns={['vendor_id']}
       linkToCreateGuards={[permission('create_expense')]}
       hideEditableOptions={!hasPermission('edit_expense')}
     />

--- a/src/pages/vendors/show/pages/PurchaseOrders.tsx
+++ b/src/pages/vendors/show/pages/PurchaseOrders.tsx
@@ -51,6 +51,7 @@ export default function PurchaseOrders() {
       bulkRoute="/api/v1/purchase_orders/bulk"
       linkToCreate={route('/purchase_orders/create?vendor=:id', { id })}
       linkToEdit="/purchase_orders/:id/edit"
+      excludeColumns={['vendor_id']}
       linkToCreateGuards={[permission('create_purchase_order')]}
       hideEditableOptions={!hasPermission('edit_purchase_order')}
     />

--- a/src/pages/vendors/show/pages/RecurringExpenses.tsx
+++ b/src/pages/vendors/show/pages/RecurringExpenses.tsx
@@ -40,6 +40,7 @@ export default function RecurringExpenses() {
       bulkRoute="/api/v1/recurring_expenses/bulk"
       linkToCreate={route('/recurring_expenses/create?vendor=:id', { id })}
       linkToEdit="/recurring_expenses/:id/edit"
+      excludeColumns={['vendor_id']}
       linkToCreateGuards={[permission('create_recurring_expense')]}
       hideEditableOptions={!hasPermission('edit_recurring_expense')}
     />


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of hiding the `client` and `vendor` columns on tables that are on the client and vendor show pages, even if they are selected in the columns. Screenshots:

![Screenshot 2024-02-26 at 11 19 41](https://github.com/invoiceninja/ui/assets/51542191/ed037358-81e1-4f58-a5e3-e89c5949b7c3)

![Screenshot 2024-02-26 at 11 19 52](https://github.com/invoiceninja/ui/assets/51542191/86c42f84-e8cb-4c60-8122-85050f859e44)

Let me know your thoughts.