### PR TITLE
[Feature] New Export Types

### DIFF
--- a/src/pages/settings/import-export/common/components/Export.tsx
+++ b/src/pages/settings/import-export/common/components/Export.tsx
@@ -25,7 +25,24 @@ type Date =
   | 'partial_due_date'
   | 'payment_date';
 
-type ExportType = 'tasks' | 'activities';
+type ExportType =
+  | 'tasks'
+  | 'activities'
+  | 'clients'
+  | 'client_contacts'
+  | 'invoices'
+  | 'invoice_items'
+  | 'quotes'
+  | 'quote_items'
+  | 'credits'
+  | 'documents'
+  | 'expenses'
+  | 'purchase_orders'
+  | 'purchase_order_items'
+  | 'recurring_invoices'
+  | 'payments'
+  | 'products'
+  | 'vendors';
 
 interface Range {
   identifier: string;
@@ -43,6 +60,21 @@ interface Export {
 
 const EXPORTS_DATES: Record<ExportType, Date[]> = {
   activities: [],
+  clients: ['created_at'],
+  client_contacts: ['created_at'],
+  invoices: ['date', 'due_date', 'partial_due_date'],
+  invoice_items: ['date', 'due_date', 'partial_due_date'],
+  quotes: ['date', 'due_date', 'partial_due_date'],
+  quote_items: ['date', 'due_date', 'partial_due_date'],
+  credits: ['date', 'due_date', 'partial_due_date'],
+  documents: ['created_at'],
+  expenses: ['date', 'payment_date'],
+  purchase_orders: [],
+  purchase_order_items: [],
+  recurring_invoices: ['date', 'due_date', 'partial_due_date'],
+  payments: ['date'],
+  products: ['created_at'],
+  vendors: [],
   tasks: ['created_at'],
 };
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of new export types under the import_export section. The only thing we miss here is the `purchase_order_items` translation keyword, which should be added. Screenshot:

![Screenshot 2024-03-11 at 17 32 53](https://github.com/invoiceninja/ui/assets/51542191/a582dcd9-93a2-4ffc-b78a-f4a78212669e)

Let me know your thoughts.