### PR TITLE
[Feature] PRO Text On Advanced Settings

### DIFF
--- a/src/components/layouts/Settings.tsx
+++ b/src/components/layouts/Settings.tsx
@@ -162,9 +162,10 @@ export function Settings(props: Props) {
           </nav>
 
           {advanced.filter((route) => route.enabled).length > 0 && (
-            <a className="flex items-center py-4 px-3 text-xs uppercase font-medium mt-8">
-              <span className="truncate">{t('advanced_settings')}</span>
-            </a>
+            <div className="flex items-center py-4 px-3 text-xs uppercase font-medium mt-8 truncate space-x-1">
+              <span>{t('advanced_settings')}</span>
+              <sup>{t('PRO')}</sup>
+            </div>
           )}
 
           <SelectField

--- a/src/components/layouts/Settings.tsx
+++ b/src/components/layouts/Settings.tsx
@@ -164,7 +164,7 @@ export function Settings(props: Props) {
           {advanced.filter((route) => route.enabled).length > 0 && (
             <div className="flex items-center py-4 px-3 text-xs uppercase font-medium mt-8 truncate space-x-1">
               <span>{t('advanced_settings')}</span>
-              <sup>{t('PRO')}</sup>
+              <sup>{t('pro')}</sup>
             </div>
           )}
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adding the subtext "PRO" to the "Advanced Settings" text. Screenshot:

<img width="1259" alt="Screenshot 2024-03-07 at 17 50 40" src="https://github.com/invoiceninja/ui/assets/51542191/cce1db6d-8de1-4fba-a638-87907677a7b4">

Let me know your thoughts.