### PR TITLE
[Bugfix] Rows Length On Import

### DIFF
--- a/src/pages/settings/import-export/common/components/UploadImport.tsx
+++ b/src/pages/settings/import-export/common/components/UploadImport.tsx
@@ -44,8 +44,8 @@ export function UploadImport(props: Props) {
         const reader = new FileReader();
 
         reader.onload = (event: ProgressEvent<FileReader>) => {
-          const cvsData = (event.target?.result as string) || '';
-          const rowData = cvsData.split('\n');
+          const csvData = (event.target?.result as string) || '';
+          const rowData = csvData.split('\n');
 
           if (!rowData.length || rowData.length === 1) {
             resolve(false);

--- a/src/pages/settings/import-export/common/components/UploadImport.tsx
+++ b/src/pages/settings/import-export/common/components/UploadImport.tsx
@@ -16,6 +16,7 @@ import { useTranslation } from 'react-i18next';
 import { MdClose } from 'react-icons/md';
 import { useColorScheme } from '$app/common/colors';
 import { ImportedFile } from './Import';
+import { toast } from '$app/common/helpers/toast/toast';
 
 interface Props {
   group: string;
@@ -37,12 +38,55 @@ export function UploadImport(props: Props) {
     );
   };
 
+  const checkRowsLengthInCSV = (file: File) => {
+    return new Promise((resolve) => {
+      try {
+        const reader = new FileReader();
+
+        reader.onload = (event: ProgressEvent<FileReader>) => {
+          const cvsData = (event.target?.result as string) || '';
+          const rowData = cvsData.split('\n');
+
+          if (!rowData.length || rowData.length === 1) {
+            resolve(false);
+          } else if (rowData.length === 2 && !rowData[1]) {
+            resolve(false);
+          } else {
+            resolve(true);
+          }
+        };
+
+        reader.readAsText(file);
+      } catch (error) {
+        resolve(false);
+      }
+    });
+  };
+
+  const checkRowsLength = async (files: File[]) => {
+    for (let i = 0; i < files.length; i++) {
+      const hasCorrectRowsLength = await checkRowsLengthInCSV(files[i]);
+
+      if (!hasCorrectRowsLength) {
+        return false;
+      }
+    }
+
+    return true;
+  };
+
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     accept: { 'text/*': ['.csv'] },
-    onDrop: (acceptedFiles) => {
-      acceptedFiles.forEach((file) => {
-        setFiles((prevState) => [...prevState, { group, file }]);
-      });
+    onDrop: async (acceptedFiles) => {
+      const shouldAddFiles = await checkRowsLength(acceptedFiles);
+
+      if (shouldAddFiles) {
+        acceptedFiles.forEach((file) => {
+          setFiles((prevState) => [...prevState, { group, file }]);
+        });
+      } else {
+        toast.error('csv_rows_length');
+      }
     },
   });
 

--- a/src/pages/settings/import-export/common/components/UploadImport.tsx
+++ b/src/pages/settings/import-export/common/components/UploadImport.tsx
@@ -63,7 +63,7 @@ export function UploadImport(props: Props) {
     });
   };
 
-  const checkRowsLength = async (files: File[]) => {
+  const shouldUploadFiles = async (files: File[]) => {
     for (let i = 0; i < files.length; i++) {
       const hasCorrectRowsLength = await checkRowsLengthInCSV(files[i]);
 
@@ -78,7 +78,7 @@ export function UploadImport(props: Props) {
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     accept: { 'text/*': ['.csv'] },
     onDrop: async (acceptedFiles) => {
-      const shouldAddFiles = await checkRowsLength(acceptedFiles);
+      const shouldAddFiles = await shouldUploadFiles(acceptedFiles);
 
       if (shouldAddFiles) {
         acceptedFiles.forEach((file) => {


### PR DESCRIPTION
@beganovich @turbo124 The PR includes additional checks for row lengths on files uploaded under the Import | Export functionality. Therefore, if we encounter a single row/header, we will not consider those files as prepared for the final import, and we will display a toaster error message with the translation keyword `csv_rows_length`. This translation keyword should display a message similar to "Please check your files, as it appears the data is too short...". Please let me know if you agree with this translation keyword. Let me know your thoughts.