### PR TITLE
[Bugfix] Custom Fields Labels Translations On Reports Page

### DIFF
--- a/src/pages/reports/common/components/SortableColumns.tsx
+++ b/src/pages/reports/common/components/SortableColumns.tsx
@@ -41,6 +41,7 @@ import { customField } from '$app/components/CustomField';
 export const reportColumn = 11;
 
 export function useTranslationAlias() {
+  const [t] = useTranslation();
   const company = useCurrentCompany();
   const customFields = company?.custom_fields;
 
@@ -84,7 +85,7 @@ export function useTranslationAlias() {
       contact_custom_value4: findCustomField('vendor_contact4', true),
     };
 
-    return fields[field as keyof typeof fields] || field;
+    return fields[field as keyof typeof fields] || t(field);
   };
 }
 
@@ -105,16 +106,18 @@ export function Column({
 }: ColumnProps) {
   const [t] = useTranslation();
 
+  const colors = useColorScheme();
+
   const findTranslationAlias = useTranslationAlias();
 
   const translateLabel = (record: Record) => {
     const parts = record.value.split('.');
 
-    return `${t(`${parts[0]}`)} - ${t(
-      `${findTranslationAlias(record.trans, parts[0] as Entity)}`
+    return `${t(`${parts[0]}`)} - ${findTranslationAlias(
+      record.trans,
+      parts[0] as Entity
     )}`;
   };
-  const colors = useColorScheme();
 
   return (
     <div>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for translations of custom fields on the reports page. To recreate this specific edge case, you need to create a custom field for the `Client` entity named "client1". 

Currently, on the develop, if you do this, you will get the translated label "Custom Value 1". However, this is translation of the "client1" keyword, which is incorrect behavior. It should remain as "client1" since that is the name of the field. Therefore, I have made a fix so that any entered value will not be translated, but instead, the value will be displayed as entered. Screenshot:

<img width="469" alt="Screenshot 2024-03-10 at 18 50 11" src="https://github.com/invoiceninja/ui/assets/51542191/989998e5-4fc8-479a-a77f-1727b3290bc0">

Let me know your thoughts.