### PR TITLE
[Cleanup] Implementing Current Page And Text Filter Through Sessions Storage

### DIFF
--- a/src/common/hooks/useDataTablePreference.ts
+++ b/src/common/hooks/useDataTablePreference.ts
@@ -8,8 +8,10 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
+import { useAtomValue } from 'jotai';
 import { useUserChanges } from './useInjectUserChanges';
 import { TableFiltersPreference } from './useReactSettings';
+import { dataTableFiltersAtom } from './useStoreSessionTableFilters';
 
 interface Params {
   tableKey: string;
@@ -19,7 +21,15 @@ export function useDataTablePreference(params: Params) {
 
   const { tableKey } = params;
 
+  const storeSessionTableFilters = useAtomValue(dataTableFiltersAtom);
+
   return (filterKey: keyof TableFiltersPreference) => {
+    if (filterKey === 'filter' || filterKey === 'currentPage') {
+      return storeSessionTableFilters?.[tableKey]?.[filterKey]
+        ? storeSessionTableFilters[tableKey][filterKey]
+        : '';
+    }
+
     const tableFilters = user?.company_user?.react_settings.table_filters;
 
     return tableFilters?.[tableKey]?.[filterKey]

--- a/src/common/hooks/useDataTablePreferences.ts
+++ b/src/common/hooks/useDataTablePreferences.ts
@@ -22,6 +22,7 @@ import { request } from '../helpers/request';
 import { useUserChanges } from './useInjectUserChanges';
 import { useDispatch } from 'react-redux';
 import { updateUser } from '../stores/slices/user';
+import { useStoreSessionTableFilters } from './useStoreSessionTableFilters';
 
 interface Params {
   apiEndpoint: URL;
@@ -58,6 +59,7 @@ export function useDataTablePreferences(params: Params) {
   } = params;
 
   const getPreference = useDataTablePreference({ tableKey });
+  const storeSessionTableFilters = useStoreSessionTableFilters({ tableKey });
 
   const handleUpdateUserPreferences = (updatedUser: User) => {
     request(
@@ -124,6 +126,8 @@ export function useDataTablePreferences(params: Params) {
       );
 
       handleUpdateUserPreferences(updatedUser as User);
+
+      storeSessionTableFilters(filter, currentPage);
     }
   };
 

--- a/src/common/hooks/useDataTablePreferences.ts
+++ b/src/common/hooks/useDataTablePreferences.ts
@@ -93,20 +93,19 @@ export function useDataTablePreferences(params: Params) {
     const defaultFilters = {
       ...(customFilters && { customFilter: ['all'] }),
       sort: apiEndpoint.searchParams.get('sort') || 'id|asc',
-      currentPage: 1,
       status: ['active'],
       perPage: '10',
     };
 
     const cleanedUpFilters = {
-      ...(filter && { filter }),
       ...(sortedBy && { sortedBy }),
       ...(customFilters && { customFilter }),
       sort,
-      currentPage,
       status,
       perPage,
     };
+
+    storeSessionTableFilters(filter, currentPage);
 
     if (isEqual(defaultFilters, cleanedUpFilters) && !currentTableFilters) {
       return;
@@ -126,8 +125,6 @@ export function useDataTablePreferences(params: Params) {
       );
 
       handleUpdateUserPreferences(updatedUser as User);
-
-      storeSessionTableFilters(filter, currentPage);
     }
   };
 

--- a/src/common/hooks/useStoreSessionTableFilters.ts
+++ b/src/common/hooks/useStoreSessionTableFilters.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 /**
  * Invoice Ninja (https://invoiceninja.com).
  *
@@ -9,10 +8,17 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
+import { useSetAtom } from 'jotai';
 import { atomWithStorage, createJSONStorage } from 'jotai/utils';
+import { AsyncStorage } from 'jotai/vanilla/utils/atomWithStorage';
 
+type SessionDataTableFilters = Record<string, Record<string, string | number>>;
 const storage = createJSONStorage(() => sessionStorage);
-const dataTableFiltersAtom = atomWithStorage('dataTableFilters', {}, storage);
+export const dataTableFiltersAtom = atomWithStorage<SessionDataTableFilters>(
+  'dataTableFilters',
+  {},
+  storage as AsyncStorage<SessionDataTableFilters>
+);
 
 interface Params {
   tableKey: string;
@@ -20,5 +26,15 @@ interface Params {
 export function useStoreSessionTableFilters(params: Params) {
   const { tableKey } = params;
 
-  return (filter: string, currentPage: number) => {};
+  const setDataTableFilters = useSetAtom(dataTableFiltersAtom);
+
+  return (filter: string, currentPage: number) => {
+    setDataTableFilters((current) => ({
+      ...current,
+      [tableKey]: {
+        filter,
+        currentPage,
+      },
+    }));
+  };
 }

--- a/src/common/hooks/useStoreSessionTableFilters.ts
+++ b/src/common/hooks/useStoreSessionTableFilters.ts
@@ -1,0 +1,24 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { atomWithStorage, createJSONStorage } from 'jotai/utils';
+
+const storage = createJSONStorage(() => sessionStorage);
+const dataTableFiltersAtom = atomWithStorage('dataTableFilters', {}, storage);
+
+interface Params {
+  tableKey: string;
+}
+export function useStoreSessionTableFilters(params: Params) {
+  const { tableKey } = params;
+
+  return (filter: string, currentPage: number) => {};
+}

--- a/src/pages/authentication/Logout.tsx
+++ b/src/pages/authentication/Logout.tsx
@@ -28,6 +28,7 @@ export function Logout() {
     // }
 
     localStorage.clear();
+    sessionStorage.clear();
 
     queryClient.invalidateQueries();
     queryClient.removeQueries();


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of `filter_text` and `current_page` filters through session storage instead of storing them into `react_settings`. Thus, once the user logs out of the app or leaves the current session, the stored data will be cleared. When the user rejoins the app, the data will be reset to the default values. Let me know your thoughts.