### PR TITLE
[Cleanup] Next Send Date Property Formatting In Date Time Format | Recurring Invoices

### DIFF
--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -15,6 +15,7 @@ import { route } from '$app/common/helpers/route';
 import entityState from './constants/entity-state';
 import { request } from './helpers/request';
 import { useCurrentCompanyDateFormats } from './hooks/useCurrentCompanyDateFormats';
+import { useCompanyTimeFormat } from './hooks/useCompanyTimeFormat';
 
 export function isHosted(): boolean {
   return import.meta.env.VITE_IS_HOSTED === 'true';
@@ -62,6 +63,29 @@ export function date(date: number | string, format: string) {
   }
 
   return dayjs(date).format(format);
+}
+
+export function dateTime(
+  date: number | string,
+  dateFormat?: string,
+  timeFormat?: string
+) {
+  const { timeFormat: companyTimeFormat } = useCompanyTimeFormat();
+  const { dateFormat: companyDateFormat } = useCurrentCompanyDateFormats();
+
+  if (date === 0 || date === '' || date === undefined) {
+    return '';
+  }
+
+  const finalFormat = `${dateFormat || companyDateFormat} ${
+    timeFormat || companyTimeFormat
+  }`;
+
+  if (typeof date === 'number') {
+    return dayjs.unix(date).format(finalFormat);
+  }
+
+  return dayjs(date).format(finalFormat);
 }
 
 export function useParseDayjs() {

--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -15,7 +15,6 @@ import { route } from '$app/common/helpers/route';
 import entityState from './constants/entity-state';
 import { request } from './helpers/request';
 import { useCurrentCompanyDateFormats } from './hooks/useCurrentCompanyDateFormats';
-import { useCompanyTimeFormat } from './hooks/useCompanyTimeFormat';
 
 export function isHosted(): boolean {
   return import.meta.env.VITE_IS_HOSTED === 'true';
@@ -63,27 +62,6 @@ export function date(date: number | string, format: string) {
   }
 
   return dayjs(date).format(format);
-}
-
-export function useDateTime() {
-  const { timeFormat: companyTimeFormat } = useCompanyTimeFormat();
-  const { dateFormat: companyDateFormat } = useCurrentCompanyDateFormats();
-
-  return (date: number | string, dateFormat?: string, timeFormat?: string) => {
-    if (date === 0 || date === '' || date === undefined) {
-      return '';
-    }
-
-    const finalFormat = `${dateFormat || companyDateFormat} ${
-      timeFormat || companyTimeFormat
-    }`;
-
-    if (typeof date === 'number') {
-      return dayjs.unix(date).format(finalFormat);
-    }
-
-    return dayjs(date).format(finalFormat);
-  };
 }
 
 export function useParseDayjs() {

--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -65,27 +65,25 @@ export function date(date: number | string, format: string) {
   return dayjs(date).format(format);
 }
 
-export function dateTime(
-  date: number | string,
-  dateFormat?: string,
-  timeFormat?: string
-) {
+export function useDateTime() {
   const { timeFormat: companyTimeFormat } = useCompanyTimeFormat();
   const { dateFormat: companyDateFormat } = useCurrentCompanyDateFormats();
 
-  if (date === 0 || date === '' || date === undefined) {
-    return '';
-  }
+  return (date: number | string, dateFormat?: string, timeFormat?: string) => {
+    if (date === 0 || date === '' || date === undefined) {
+      return '';
+    }
 
-  const finalFormat = `${dateFormat || companyDateFormat} ${
-    timeFormat || companyTimeFormat
-  }`;
+    const finalFormat = `${dateFormat || companyDateFormat} ${
+      timeFormat || companyTimeFormat
+    }`;
 
-  if (typeof date === 'number') {
-    return dayjs.unix(date).format(finalFormat);
-  }
+    if (typeof date === 'number') {
+      return dayjs.unix(date).format(finalFormat);
+    }
 
-  return dayjs(date).format(finalFormat);
+    return dayjs(date).format(finalFormat);
+  };
 }
 
 export function useParseDayjs() {

--- a/src/common/hooks/useCompanyTimeZone.ts
+++ b/src/common/hooks/useCompanyTimeZone.ts
@@ -1,0 +1,40 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { useStaticsQuery } from '$app/common/queries/statics';
+import { useEffect, useState } from 'react';
+import { useCurrentCompany } from './useCurrentCompany';
+
+export function useCompanyTimeZone() {
+  const company = useCurrentCompany();
+
+  const { data: statics } = useStaticsQuery();
+
+  const [timeZoneId, setTimeZoneId] = useState('1');
+  const [timeZone, setTimZone] = useState('America/Tijuana');
+
+  useEffect(() => {
+    if (statics?.timezones) {
+      const result = statics.timezones.find(
+        (format: any) => format.id === company?.settings?.timezone_id ?? '1'
+      );
+
+      if (result) {
+        setTimZone(result.name);
+        setTimeZoneId(result.id);
+      }
+    }
+  }, [company, statics]);
+
+  return {
+    timeZoneId,
+    timeZone,
+  };
+}

--- a/src/common/hooks/useDateTime.ts
+++ b/src/common/hooks/useDateTime.ts
@@ -17,6 +17,7 @@ import timezone from 'dayjs/plugin/timezone';
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
+
 export function useDateTime() {
   const { timeZone: companyTimeZone } = useCompanyTimeZone();
   const { timeFormat: companyTimeFormat } = useCompanyTimeFormat();
@@ -38,12 +39,13 @@ export function useDateTime() {
 
     if (typeof date === 'number') {
       return dayjs
-        .unix(date)
+        .utc(date)
         .tz(timeZone || companyTimeZone)
         .format(finalFormat);
     }
 
-    return dayjs(date)
+    return dayjs
+      .utc(date)
       .tz(timeZone || companyTimeZone)
       .format(finalFormat);
   };

--- a/src/common/hooks/useDateTime.ts
+++ b/src/common/hooks/useDateTime.ts
@@ -1,0 +1,50 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import dayjs from 'dayjs';
+import { useCompanyTimeFormat } from './useCompanyTimeFormat';
+import { useCompanyTimeZone } from './useCompanyTimeZone';
+import { useCurrentCompanyDateFormats } from './useCurrentCompanyDateFormats';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+export function useDateTime() {
+  const { timeZone: companyTimeZone } = useCompanyTimeZone();
+  const { timeFormat: companyTimeFormat } = useCompanyTimeFormat();
+  const { dateFormat: companyDateFormat } = useCurrentCompanyDateFormats();
+
+  return (
+    date: number | string,
+    dateFormat?: string,
+    timeFormat?: string,
+    timeZone?: string
+  ) => {
+    if (date === 0 || date === '' || date === undefined) {
+      return '';
+    }
+
+    const finalFormat = `${dateFormat || companyDateFormat} ${
+      timeFormat || companyTimeFormat
+    }`;
+
+    if (typeof date === 'number') {
+      return dayjs
+        .unix(date)
+        .tz(timeZone || companyTimeZone)
+        .format(finalFormat);
+    }
+
+    return dayjs(date)
+      .tz(timeZone || companyTimeZone)
+      .format(finalFormat);
+  };
+}

--- a/src/pages/dashboard/components/UpcomingRecurringInvoices.tsx
+++ b/src/pages/dashboard/components/UpcomingRecurringInvoices.tsx
@@ -17,9 +17,10 @@ import { Badge } from '$app/components/Badge';
 import { useDisableNavigation } from '$app/common/hooks/useDisableNavigation';
 import { DynamicLink } from '$app/components/DynamicLink';
 import { RecurringInvoice } from '$app/common/interfaces/recurring-invoice';
-import { dateTime } from '$app/common/helpers';
+import { useDateTime } from '$app/common/helpers';
 
 export function UpcomingRecurringInvoices() {
+  const dateTime = useDateTime();
   const formatMoney = useFormatMoney();
   const disableNavigation = useDisableNavigation();
 

--- a/src/pages/dashboard/components/UpcomingRecurringInvoices.tsx
+++ b/src/pages/dashboard/components/UpcomingRecurringInvoices.tsx
@@ -17,7 +17,7 @@ import { Badge } from '$app/components/Badge';
 import { useDisableNavigation } from '$app/common/hooks/useDisableNavigation';
 import { DynamicLink } from '$app/components/DynamicLink';
 import { RecurringInvoice } from '$app/common/interfaces/recurring-invoice';
-import { useDateTime } from '$app/common/helpers';
+import { useDateTime } from '$app/common/hooks/useDateTime';
 
 export function UpcomingRecurringInvoices() {
   const dateTime = useDateTime();
@@ -57,7 +57,7 @@ export function UpcomingRecurringInvoices() {
       ),
     },
     {
-      id: 'next_send_date',
+      id: 'next_send_datetime',
       label: t('next_send_date'),
       format: (value) => dateTime(value),
     },

--- a/src/pages/dashboard/components/UpcomingRecurringInvoices.tsx
+++ b/src/pages/dashboard/components/UpcomingRecurringInvoices.tsx
@@ -15,15 +15,12 @@ import { route } from '$app/common/helpers/route';
 import { Card } from '$app/components/cards';
 import { Badge } from '$app/components/Badge';
 import { useDisableNavigation } from '$app/common/hooks/useDisableNavigation';
-import { useCurrentCompanyDateFormats } from '$app/common/hooks/useCurrentCompanyDateFormats';
 import { DynamicLink } from '$app/components/DynamicLink';
 import { RecurringInvoice } from '$app/common/interfaces/recurring-invoice';
-import { date } from '$app/common/helpers';
+import { dateTime } from '$app/common/helpers';
 
 export function UpcomingRecurringInvoices() {
   const formatMoney = useFormatMoney();
-  const { dateFormat } = useCurrentCompanyDateFormats();
-
   const disableNavigation = useDisableNavigation();
 
   const columns: DataTableColumns<RecurringInvoice> = [
@@ -61,7 +58,7 @@ export function UpcomingRecurringInvoices() {
     {
       id: 'next_send_date',
       label: t('next_send_date'),
-      format: (value) => date(value, dateFormat),
+      format: (value) => dateTime(value),
     },
     {
       id: 'balance',

--- a/src/pages/recurring-invoices/common/components/RecurringInvoiceSlider.tsx
+++ b/src/pages/recurring-invoices/common/components/RecurringInvoiceSlider.tsx
@@ -16,7 +16,7 @@ import { Slider } from '$app/components/cards/Slider';
 import { atom, useAtom } from 'jotai';
 import { useTranslation } from 'react-i18next';
 import { useCurrentCompanyDateFormats } from '$app/common/hooks/useCurrentCompanyDateFormats';
-import { date, endpoint, trans, useDateTime } from '$app/common/helpers';
+import { date, endpoint, trans } from '$app/common/helpers';
 import { ResourceActions } from '$app/components/ResourceActions';
 import { toast } from '$app/common/helpers/toast/toast';
 import { useQuery } from 'react-query';
@@ -46,6 +46,7 @@ import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission
 import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
 import { useDisableNavigation } from '$app/common/hooks/useDisableNavigation';
 import { DynamicLink } from '$app/components/DynamicLink';
+import { useDateTime } from '$app/common/hooks/useDateTime';
 
 export const recurringInvoiceSliderAtom = atom<RecurringInvoice | null>(null);
 export const recurringInvoiceSliderVisibilityAtom = atom(false);
@@ -194,7 +195,7 @@ export const RecurringInvoiceSlider = () => {
             {recurringInvoice && recurringInvoice.next_send_date ? (
               <Element leftSide={t('next_send_date')}>
                 {recurringInvoice
-                  ? dateTime(recurringInvoice.next_send_date)
+                  ? dateTime(recurringInvoice.next_send_datetime)
                   : null}
               </Element>
             ) : null}

--- a/src/pages/recurring-invoices/common/components/RecurringInvoiceSlider.tsx
+++ b/src/pages/recurring-invoices/common/components/RecurringInvoiceSlider.tsx
@@ -16,7 +16,7 @@ import { Slider } from '$app/components/cards/Slider';
 import { atom, useAtom } from 'jotai';
 import { useTranslation } from 'react-i18next';
 import { useCurrentCompanyDateFormats } from '$app/common/hooks/useCurrentCompanyDateFormats';
-import { date, dateTime, endpoint, trans } from '$app/common/helpers';
+import { date, endpoint, trans, useDateTime } from '$app/common/helpers';
 import { ResourceActions } from '$app/components/ResourceActions';
 import { toast } from '$app/common/helpers/toast/toast';
 import { useQuery } from 'react-query';
@@ -96,6 +96,7 @@ export const RecurringInvoiceSlider = () => {
   );
   const [t] = useTranslation();
 
+  const dateTime = useDateTime();
   const hasPermission = useHasPermission();
   const entityAssigned = useEntityAssigned();
   const disableNavigation = useDisableNavigation();

--- a/src/pages/recurring-invoices/common/components/RecurringInvoiceSlider.tsx
+++ b/src/pages/recurring-invoices/common/components/RecurringInvoiceSlider.tsx
@@ -16,7 +16,7 @@ import { Slider } from '$app/components/cards/Slider';
 import { atom, useAtom } from 'jotai';
 import { useTranslation } from 'react-i18next';
 import { useCurrentCompanyDateFormats } from '$app/common/hooks/useCurrentCompanyDateFormats';
-import { date, endpoint, trans } from '$app/common/helpers';
+import { date, dateTime, endpoint, trans } from '$app/common/helpers';
 import { ResourceActions } from '$app/components/ResourceActions';
 import { toast } from '$app/common/helpers/toast/toast';
 import { useQuery } from 'react-query';
@@ -193,7 +193,7 @@ export const RecurringInvoiceSlider = () => {
             {recurringInvoice && recurringInvoice.next_send_date ? (
               <Element leftSide={t('next_send_date')}>
                 {recurringInvoice
-                  ? date(recurringInvoice.next_send_date, dateFormat)
+                  ? dateTime(recurringInvoice.next_send_date)
                   : null}
               </Element>
             ) : null}

--- a/src/pages/recurring-invoices/common/hooks.tsx
+++ b/src/pages/recurring-invoices/common/hooks.tsx
@@ -11,12 +11,7 @@
 import { AxiosError } from 'axios';
 import { RecurringInvoiceStatus } from '$app/common/enums/recurring-invoice-status';
 import { RecurringInvoiceStatus as RecurringInvoiceStatusBadge } from '../common/components/RecurringInvoiceStatus';
-import {
-  date,
-  endpoint,
-  getEntityState,
-  useDateTime,
-} from '$app/common/helpers';
+import { date, endpoint, getEntityState } from '$app/common/helpers';
 import { InvoiceSum } from '$app/common/helpers/invoices/invoice-sum';
 import { request } from '$app/common/helpers/request';
 import { toast } from '$app/common/helpers/toast/toast';
@@ -77,6 +72,7 @@ import { useDisableNavigation } from '$app/common/hooks/useDisableNavigation';
 import { DynamicLink } from '$app/components/DynamicLink';
 import { CloneOptionsModal } from './components/CloneOptionsModal';
 import { useFormatCustomFieldValue } from '$app/common/hooks/useFormatCustomFieldValue';
+import { useDateTime } from '$app/common/hooks/useDateTime';
 
 interface RecurringInvoiceUtilitiesProps {
   client?: Client;
@@ -575,7 +571,7 @@ export function useRecurringInvoiceColumns() {
     },
     {
       column: 'next_send_date',
-      id: 'next_send_date',
+      id: 'next_send_datetime',
       label: t('next_send_date'),
       format: (value) => dateTime(value),
     },

--- a/src/pages/recurring-invoices/common/hooks.tsx
+++ b/src/pages/recurring-invoices/common/hooks.tsx
@@ -11,7 +11,7 @@
 import { AxiosError } from 'axios';
 import { RecurringInvoiceStatus } from '$app/common/enums/recurring-invoice-status';
 import { RecurringInvoiceStatus as RecurringInvoiceStatusBadge } from '../common/components/RecurringInvoiceStatus';
-import { date, endpoint, getEntityState } from '$app/common/helpers';
+import { date, dateTime, endpoint, getEntityState } from '$app/common/helpers';
 import { InvoiceSum } from '$app/common/helpers/invoices/invoice-sum';
 import { request } from '$app/common/helpers/request';
 import { toast } from '$app/common/helpers/toast/toast';
@@ -493,6 +493,7 @@ export function useAllRecurringInvoiceColumns() {
 
 export function useRecurringInvoiceColumns() {
   const { t } = useTranslation();
+
   const { dateFormat } = useCurrentCompanyDateFormats();
 
   const disableNavigation = useDisableNavigation();
@@ -570,7 +571,7 @@ export function useRecurringInvoiceColumns() {
       column: 'next_send_date',
       id: 'next_send_date',
       label: t('next_send_date'),
-      format: (value) => date(value, dateFormat),
+      format: (value) => dateTime(value),
     },
     {
       column: 'frequency',

--- a/src/pages/recurring-invoices/common/hooks.tsx
+++ b/src/pages/recurring-invoices/common/hooks.tsx
@@ -11,7 +11,12 @@
 import { AxiosError } from 'axios';
 import { RecurringInvoiceStatus } from '$app/common/enums/recurring-invoice-status';
 import { RecurringInvoiceStatus as RecurringInvoiceStatusBadge } from '../common/components/RecurringInvoiceStatus';
-import { date, dateTime, endpoint, getEntityState } from '$app/common/helpers';
+import {
+  date,
+  endpoint,
+  getEntityState,
+  useDateTime,
+} from '$app/common/helpers';
 import { InvoiceSum } from '$app/common/helpers/invoices/invoice-sum';
 import { request } from '$app/common/helpers/request';
 import { toast } from '$app/common/helpers/toast/toast';
@@ -496,6 +501,7 @@ export function useRecurringInvoiceColumns() {
 
   const { dateFormat } = useCurrentCompanyDateFormats();
 
+  const dateTime = useDateTime();
   const disableNavigation = useDisableNavigation();
 
   const recurringInvoiceColumns = useAllRecurringInvoiceColumns();


### PR DESCRIPTION
@beganovich @turbo124 The PR includes formatting the "next_send_date" column for Recurring Invoices. It involves formatting it to the date-time format using the formats entered in the company settings along with the "military_time" property. This has been done in three places:

- All Recurring Invoices tables including the dashboard table
- Recurring Invoice Slider

Screenshot:

![Screenshot 2024-03-30 at 02 36 52](https://github.com/invoiceninja/ui/assets/51542191/b3a2d763-07e3-4ce8-92fd-9f8ecd3bb9cb)

Let me know your thoughts.