### PR TITLE
[Bugfix] Displaying Upgrade Plan Button

### DIFF
--- a/src/common/hooks/useUnlockButtonForHosted.ts
+++ b/src/common/hooks/useUnlockButtonForHosted.ts
@@ -10,12 +10,18 @@
 
 import { freePlan } from '$app/common/guards/guards/free-plan';
 import { isHosted } from '$app/common/helpers';
+import { useAdmin } from './permissions/useHasPermission';
 import { useCurrentAccount } from './useCurrentAccount';
 
 export function useUnlockButtonForHosted() {
   const account = useCurrentAccount();
+  const { isAdmin, isOwner } = useAdmin();
 
   const isPlanExpired = new Date(account?.plan_expires) < new Date();
 
-  return isHosted() && (freePlan() || (account?.plan && isPlanExpired));
+  return (
+    isHosted() &&
+    (freePlan() || (account?.plan && isPlanExpired)) &&
+    (isAdmin || isOwner)
+  );
 }

--- a/src/common/hooks/useUnlockButtonForSelfHosted.ts
+++ b/src/common/hooks/useUnlockButtonForSelfHosted.ts
@@ -9,12 +9,18 @@
  */
 
 import { isSelfHosted } from '$app/common/helpers';
+import { useAdmin } from './permissions/useHasPermission';
 import { useCurrentAccount } from './useCurrentAccount';
 
 export function useUnlockButtonForSelfHosted() {
   const account = useCurrentAccount();
+  const { isAdmin, isOwner } = useAdmin();
 
   const isPlanExpired = new Date(account?.plan_expires) < new Date();
 
-  return isSelfHosted() && ((account?.plan && isPlanExpired) || !account?.plan);
+  return (
+    isSelfHosted() &&
+    ((account?.plan && isPlanExpired) || !account?.plan) &&
+    (isAdmin || isOwner)
+  );
 }

--- a/src/components/layouts/Default.tsx
+++ b/src/components/layouts/Default.tsx
@@ -31,10 +31,7 @@ import { Button } from '$app/components/forms';
 import { Breadcrumbs, Page } from '$app/components/Breadcrumbs';
 import { DesktopSidebar, NavigationItem } from './components/DesktopSidebar';
 import { MobileSidebar } from './components/MobileSidebar';
-import {
-  useAdmin,
-  useHasPermission,
-} from '$app/common/hooks/permissions/useHasPermission';
+import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 import { BiBuildings, BiWallet, BiFile } from 'react-icons/bi';
 import { AiOutlineBank } from 'react-icons/ai';
 import { ModuleBitmask } from '$app/pages/settings/account-management/component';
@@ -363,7 +360,6 @@ export function Default(props: Props) {
     },
   ];
 
-  const { isOwner } = useAdmin();
   const saveBtn = useAtomValue(saveBtnAtom);
   const navigationTopRightElement = useNavigationTopRightElement();
   const colors = useColorScheme();
@@ -430,9 +426,7 @@ export function Default(props: Props) {
                   }
                 >
                   <span>
-                    {isSelfHosted() && isOwner
-                      ? t('white_label_button')
-                      : t('unlock_pro')}
+                    {isSelfHosted() ? t('white_label_button') : t('unlock_pro')}
                   </span>
                 </button>
               )}


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for displaying the upgrade plan button for both hosted and self-hosted platforms. So, the "white_label_button" will be displayed only for ADMIN/OWNER users on the SELF-HOSTED platform, while the "unlock_pro" button will be displayed only for ADMIN/OWNER users on the HOSTED platform. Sub-accounts that are not admins or owners will not have any buttons displayed for upgrading the plan. Let me know your thoughts.