### PR TITLE
[Feature] Upcoming Recurring Invoices Dashboard Table

### DIFF
--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -69,12 +69,6 @@ export default function Dashboard() {
           </div>
         )}
 
-        {enabled(ModuleBitmask.RecurringInvoices) && (
-          <div className="col-span-12 xl:col-span-6">
-            <UpcomingRecurringInvoices />
-          </div>
-        )}
-
         {enabled(ModuleBitmask.Quotes) && (
           <div className="col-span-12 xl:col-span-6">
             <ExpiredQuotes />
@@ -84,6 +78,12 @@ export default function Dashboard() {
         {enabled(ModuleBitmask.Quotes) && (
           <div className="col-span-12 xl:col-span-6">
             <UpcomingQuotes />
+          </div>
+        )}
+
+        {enabled(ModuleBitmask.RecurringInvoices) && (
+          <div className="col-span-12 xl:col-span-6">
+            <UpcomingRecurringInvoices />
           </div>
         )}
       </div>

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -23,10 +23,11 @@ import { ExpiredQuotes } from './components/ExpiredQuotes';
 import { UpcomingQuotes } from './components/UpcomingQuotes';
 import { useEnabled } from '$app/common/guards/guards/enabled';
 import { ModuleBitmask } from '../settings';
+import { UpcomingRecurringInvoices } from './components/UpcomingRecurringInvoices';
 
 export default function Dashboard() {
   useTitle('dashboard');
-  
+
   const [t] = useTranslation();
 
   const user = useCurrentUser();
@@ -65,6 +66,12 @@ export default function Dashboard() {
         {enabled(ModuleBitmask.Invoices) && (
           <div className="col-span-12 xl:col-span-6">
             <PastDueInvoices />
+          </div>
+        )}
+
+        {enabled(ModuleBitmask.RecurringInvoices) && (
+          <div className="col-span-12 xl:col-span-6">
+            <UpcomingRecurringInvoices />
           </div>
         )}
 

--- a/src/pages/dashboard/components/UpcomingRecurringInvoices.tsx
+++ b/src/pages/dashboard/components/UpcomingRecurringInvoices.tsx
@@ -1,0 +1,116 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { useFormatMoney } from '$app/common/hooks/money/useFormatMoney';
+import { DataTable, DataTableColumns } from '$app/components/DataTable';
+import { t } from 'i18next';
+import { route } from '$app/common/helpers/route';
+import { Card } from '$app/components/cards';
+import { Badge } from '$app/components/Badge';
+import { useDisableNavigation } from '$app/common/hooks/useDisableNavigation';
+import { useCurrentCompanyDateFormats } from '$app/common/hooks/useCurrentCompanyDateFormats';
+import { DynamicLink } from '$app/components/DynamicLink';
+import { RecurringInvoice } from '$app/common/interfaces/recurring-invoice';
+import { date } from '$app/common/helpers';
+
+export function UpcomingRecurringInvoices() {
+  const formatMoney = useFormatMoney();
+  const { dateFormat } = useCurrentCompanyDateFormats();
+
+  const disableNavigation = useDisableNavigation();
+
+  const columns: DataTableColumns<RecurringInvoice> = [
+    {
+      id: 'number',
+      label: t('number'),
+      format: (_, recurringInvoice) => {
+        return (
+          <DynamicLink
+            to={route('/recurring_invoices/:id/edit', {
+              id: recurringInvoice.id,
+            })}
+            renderSpan={disableNavigation(
+              'recurring_invoice',
+              recurringInvoice
+            )}
+          >
+            {recurringInvoice.number}
+          </DynamicLink>
+        );
+      },
+    },
+    {
+      id: 'client_id',
+      label: t('client'),
+      format: (_, recurringInvoice) => (
+        <DynamicLink
+          to={route('/clients/:id', { id: recurringInvoice.client_id })}
+          renderSpan={disableNavigation('client', recurringInvoice.client)}
+        >
+          {recurringInvoice.client?.display_name}
+        </DynamicLink>
+      ),
+    },
+    {
+      id: 'next_send_date',
+      label: t('next_send_date'),
+      format: (value) => date(value, dateFormat),
+    },
+    {
+      id: 'balance',
+      label: t('balance'),
+      format: (value, recurringInvoice) => (
+        <Badge variant="red">
+          {formatMoney(
+            value,
+            recurringInvoice.client?.country_id,
+            recurringInvoice.client?.settings.currency_id
+          )}
+        </Badge>
+      ),
+    },
+  ];
+
+  return (
+    <Card
+      title={t('upcoming_recurring_invoices')}
+      className="h-96 relative"
+      withoutBodyPadding
+      withoutHeaderBorder
+    >
+      <div className="pl-6 pr-4">
+        <DataTable
+          resource="recurring_invoice"
+          columns={columns}
+          className="pr-4"
+          endpoint="/api/v1/recurring_invoices?include=client&client_status=active&without_deleted_clients=true&per_page=50&page=1&sort=next_send_date_client|asc"
+          withoutActions
+          withoutPagination
+          withoutPadding
+          styleOptions={{
+            addRowSeparator: true,
+            withoutBottomBorder: true,
+            withoutTopBorder: true,
+            withoutLeftBorder: true,
+            withoutRightBorder: true,
+            headerBackgroundColor: 'transparent',
+            thChildrenClassName: 'text-gray-500 dark:text-white',
+            tdClassName: 'first:pl-0 py-4',
+            thClassName: 'first:pl-0',
+            tBodyStyle: { border: 0 },
+          }}
+          style={{
+            height: '19.9rem',
+          }}
+        />
+      </div>
+    </Card>
+  );
+}


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of a new dashboard table for "Upcoming" Recurring Invoices. Screenshot:

<img width="1261" alt="Screenshot 2024-03-19 at 22 44 43" src="https://github.com/invoiceninja/ui/assets/51542191/379c9a1f-cf75-4a81-8ab3-8236c743a17a">


`Note`: We're missing the "upcoming_recurring_invoices" translation keyword from the files, so if you agree, please just add it.

Let me know your thoughts.