### PR TITLE
[Cleanup] Adjusting Company Wizard Titles

### DIFF
--- a/src/pages/settings/company/components/Logo.tsx
+++ b/src/pages/settings/company/components/Logo.tsx
@@ -159,7 +159,7 @@ export function Logo({ isSettingsPage = true }: Props) {
     </Card>
   ) : (
     <div className="flex flex-col space-y-5">
-      <span className="text-lg font-medium">{t('upload_logo')}</span>
+      <span className="text-lg font-medium">{t('upload_company_logo')}</span>
 
       <div className="grid grid-cols-12 gap-x-4">
         <div className="bg-gray-200 col-span-6 rounded-lg p-6">

--- a/src/pages/settings/company/edit/CompanyEdit.tsx
+++ b/src/pages/settings/company/edit/CompanyEdit.tsx
@@ -139,9 +139,11 @@ export function CompanyEdit(props: Props) {
   return (
     <Modal
       title={
-        stepIndex !== 2
-          ? t('welcome_to_invoice_ninja')
-          : t('accept_payments_online')
+        stepIndex !== 1
+          ? stepIndex === 0
+            ? t('welcome_to_invoice_ninja')
+            : t('accept_payments_online')
+          : ''
       }
       visible={props.isModalOpen}
       onClose={() => {


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adjusting the company wizard titles for the upload logo wizard step. Screenshot:

![Screenshot 2024-04-01 at 16 55 12](https://github.com/invoiceninja/ui/assets/51542191/cdacc0ca-f205-453a-8a84-c75df50f6d6f)

`Note`: We are missing the "upload_company_logo" translation keyword for the "Upload your Company Logo" translation in the files. If you agree, please just add it there.

Let me know your thoughts.