### PR TITLE
[Feature] API Version On Health Check Modal

### DIFF
--- a/src/components/AboutModal.tsx
+++ b/src/components/AboutModal.tsx
@@ -331,9 +331,7 @@ export function AboutModal(props: Props) {
                 {t('cli')}: {systemInfo?.php_version.current_php_cli_version}
               </span>
               <span>Memory: {systemInfo?.php_version.memory_limit}</span>
-              <span>
-                {t('api_version')}: {systemInfo?.api_version}
-              </span>
+              <span>API: {systemInfo?.api_version}</span>
             </div>
 
             <div>

--- a/src/components/AboutModal.tsx
+++ b/src/components/AboutModal.tsx
@@ -62,6 +62,7 @@ interface SystemInfo {
   trailing_slash: boolean;
   file_permissions: string;
   exchange_rate_api_not_configured: boolean;
+  api_version: string;
 }
 
 interface Props {
@@ -330,6 +331,9 @@ export function AboutModal(props: Props) {
                 {t('cli')}: {systemInfo?.php_version.current_php_cli_version}
               </span>
               <span>Memory: {systemInfo?.php_version.memory_limit}</span>
+              <span>
+                {t('api_version')}: {systemInfo?.api_version}
+              </span>
             </div>
 
             <div>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of an additional label on the health check info modal. Currently, we do not have it in the response, but I assumed it is there. The label will be the translated keyword "api_version," but the value will be the `api_version` property from the response. Screenshot:

![Screenshot 2024-02-28 at 02 05 32](https://github.com/invoiceninja/ui/assets/51542191/360317dc-b348-48d7-9e2a-7aebfdb6bf5e)

Let me know your thoughts.