### PR TITLE
[Cleanup] Moving Payments Fields From Defaults Page To Payment Settings Page

### DIFF
--- a/src/pages/settings/company/components/Defaults.tsx
+++ b/src/pages/settings/company/components/Defaults.tsx
@@ -10,142 +10,29 @@
 
 import { useTranslation } from 'react-i18next';
 import { Card, Element } from '../../../../components/cards';
-import { SelectField } from '../../../../components/forms';
 import { useDispatch, useSelector } from 'react-redux';
-import { useStaticsQuery } from '$app/common/queries/statics';
-import { ChangeEvent } from 'react';
 import { RootState } from '$app/common/stores/store';
 import { updateChanges } from '$app/common/stores/slices/company-users';
-import { PaymentTerm } from '../../../../common/interfaces/payment-term';
 import { MarkdownEditor } from '$app/components/forms/MarkdownEditor';
-import { Divider } from '$app/components/cards/Divider';
-import { useAtomValue } from 'jotai';
-import { companySettingsErrorsAtom } from '../../common/atoms';
 import { useDisableSettingsField } from '$app/common/hooks/useDisableSettingsField';
 import { PropertyCheckbox } from '$app/components/PropertyCheckbox';
 import { SettingsLabel } from '$app/components/SettingsLabel';
-import { usePaymentTermsQuery } from '$app/common/queries/payment-terms';
 
 export function Defaults() {
   const [t] = useTranslation();
   const dispatch = useDispatch();
-  const { data: statics } = useStaticsQuery();
 
   const disableSettingsField = useDisableSettingsField();
-
-  const errors = useAtomValue(companySettingsErrorsAtom);
-
-  const { data: paymentTermsResponse } = usePaymentTermsQuery({});
 
   const companyChanges = useSelector(
     (state: RootState) => state.companyUsers.changes.company
   );
-
-  const handleChange = (event: ChangeEvent<HTMLInputElement>) =>
-    dispatch(
-      updateChanges({
-        object: 'company',
-        property: event.target.id,
-        value: event.target.value,
-      })
-    );
 
   return (
     <>
       {companyChanges?.settings && (
         <Card title={t('defaults')}>
           <Element
-            leftSide={
-              <PropertyCheckbox
-                propertyKey="payment_type_id"
-                labelElement={<SettingsLabel label={t('payment_type')} />}
-              />
-            }
-          >
-            <SelectField
-              value={companyChanges?.settings?.payment_type_id || '0'}
-              onChange={handleChange}
-              id="settings.payment_type_id"
-              blankOptionValue="0"
-              disabled={disableSettingsField('payment_type_id')}
-              withBlank
-              errorMessage={errors?.errors['settings.payment_type_id']}
-            >
-              {statics?.payment_types.map(
-                (type: { id: string; name: string }) => (
-                  <option key={type.id} value={type.id}>
-                    {type.name}
-                  </option>
-                )
-              )}
-            </SelectField>
-          </Element>
-
-          {paymentTermsResponse && (
-            <Element
-              leftSide={
-                <PropertyCheckbox
-                  propertyKey="valid_until"
-                  labelElement={
-                    <SettingsLabel label={t('quote_valid_until')} />
-                  }
-                />
-              }
-            >
-              <SelectField
-                value={companyChanges?.settings?.valid_until || ''}
-                id="settings.valid_until"
-                onChange={handleChange}
-                disabled={disableSettingsField('valid_until')}
-                withBlank
-                errorMessage={errors?.errors['settings.valid_until']}
-              >
-                {paymentTermsResponse.data.data.map((type: PaymentTerm) => (
-                  <option key={type.id} value={type.num_days}>
-                    {type.name}
-                  </option>
-                ))}
-              </SelectField>
-            </Element>
-          )}
-
-          <Element
-            leftSide={
-              <PropertyCheckbox
-                propertyKey="default_expense_payment_type_id"
-                labelElement={
-                  <SettingsLabel label={t('expense_payment_type')} />
-                }
-              />
-            }
-          >
-            <SelectField
-              value={
-                companyChanges?.settings?.default_expense_payment_type_id || ''
-              }
-              onChange={handleChange}
-              disabled={disableSettingsField('default_expense_payment_type_id')}
-              id="settings.default_expense_payment_type_id"
-              blankOptionValue="0"
-              withBlank
-              errorMessage={
-                errors?.errors['settings.default_expense_payment_type_id']
-              }
-            >
-              {statics?.payment_types.map(
-                (type: { id: string; name: string }) => (
-                  <option key={type.id} value={type.id}>
-                    {type.name}
-                  </option>
-                )
-              )}
-            </SelectField>
-          </Element>
-
-          <Divider />
-
-          <Element
-            className="mt-4"
             leftSide={
               <PropertyCheckbox
                 propertyKey="invoice_terms"

--- a/src/pages/settings/online-payments/OnlinePayments.tsx
+++ b/src/pages/settings/online-payments/OnlinePayments.tsx
@@ -34,17 +34,18 @@ import { useCurrentSettingsLevel } from '$app/common/hooks/useCurrentSettingsLev
 import { PropertyCheckbox } from '$app/components/PropertyCheckbox';
 import { useDisableSettingsField } from '$app/common/hooks/useDisableSettingsField';
 import { SettingsLabel } from '$app/components/SettingsLabel';
+import { useStaticsQuery } from '$app/common/queries/statics';
 
 export function OnlinePayments() {
+  useTitle('online_payments');
   const [t] = useTranslation();
 
   const dispatch = useDispatch();
-
   const disableSettingsField = useDisableSettingsField();
 
   const { isCompanySettingsActive } = useCurrentSettingsLevel();
 
-  useTitle('online_payments');
+  const { data: statics } = useStaticsQuery();
 
   const pages = [
     { name: t('settings'), href: '/settings' },
@@ -253,6 +254,86 @@ export function OnlinePayments() {
             </Element>
           </>
         )}
+
+        <Element
+          leftSide={
+            <PropertyCheckbox
+              propertyKey="payment_type_id"
+              labelElement={<SettingsLabel label={t('payment_type')} />}
+            />
+          }
+        >
+          <SelectField
+            value={company?.settings?.payment_type_id || '0'}
+            onChange={handleChange}
+            id="settings.payment_type_id"
+            blankOptionValue="0"
+            disabled={disableSettingsField('payment_type_id')}
+            withBlank
+            errorMessage={errors?.errors['settings.payment_type_id']}
+          >
+            {statics?.payment_types.map(
+              (type: { id: string; name: string }) => (
+                <option key={type.id} value={type.id}>
+                  {type.name}
+                </option>
+              )
+            )}
+          </SelectField>
+        </Element>
+
+        <Element
+          leftSide={
+            <PropertyCheckbox
+              propertyKey="valid_until"
+              labelElement={<SettingsLabel label={t('quote_valid_until')} />}
+            />
+          }
+        >
+          <SelectField
+            value={company?.settings?.valid_until || ''}
+            id="settings.valid_until"
+            onChange={handleChange}
+            disabled={disableSettingsField('valid_until')}
+            withBlank
+            errorMessage={errors?.errors['settings.valid_until']}
+          >
+            {paymentTerms?.map((type: PaymentTerm) => (
+              <option key={type.id} value={type.num_days}>
+                {type.name}
+              </option>
+            ))}
+          </SelectField>
+        </Element>
+
+        <Element
+          leftSide={
+            <PropertyCheckbox
+              propertyKey="default_expense_payment_type_id"
+              labelElement={<SettingsLabel label={t('expense_payment_type')} />}
+            />
+          }
+        >
+          <SelectField
+            value={company?.settings?.default_expense_payment_type_id || ''}
+            onChange={handleChange}
+            disabled={disableSettingsField('default_expense_payment_type_id')}
+            id="settings.default_expense_payment_type_id"
+            blankOptionValue="0"
+            withBlank
+            errorMessage={
+              errors?.errors['settings.default_expense_payment_type_id']
+            }
+          >
+            {statics?.payment_types.map(
+              (type: { id: string; name: string }) => (
+                <option key={type.id} value={type.id}>
+                  {type.name}
+                </option>
+              )
+            )}
+          </SelectField>
+        </Element>
 
         <Element
           leftSideHelp={t('manual_payment_email_help')}


### PR DESCRIPTION
@beganovich @turbo124 The PR includes moving the Payment fields from the Defaults page to the Payment Settings page. Screenshot:

![Screenshot 2024-03-05 at 19 46 51](https://github.com/invoiceninja/ui/assets/51542191/6646bda3-01f8-4de3-b009-006c226f40b5)

Let me know your thoughts.