### PR TITLE
[Feature] Purchase Page Column Implementation && Removing Purchase Page Link From Creation Page

### DIFF
--- a/src/pages/settings/subscriptions/common/components/Overview.tsx
+++ b/src/pages/settings/subscriptions/common/components/Overview.tsx
@@ -28,6 +28,7 @@ export interface SubscriptionProps {
     value: Subscription[keyof Subscription]
   ) => void;
   errors: ValidationBag | undefined;
+  page?: 'create' | 'edit';
 }
 
 interface OverviewSubscriptionProps extends SubscriptionProps {
@@ -37,7 +38,7 @@ interface OverviewSubscriptionProps extends SubscriptionProps {
 export function Overview(props: OverviewSubscriptionProps) {
   const [t] = useTranslation();
 
-  const { subscription, handleChange, errors, products } = props;
+  const { subscription, handleChange, errors, products, page } = props;
 
   return (
     <Card title={t('overview')}>
@@ -114,12 +115,14 @@ export function Overview(props: OverviewSubscriptionProps) {
         />
       </Element>
 
-      <Element leftSide={t('purchase_page')}>
-        <CopyToClipboard
-          className="break-all"
-          text={subscription.purchase_page}
-        />
-      </Element>
+      {page !== 'create' && (
+        <Element leftSide={t('purchase_page')}>
+          <CopyToClipboard
+            className="break-all"
+            text={subscription.purchase_page}
+          />
+        </Element>
+      )}
     </Card>
   );
 }

--- a/src/pages/settings/subscriptions/common/hooks/useSubscriptionColumns.tsx
+++ b/src/pages/settings/subscriptions/common/hooks/useSubscriptionColumns.tsx
@@ -11,7 +11,9 @@
 import { useFormatMoney } from '$app/common/hooks/money/useFormatMoney';
 import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { Subscription } from '$app/common/interfaces/subscription';
+import { CopyToClipboardIconOnly } from '$app/components/CopyToClipBoardIconOnly';
 import { DataTableColumns } from '$app/components/DataTable';
+import { Link } from '$app/components/forms';
 import { useTranslation } from 'react-i18next';
 
 export const useSubscriptionColumns = () => {
@@ -35,6 +37,22 @@ export const useSubscriptionColumns = () => {
           company?.settings.country_id,
           company?.settings.currency_id
         ),
+    },
+    {
+      id: 'purchase_page',
+      label: t('purchase_page'),
+      format: (value) => (
+        <div
+          className="flex space-x-2"
+          onClick={(event) => event.stopPropagation()}
+        >
+          <Link to={value as string} external>
+            {t('purchase_page')}
+          </Link>
+
+          <CopyToClipboardIconOnly text={value as string} />
+        </div>
+      ),
     },
   ];
 

--- a/src/pages/settings/subscriptions/create/Create.tsx
+++ b/src/pages/settings/subscriptions/create/Create.tsx
@@ -136,6 +136,7 @@ export function Create() {
               handleChange={handleChange}
               errors={errors}
               products={products}
+              page="create"
             />
           )}
         </div>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of the `purchase_page` column. Screenshot:

<img width="1261" alt="Screenshot 2024-03-11 at 18 59 55" src="https://github.com/invoiceninja/ui/assets/51542191/f26fff1e-20f8-4c06-b93f-1ca90fad4d7a">

Additionally, I noticed that we display the `purchase_page` link on the creation page. However, at that point, we do not yet have the correct URL since the ID for the object is not defined. Therefore, I removed this link from the creation page.

<img width="809" alt="Screenshot 2024-03-11 at 18 49 12" src="https://github.com/invoiceninja/ui/assets/51542191/732906e3-07ce-41e6-a303-8b8a77a1996c">

Let me know your thoughts.