### PR TITLE
[Bugfix] Fixing Date Formatting On Range Picker Value Change

### DIFF
--- a/src/components/DropdownDateRangePicker.tsx
+++ b/src/components/DropdownDateRangePicker.tsx
@@ -52,9 +52,9 @@ export function DropdownDateRangePicker(props: Props) {
     }
 
     props.handleDateChange(
-      dayjs(value[0], dateFormat, antdLocale?.locale).format('YYYY-MM-DD') +
+      dayjs(value[0]).format('YYYY-MM-DD') +
         ',' +
-        dayjs(value[1], dateFormat, antdLocale?.locale).format('YYYY-MM-DD')
+        dayjs(value[1]).format('YYYY-MM-DD')
     );
   };
 

--- a/src/components/DropdownDateRangePicker.tsx
+++ b/src/components/DropdownDateRangePicker.tsx
@@ -51,10 +51,20 @@ export function DropdownDateRangePicker(props: Props) {
       return;
     }
 
+    const unsupportedFormats = ['DD. MMM. YYYY', 'ddd MMM D, YYYY'];
+
     props.handleDateChange(
-      dayjs(value[0], dateFormat || undefined).format('YYYY-MM-DD') +
+      dayjs(
+        value[0],
+        !unsupportedFormats.includes(dateFormat) ? dateFormat : undefined,
+        antdLocale?.locale
+      ).format('YYYY-MM-DD') +
         ',' +
-        dayjs(value[1], dateFormat || undefined).format('YYYY-MM-DD')
+        dayjs(
+          value[1],
+          !unsupportedFormats.includes(dateFormat) ? dateFormat : undefined,
+          antdLocale?.locale
+        ).format('YYYY-MM-DD')
     );
   };
 

--- a/src/components/DropdownDateRangePicker.tsx
+++ b/src/components/DropdownDateRangePicker.tsx
@@ -52,9 +52,9 @@ export function DropdownDateRangePicker(props: Props) {
     }
 
     props.handleDateChange(
-      dayjs(value[0]).format('YYYY-MM-DD') +
+      dayjs(value[0], dateFormat || undefined).format('YYYY-MM-DD') +
         ',' +
-        dayjs(value[1]).format('YYYY-MM-DD')
+        dayjs(value[1], dateFormat || undefined).format('YYYY-MM-DD')
     );
   };
 

--- a/src/components/datatables/DateRangePicker.tsx
+++ b/src/components/datatables/DateRangePicker.tsx
@@ -49,12 +49,22 @@ export function DateRangePicker(props: Props) {
   const handleChangeValue = (value: [string, string]) => {
     dayjs.extend(customParseFormat);
 
+    const unsupportedFormats = ['DD. MMM. YYYY', 'ddd MMM D, YYYY'];
+
     const start = value[0]
-      ? dayjs(value[0], dateFormat || undefined).format('YYYY-MM-DD')
+      ? dayjs(
+          value[0],
+          !unsupportedFormats.includes(dateFormat) ? dateFormat : undefined,
+          antdLocale?.locale
+        ).format('YYYY-MM-DD')
       : '';
 
     const end = value[1]
-      ? dayjs(value[1], dateFormat || undefined).format('YYYY-MM-DD')
+      ? dayjs(
+          value[1],
+          !unsupportedFormats.includes(dateFormat) ? dateFormat : undefined,
+          antdLocale?.locale
+        ).format('YYYY-MM-DD')
       : '';
 
     setCurrentDateRange(start || end ? [start, end].join(',') : '');

--- a/src/components/datatables/DateRangePicker.tsx
+++ b/src/components/datatables/DateRangePicker.tsx
@@ -49,13 +49,9 @@ export function DateRangePicker(props: Props) {
   const handleChangeValue = (value: [string, string]) => {
     dayjs.extend(customParseFormat);
 
-    const start = value[0]
-      ? dayjs(value[0], dateFormat, antdLocale?.locale).format('YYYY-MM-DD')
-      : '';
+    const start = value[0] ? dayjs(value[0]).format('YYYY-MM-DD') : '';
 
-    const end = value[1]
-      ? dayjs(value[1], dateFormat, antdLocale?.locale).format('YYYY-MM-DD')
-      : '';
+    const end = value[1] ? dayjs(value[1]).format('YYYY-MM-DD') : '';
 
     setCurrentDateRange(start || end ? [start, end].join(',') : '');
 

--- a/src/components/datatables/DateRangePicker.tsx
+++ b/src/components/datatables/DateRangePicker.tsx
@@ -49,9 +49,13 @@ export function DateRangePicker(props: Props) {
   const handleChangeValue = (value: [string, string]) => {
     dayjs.extend(customParseFormat);
 
-    const start = value[0] ? dayjs(value[0]).format('YYYY-MM-DD') : '';
+    const start = value[0]
+      ? dayjs(value[0], dateFormat || undefined).format('YYYY-MM-DD')
+      : '';
 
-    const end = value[1] ? dayjs(value[1]).format('YYYY-MM-DD') : '';
+    const end = value[1]
+      ? dayjs(value[1], dateFormat || undefined).format('YYYY-MM-DD')
+      : '';
 
     setCurrentDateRange(start || end ? [start, end].join(',') : '');
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes with date formatting on the range picker on the invoices table and dashboard. So, the issue was related to the `dayjs` library not supporting our two formats (`'DD. MMM. YYYY'` and.`'ddd MMM D, YYYY'`). Once we select those two formats, we should not pass them to the `dayjs` function. Only if we do not pass the format, it will be formatted correctly. Let me know your thoughts.