### PR TITLE
[Cleanup] Invoicing Project | Project Name In Line Item Description

### DIFF
--- a/src/pages/projects/common/hooks/useInvoiceProject.tsx
+++ b/src/pages/projects/common/hooks/useInvoiceProject.tsx
@@ -156,10 +156,9 @@ export function useInvoiceProject() {
           tax_id: '',
         };
 
-        const projectName =
-          company.invoice_task_project && task?.project?.name
-            ? '## ' + task.project?.name + '\n'
-            : '';
+        const projectName = task?.project?.name
+          ? '## ' + task.project?.name + '\n'
+          : '';
 
         if (parsed.length) {
           item.notes = projectName + task?.description + ' ' + parsed.join(' ');


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes in the logic of invoicing project action. Actually, we already had an implementation for showing the project name in the line item description, but we had one unnecessary part of the logic. We showed the project name only if the `company.invoice_task_project` is turned on. I checked the Flutter app, and it does not work like that there. So, I removed this part of the logic to make it work always. Screenshot:

![Screenshot 2024-03-05 at 19 25 39](https://github.com/invoiceninja/ui/assets/51542191/76ece609-2248-4b05-b47f-56f9eb084c95)

Let me know your thoughts.