### PR TITLE
[Cleanup] Past Due/Overdue Terminology Changing

### DIFF
--- a/src/pages/invoices/common/components/InvoiceStatus.tsx
+++ b/src/pages/invoices/common/components/InvoiceStatus.tsx
@@ -63,7 +63,7 @@ export function InvoiceStatus(props: Props) {
   }
 
   if (isPastDue() && !isCancelledOrReversed) {
-    return <Badge variant="yellow">{t('overdue')}</Badge>;
+    return <Badge variant="yellow">{t('past_due')}</Badge>;
   }
 
   if (isViewed && isUnpaid && !isPartial && !isCancelledOrReversed) {

--- a/src/pages/invoices/common/hooks/useInvoiceFilters.ts
+++ b/src/pages/invoices/common/hooks/useInvoiceFilters.ts
@@ -40,7 +40,7 @@ export function useInvoiceFilters() {
       backgroundColor: '#F97316',
     },
     {
-      label: t('overdue'),
+      label: t('past_due'),
       value: 'overdue',
       color: 'white',
       backgroundColor: '#CA8A04',


### PR DESCRIPTION
@beganovich @turbo124 The PR includes changing "overdue" to "past_due" in translated text. The terminology is not just changed in the status badge but also in the custom filter section. Of course, the same value will be sent in the query parameter, the change is only on the UI. Screenshot:

<img width="1261" alt="Screenshot 2024-03-11 at 19 25 54" src="https://github.com/invoiceninja/ui/assets/51542191/678d95cd-c080-4340-bbb1-6a956c4b2ac1">

Let me know your thoughts.
