### PR TITLE
[Cleanup] Replacing "Use Quote Terms" Field

### DIFF
--- a/src/pages/settings/company/components/Defaults.tsx
+++ b/src/pages/settings/company/components/Defaults.tsx
@@ -11,7 +11,6 @@
 import { useTranslation } from 'react-i18next';
 import { Card, Element } from '../../../../components/cards';
 import { SelectField } from '../../../../components/forms';
-import Toggle from '../../../../components/forms/Toggle';
 import { useDispatch, useSelector } from 'react-redux';
 import { useStaticsQuery } from '$app/common/queries/statics';
 import { ChangeEvent } from 'react';
@@ -22,7 +21,6 @@ import { MarkdownEditor } from '$app/components/forms/MarkdownEditor';
 import { Divider } from '$app/components/cards/Divider';
 import { useAtomValue } from 'jotai';
 import { companySettingsErrorsAtom } from '../../common/atoms';
-import { useCurrentSettingsLevel } from '$app/common/hooks/useCurrentSettingsLevel';
 import { useDisableSettingsField } from '$app/common/hooks/useDisableSettingsField';
 import { PropertyCheckbox } from '$app/components/PropertyCheckbox';
 import { SettingsLabel } from '$app/components/SettingsLabel';
@@ -34,8 +32,6 @@ export function Defaults() {
   const { data: statics } = useStaticsQuery();
 
   const disableSettingsField = useDisableSettingsField();
-
-  const { isCompanySettingsActive } = useCurrentSettingsLevel();
 
   const errors = useAtomValue(companySettingsErrorsAtom);
 
@@ -147,29 +143,6 @@ export function Defaults() {
           </Element>
 
           <Divider />
-
-          {isCompanySettingsActive && (
-            <Element
-              className="mb-3"
-              leftSide={t('use_quote_terms')}
-              leftSideHelp={t('use_quote_terms_help')}
-            >
-              <Toggle
-                checked={Boolean(companyChanges?.use_quote_terms_on_conversion)}
-                onChange={(value: boolean) =>
-                  dispatch(
-                    updateChanges({
-                      object: 'company',
-                      property: 'use_quote_terms_on_conversion',
-                      value,
-                    })
-                  )
-                }
-              />
-            </Element>
-          )}
-
-          {isCompanySettingsActive && <Divider withoutPadding />}
 
           <Element
             className="mt-4"

--- a/src/pages/settings/workflow-settings/components/Quotes.tsx
+++ b/src/pages/settings/workflow-settings/components/Quotes.tsx
@@ -17,11 +17,14 @@ import Toggle from '../../../../components/forms/Toggle';
 import { PropertyCheckbox } from '$app/components/PropertyCheckbox';
 import { useDisableSettingsField } from '$app/common/hooks/useDisableSettingsField';
 import { SettingsLabel } from '$app/components/SettingsLabel';
+import { useCurrentSettingsLevel } from '$app/common/hooks/useCurrentSettingsLevel';
 
 export function Quotes() {
   const [t] = useTranslation();
   const dispatch = useDispatch();
   const companyChanges = useCompanyChanges();
+
+  const { isCompanySettingsActive } = useCurrentSettingsLevel();
 
   const disableSettingsField = useDisableSettingsField();
 
@@ -80,6 +83,20 @@ export function Quotes() {
           disabled={disableSettingsField('auto_archive_quote')}
         />
       </Element>
+
+      {isCompanySettingsActive && (
+        <Element
+          leftSide={t('use_quote_terms')}
+          leftSideHelp={t('use_quote_terms_help')}
+        >
+          <Toggle
+            checked={Boolean(companyChanges?.use_quote_terms_on_conversion)}
+            onChange={(value: boolean) =>
+              handleToggleChange('use_quote_terms_on_conversion', value)
+            }
+          />
+        </Element>
+      )}
     </Card>
   );
 }


### PR DESCRIPTION
@beganovich @turbo124 The PR includes replacing the "use quote terms" field. Screenshot:

<img width="1260" alt="Screenshot 2024-03-01 at 00 22 21" src="https://github.com/invoiceninja/ui/assets/51542191/de185868-bfbb-451f-a1d0-224d9558d2fa">

Let me know your thoughts.