### PR TITLE
[Feature] Rappen Rounding Field | Localization

### DIFF
--- a/src/common/interfaces/company.interface.ts
+++ b/src/common/interfaces/company.interface.ts
@@ -315,6 +315,7 @@ export interface Settings {
   delivery_note_design_id: string;
   payment_receipt_design_id: string;
   payment_refund_design_id: string;
+  enable_rappen_rounding: boolean;
 }
 
 export interface TaxData {

--- a/src/pages/settings/localization/components/Settings.tsx
+++ b/src/pages/settings/localization/components/Settings.tsx
@@ -223,6 +223,32 @@ export function Settings() {
           />
         </Element>
 
+        <Element
+          leftSide={
+            <PropertyCheckbox
+              propertyKey="enable_rappen_rounding"
+              labelElement={
+                <SettingsLabel label={t('enable_rappen_rounding')} />
+              }
+              defaultValue={false}
+            />
+          }
+        >
+          <Toggle
+            checked={Boolean(company?.settings?.enable_rappen_rounding)}
+            onChange={(value: boolean) =>
+              dispatch(
+                updateChanges({
+                  object: 'company',
+                  property: 'settings.enable_rappen_rounding',
+                  value,
+                })
+              )
+            }
+            disabled={disableSettingsField('enable_rappen_rounding')}
+          />
+        </Element>
+
         {isCompanySettingsActive && <Divider />}
 
         {isCompanySettingsActive && (


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of the new localization field "Rappen Rounding". Screenshot:

<img width="1263" alt="Screenshot 2024-03-19 at 22 22 41" src="https://github.com/invoiceninja/ui/assets/51542191/2e32d73a-fda7-4202-bd0d-d2a2ed8d5e13">

Note: We're missing the "enable_rappen_rounding" translation keyword from files. If you agree with it, please just add it there.

Let me know your thoughts.