### PR TITLE
[Cleanup] Invalidating The Activities Query On Any Delete/Edit/Update

### DIFF
--- a/src/common/helpers/request.ts
+++ b/src/common/helpers/request.ts
@@ -12,17 +12,29 @@ import axios, { AxiosError, AxiosRequestConfig, Method } from 'axios';
 import { defaultHeaders } from '$app/common/queries/common/headers';
 import { ValidationBag } from '../interfaces/validation-bag';
 import { toast } from './toast/toast';
+import { $refetch } from '../hooks/useRefetch';
 
 const client = axios.create();
 
 client.interceptors.response.use(
   (response) => {
+    const payload = response.config.data && JSON.parse(response.config.data);
+    const requestMethod = response.config.method;
+
+    if (
+      requestMethod === 'put' ||
+      (requestMethod === 'post' && payload?.action === 'delete') ||
+      requestMethod === 'delete'
+    ) {
+      $refetch(['activities']);
+    }
+
     return response;
   },
   (error: AxiosError<ValidationBag>) => {
     if (error.response?.status === 429 || error.response?.status === 403) {
-      window.location.reload();
-      localStorage.clear();
+      //window.location.reload();
+      //localStorage.clear();
     }
 
     if (error.response?.status === 404) {

--- a/src/common/helpers/request.ts
+++ b/src/common/helpers/request.ts
@@ -33,8 +33,8 @@ client.interceptors.response.use(
   },
   (error: AxiosError<ValidationBag>) => {
     if (error.response?.status === 429 || error.response?.status === 403) {
-      //window.location.reload();
-      //localStorage.clear();
+      window.location.reload();
+      localStorage.clear();
     }
 
     if (error.response?.status === 404) {

--- a/src/common/hooks/useRefetch.tsx
+++ b/src/common/hooks/useRefetch.tsx
@@ -213,6 +213,10 @@ export const keys = {
     path: '/api/v1/subscriptions',
     dependencies: [],
   },
+  activities: {
+    path: '/api/v1/activities',
+    dependencies: ['/api/v1/activities/entity'],
+  },
 };
 
 export function useRefetch() {

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -51,7 +51,7 @@ import classNames from 'classnames';
 import { Guard } from '$app/common/guards/Guard';
 import { EntityState } from '$app/common/enums/entity-state';
 import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-api-response';
-import { refetchByUrl } from '$app/common/hooks/useRefetch';
+import { $refetch, refetchByUrl } from '$app/common/hooks/useRefetch';
 import { useLocation } from 'react-router-dom';
 import { useDataTableOptions } from '$app/common/hooks/useDataTableOptions';
 import { useDataTableUtilities } from '$app/common/hooks/useDataTableUtilities';
@@ -344,6 +344,8 @@ export function DataTable<T extends object>(props: Props<T>) {
             },
           })
         );
+
+        $refetch(['activities']);
       })
       .finally(() => {
         refetchByUrl([props.endpoint, apiEndpoint.pathname]);

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -51,7 +51,7 @@ import classNames from 'classnames';
 import { Guard } from '$app/common/guards/Guard';
 import { EntityState } from '$app/common/enums/entity-state';
 import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-api-response';
-import { $refetch, refetchByUrl } from '$app/common/hooks/useRefetch';
+import { refetchByUrl } from '$app/common/hooks/useRefetch';
 import { useLocation } from 'react-router-dom';
 import { useDataTableOptions } from '$app/common/hooks/useDataTableOptions';
 import { useDataTableUtilities } from '$app/common/hooks/useDataTableUtilities';
@@ -344,8 +344,6 @@ export function DataTable<T extends object>(props: Props<T>) {
             },
           })
         );
-
-        $refetch(['activities']);
       })
       .finally(() => {
         refetchByUrl([props.endpoint, apiEndpoint.pathname]);


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of query invalidation for activities in three cases:

- For any `PUT` method (Updating/Editing entities).
- For any `DELETE` method (Deleting entities).
- For any `POST` method which contains the `action` property in the payload set to `'delete'` (Deleting entities).

Let me know your thoughts.