### PR TITLE
[Feature] Implementing Default Palette Modal Picker | Invoice Design

### DIFF
--- a/src/components/forms/ColorPicker.tsx
+++ b/src/components/forms/ColorPicker.tsx
@@ -23,6 +23,7 @@ interface Props {
   value?: string;
   onValueChange?: (color: string) => unknown;
   disabled?: boolean;
+  includeDefaultPalette?: boolean;
 }
 
 const DEFAULT_COLORS = [
@@ -55,14 +56,17 @@ const DEFAULT_COLORS = [
 export function ColorPicker(props: Props) {
   const { t } = useTranslation();
 
+  const { includeDefaultPalette } = props;
+
+  const colors = useColorScheme();
+
   const [color, setColor] = useState(props.value || '#000000');
+
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [isDefaultPaletteModalOpen, setIsDefaultPaletteModalOpen] =
     useState<boolean>(false);
 
   useDebounce(() => props.onValueChange?.(color), 500, [color]);
-
-  const colors = useColorScheme();
 
   useEffect(() => {
     props.value && setColor(props.value);
@@ -75,6 +79,7 @@ export function ColorPicker(props: Props) {
         visible={isModalOpen}
         onClose={setIsModalOpen}
         centerContent
+        disableClosing={isDefaultPaletteModalOpen}
       >
         <HexColorPicker color={color} onChange={setColor} />
         <HexColorInput
@@ -84,9 +89,19 @@ export function ColorPicker(props: Props) {
           style={{ backgroundColor: colors.$1, borderColor: colors.$4 }}
         />
 
-        <div className="flex">
+        <div className="flex w-full justify-between">
+          {includeDefaultPalette && (
+            <Button
+              behavior="button"
+              type="secondary"
+              onClick={() => setIsDefaultPaletteModalOpen(true)}
+            >
+              {t('default')}
+            </Button>
+          )}
+
           <Button
-            className="w-full"
+            className={classNames({ 'w-full': !includeDefaultPalette })}
             behavior="button"
             onClick={() => setIsModalOpen(false)}
           >
@@ -96,7 +111,7 @@ export function ColorPicker(props: Props) {
       </Modal>
 
       <Modal
-        title={t('default_palette')}
+        title={t('default')}
         visible={isDefaultPaletteModalOpen}
         size="small"
         onClose={() => setIsDefaultPaletteModalOpen(false)}
@@ -123,13 +138,14 @@ export function ColorPicker(props: Props) {
             ))}
           </div>
 
-          <Button
-            className="self-end"
-            behavior="button"
-            onClick={() => setIsDefaultPaletteModalOpen(false)}
-          >
-            {t('done')}
-          </Button>
+          <div className="flex justify-end">
+            <Button
+              behavior="button"
+              onClick={() => setIsDefaultPaletteModalOpen(false)}
+            >
+              {t('done')}
+            </Button>
+          </div>
         </div>
       </Modal>
 

--- a/src/components/forms/ColorPicker.tsx
+++ b/src/components/forms/ColorPicker.tsx
@@ -16,6 +16,8 @@ import { HexColorPicker, HexColorInput } from 'react-colorful';
 import { useTranslation } from 'react-i18next';
 import { useDebounce } from 'react-use';
 import { Button } from './Button';
+import { Icon } from '../icons/Icon';
+import { MdDone } from 'react-icons/md';
 
 interface Props {
   value?: string;
@@ -23,11 +25,40 @@ interface Props {
   disabled?: boolean;
 }
 
+const DEFAULT_COLORS = [
+  '#f44336',
+  '#e91e63',
+  '#9c27b0',
+  '#673ab7',
+  '#3f51b5',
+  '#2f7dc3',
+  '#2196f3',
+  '#03a9f4',
+  '#00bcd4',
+  '#009688',
+  '#4caf50',
+  '#8bc34a',
+  '#ff9800',
+  '#ff5722',
+  '#795548',
+  '#9e9e9e',
+  '#607d8b',
+  '#616161',
+  '#000000',
+  '#57a6e4',
+  '#324da1',
+  '#4c9a1c',
+  '#cd8900',
+  '#b93700',
+];
+
 export function ColorPicker(props: Props) {
   const { t } = useTranslation();
 
   const [color, setColor] = useState(props.value || '#000000');
-  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [isDefaultPaletteModalOpen, setIsDefaultPaletteModalOpen] =
+    useState<boolean>(false);
 
   useDebounce(() => props.onValueChange?.(color), 500, [color]);
 
@@ -53,13 +84,53 @@ export function ColorPicker(props: Props) {
           style={{ backgroundColor: colors.$1, borderColor: colors.$4 }}
         />
 
-        <Button
-          className="w-full"
-          behavior="button"
-          onClick={() => setIsModalOpen(false)}
-        >
-          {t('done')}
-        </Button>
+        <div className="flex">
+          <Button
+            className="w-full"
+            behavior="button"
+            onClick={() => setIsModalOpen(false)}
+          >
+            {t('done')}
+          </Button>
+        </div>
+      </Modal>
+
+      <Modal
+        title={t('default_palette')}
+        visible={isDefaultPaletteModalOpen}
+        size="small"
+        onClose={() => setIsDefaultPaletteModalOpen(false)}
+      >
+        <div className="flex flex-col space-y-6">
+          <div className="grid grid-cols-6 gap-x-2 gap-y-2">
+            {DEFAULT_COLORS.map((defaultColor) => (
+              <div
+                key={defaultColor}
+                className="relative cursor-pointer w-full hover:opacity-75"
+                onClick={() => setColor(defaultColor)}
+                style={{ height: 32, backgroundColor: defaultColor }}
+              >
+                {color === defaultColor && (
+                  <Icon
+                    className="absolute"
+                    element={MdDone}
+                    color="white"
+                    size={25}
+                    style={{ top: '0.3rem', left: '1.45rem' }}
+                  />
+                )}
+              </div>
+            ))}
+          </div>
+
+          <Button
+            className="self-end"
+            behavior="button"
+            onClick={() => setIsDefaultPaletteModalOpen(false)}
+          >
+            {t('done')}
+          </Button>
+        </div>
       </Modal>
 
       <div

--- a/src/pages/settings/invoice-design/pages/general-settings/components/GeneralSettings.tsx
+++ b/src/pages/settings/invoice-design/pages/general-settings/components/GeneralSettings.tsx
@@ -1348,6 +1348,7 @@ export default function GeneralSettings() {
             }
           }}
           disabled={disableSettingsField('primary_color')}
+          includeDefaultPalette
         />
       </Element>
 
@@ -1370,6 +1371,7 @@ export default function GeneralSettings() {
             }
           }}
           disabled={disableSettingsField('secondary_color')}
+          includeDefaultPalette
         />
       </Element>
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of the default palette color picker for "primary" and "secondary" colors on the general settings invoice design page, in the standard color picker. Screenshots:

![Screenshot 2024-03-29 at 01 32 08](https://github.com/invoiceninja/ui/assets/51542191/db45e00e-dc53-4a83-9eaf-eed3fb6605b5)

![Screenshot 2024-03-29 at 01 32 17](https://github.com/invoiceninja/ui/assets/51542191/4df53970-04cb-4d0e-8e1a-b2fa088fda54)

Let me know your thoughts.