### PR TITLE
[Bugfix] Private Notes Icon | Client Show Page

### DIFF
--- a/src/pages/clients/show/components/Standing.tsx
+++ b/src/pages/clients/show/components/Standing.tsx
@@ -97,16 +97,18 @@ export function Standing(props: Props) {
                   </Element>
                 )}
 
-                <div className="flex items-center space-x-1">
-                  <div>
-                    <Icon element={MdLockOutline} size={24} />
-                  </div>
+                {client.private_notes && (
+                  <div className="flex items-center space-x-1">
+                    <div>
+                      <Icon element={MdLockOutline} size={24} />
+                    </div>
 
-                  <span
-                    className="whitespace-normal"
-                    dangerouslySetInnerHTML={{ __html: client.private_notes }}
-                  />
-                </div>
+                    <span
+                      className="whitespace-normal"
+                      dangerouslySetInnerHTML={{ __html: client.private_notes }}
+                    />
+                  </div>
+                )}
               </div>
             }
             className="h-full"


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for the private_notes icon on the client show page. So, even if we did not enter any private notes, we were still showing the icon, which slightly breaks the UX here. Screenshot:

<img width="279" alt="Screenshot 2024-03-09 at 18 25 41" src="https://github.com/invoiceninja/ui/assets/51542191/f8a5f1ef-a726-45be-955f-69ef456975b4">

Let me know your thoughts.