### PR TITLE
[Bugfix] Adding Missing E-Invoice Type Options

### DIFF
--- a/src/pages/settings/email-settings/EmailSettings.tsx
+++ b/src/pages/settings/email-settings/EmailSettings.tsx
@@ -309,6 +309,8 @@ export function EmailSettings() {
                 errorMessage={errors?.errors['settings.e_invoice_type']}
               >
                 <option value="EN16931">EN16931</option>
+                <option value="XInvoice_3.0">XInvoice_3.0</option>
+                <option value="XInvoice_2_3">XInvoice_2_3</option>
                 <option value="XInvoice_2_2">XInvoice_2_2</option>
                 <option value="XInvoice_2_1">XInvoice_2_1</option>
                 <option value="XInvoice_2_0">XInvoice_2_0</option>
@@ -316,9 +318,9 @@ export function EmailSettings() {
                 <option value="XInvoice-Extended">XInvoice-Extended</option>
                 <option value="XInvoice-BasicWL">XInvoice-BasicWL</option>
                 <option value="XInvoice-Basic">XInvoice-Basic</option>
-                <option value="Facturae_3.2">Facturae_3.2</option>
-                <option value="Facturae_3.2.1">Facturae_3.2.1</option>
                 <option value="Facturae_3.2.2">Facturae_3.2.2</option>
+                <option value="Facturae_3.2.1">Facturae_3.2.1</option>
+                <option value="Facturae_3.2">Facturae_3.2</option>
               </SelectField>
             </Element>
           </>

--- a/src/pages/settings/email-settings/EmailSettings.tsx
+++ b/src/pages/settings/email-settings/EmailSettings.tsx
@@ -309,12 +309,12 @@ export function EmailSettings() {
                 errorMessage={errors?.errors['settings.e_invoice_type']}
               >
                 <option value="EN16931">EN16931</option>
-                <option value="XInvoice_3_0">XInvoice_3_0</option>
-                <option value="XInvoice_2_3">XInvoice_2_3</option>
-                <option value="XInvoice_2_2">XInvoice_2_2</option>
-                <option value="XInvoice_2_1">XInvoice_2_1</option>
-                <option value="XInvoice_2_0">XInvoice_2_0</option>
-                <option value="XInvoice_1_0">XInvoice_1_0</option>
+                <option value="XInvoice_3_0">XInvoice_3.0</option>
+                <option value="XInvoice_2_3">XInvoice_2.3</option>
+                <option value="XInvoice_2_2">XInvoice_2.2</option>
+                <option value="XInvoice_2_1">XInvoice_2.1</option>
+                <option value="XInvoice_2_0">XInvoice_2.0</option>
+                <option value="XInvoice_1_0">XInvoice_1.0</option>
                 <option value="XInvoice-Extended">XInvoice-Extended</option>
                 <option value="XInvoice-BasicWL">XInvoice-BasicWL</option>
                 <option value="XInvoice-Basic">XInvoice-Basic</option>

--- a/src/pages/settings/email-settings/EmailSettings.tsx
+++ b/src/pages/settings/email-settings/EmailSettings.tsx
@@ -309,7 +309,7 @@ export function EmailSettings() {
                 errorMessage={errors?.errors['settings.e_invoice_type']}
               >
                 <option value="EN16931">EN16931</option>
-                <option value="XInvoice_3.0">XInvoice_3.0</option>
+                <option value="XInvoice_3_0">XInvoice_3_0</option>
                 <option value="XInvoice_2_3">XInvoice_2_3</option>
                 <option value="XInvoice_2_2">XInvoice_2_2</option>
                 <option value="XInvoice_2_1">XInvoice_2_1</option>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adding missing e-invoice type select field options. We missed `XInvoice_3_0` and `XInvoice_2_3`. Screenshot:

<img width="800" alt="Screenshot 2024-03-08 at 22 23 00" src="https://github.com/invoiceninja/ui/assets/51542191/a4576b82-5f98-440c-a04a-2c6225a60798">

Let me know your thoughts. 