### PR TITLE
[Cleanup] Adjusting Code Cards Height | Custom Designs

### DIFF
--- a/src/components/cards/Card.tsx
+++ b/src/components/cards/Card.tsx
@@ -55,12 +55,13 @@ interface Props {
   childrenClassName?: string;
   withoutHeaderBorder?: boolean;
   topRight?: ReactNode;
+  height?: 'full';
 }
 
 export function Card(props: Props) {
   const [t] = useTranslation();
 
-  const { padding = 'regular' } = props;
+  const { padding = 'regular', height } = props;
 
   const [isCollapsed, setIsCollpased] = useState(props.collapsed);
 
@@ -70,7 +71,10 @@ export function Card(props: Props) {
     <div
       className={classNames(
         `border shadow rounded overflow-visible ${props.className}`,
-        { 'overflow-y-auto': props.withScrollableBody }
+        {
+          'overflow-y-auto': props.withScrollableBody,
+          'h-full': height === 'full',
+        }
       )}
       style={{
         ...props.style,
@@ -79,7 +83,10 @@ export function Card(props: Props) {
         borderColor: colors.$4,
       }}
     >
-      <form onSubmit={props.onFormSubmit}>
+      <form
+        onSubmit={props.onFormSubmit}
+        className={classNames({ 'h-full': height === 'full' })}
+      >
         {props.title && (
           <div
             className={classNames({
@@ -134,6 +141,7 @@ export function Card(props: Props) {
             'py-0': props.withoutBodyPadding,
             'py-4': padding === 'regular' && !props.withoutBodyPadding,
             'py-2': padding === 'small' && !props.withoutBodyPadding,
+            'h-full': height === 'full',
           })}
         >
           {props.isLoading && <Element leftSide={<Spinner />} />}

--- a/src/pages/settings/invoice-design/pages/custom-designs/CustomDesign.tsx
+++ b/src/pages/settings/invoice-design/pages/custom-designs/CustomDesign.tsx
@@ -115,7 +115,7 @@ export default function CustomDesign() {
 
       <PanelGroup>
         <Panel>
-          <div className="space-y-4 max-h-[80vh] overflow-y-auto">
+          <div className="space-y-4 h-full max-h-[80vh] overflow-y-auto">
             <Outlet
               context={{
                 errors,

--- a/src/pages/settings/invoice-design/pages/custom-designs/pages/edit/components/Body.tsx
+++ b/src/pages/settings/invoice-design/pages/custom-designs/pages/edit/components/Body.tsx
@@ -32,10 +32,9 @@ export default function Body() {
   useDebounce(() => value && handleBlockChange('body', value), 1000, [value]);
 
   return (
-    <Card title={t('body')} padding="small">
+    <Card title={t('body')} padding="small" height="full">
       <Editor
         theme={colors.name === 'invoiceninja.dark' ? 'vs-dark' : 'light'}
-        height="25rem"
         defaultLanguage="html"
         value={payload.design?.design.body}
         options={{

--- a/src/pages/settings/invoice-design/pages/custom-designs/pages/edit/components/Footer.tsx
+++ b/src/pages/settings/invoice-design/pages/custom-designs/pages/edit/components/Footer.tsx
@@ -42,10 +42,9 @@ export default function Footer() {
   useDebounce(() => value && handleBlockChange('footer', value), 1000, [value]);
 
   return (
-    <Card title={t('footer')} padding="small">
+    <Card title={t('footer')} padding="small" height="full">
       <Editor
         theme={colors.name === 'invoiceninja.dark' ? 'vs-dark' : 'light'}
-        height="25rem"
         defaultLanguage="html"
         value={payload.design?.design.footer}
         options={{

--- a/src/pages/settings/invoice-design/pages/custom-designs/pages/edit/components/Headers.tsx
+++ b/src/pages/settings/invoice-design/pages/custom-designs/pages/edit/components/Headers.tsx
@@ -32,10 +32,9 @@ export default function Header() {
   const colors = useColorScheme();
 
   return (
-    <Card title={t('header')} padding="small">
+    <Card title={t('header')} padding="small" height="full">
       <Editor
         theme={colors.name === 'invoiceninja.dark' ? 'vs-dark' : 'light'}
-        height="25rem"
         defaultLanguage="html"
         value={payload.design?.design.header}
         options={{

--- a/src/pages/settings/invoice-design/pages/custom-designs/pages/edit/components/Includes.tsx
+++ b/src/pages/settings/invoice-design/pages/custom-designs/pages/edit/components/Includes.tsx
@@ -44,9 +44,8 @@ export default function Includes() {
   ]);
 
   return (
-    <Card title={t('includes')} padding="small">
+    <Card title={t('includes')} padding="small" height="full">
       <Editor
-        height="25rem"
         defaultLanguage="html"
         value={payload.design?.design.includes}
         theme={colors.name === 'invoiceninja.dark' ? 'vs-dark' : 'light'}


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adjusting the height for cards on custom design pages. Screenshot:

<img width="1261" alt="Screenshot 2024-03-26 at 19 31 41" src="https://github.com/invoiceninja/ui/assets/51542191/d5f82995-2593-49e7-a430-62d8ad247505">

Let me know your thoughts.