### PR TITLE
[Cleanup] Product Modal Creation On Invoice Edit Page

### DIFF
--- a/src/pages/invoices/common/components/ProductCreate.tsx
+++ b/src/pages/invoices/common/components/ProductCreate.tsx
@@ -13,7 +13,7 @@ import { AxiosError } from 'axios';
 import { endpoint } from '$app/common/helpers';
 import { useBlankProductQuery } from '$app/common/queries/products';
 import { Modal } from '$app/components/Modal';
-import { FormEvent, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Product } from '$app/common/interfaces/product';
 import { request } from '$app/common/helpers/request';
@@ -43,9 +43,7 @@ export function ProductCreate(props: Props) {
 
   const handleChange = useHandleChange({ setErrors, setProduct });
 
-  const handleSave = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-
+  const handleSave = () => {
     if (!isFormBusy) {
       setIsFormBusy(true);
 
@@ -55,8 +53,11 @@ export function ProductCreate(props: Props) {
 
           $refetch(['products']);
 
+          setTimeout(() => {
+            props.onProductCreated?.(response.data.data);
+          }, 200);
+
           props.setIsModalOpen(false);
-          props.onProductCreated?.(response.data.data);
         })
         .catch((error: AxiosError<ValidationBag>) => {
           if (error.response?.status === 422) {


### PR DESCRIPTION
@beganovich @turbo124 I did not succeed in recreating the bug when the product is not selected in the combobox or created, but the modal is just closed. The logic seems very clear, it's just a function that creates the product. However, I made a little cleanup for this edge case that you experienced. Since we have an endpoint on the combobox that pulls 800 products on the first page, I consider that it could be a possible reason for this bug. 

Maybe it just needed a little bit more time for the endpoint to pull all products. I added a tiny timeout for the product selection in the combobox once the products are refetched in the list. It is not even visible on the UI, but I think it can help to always have a selected product in the combobox. Let me know your thoughts.