### PR TITLE
[Bugfix] Force Update Button

### DIFF
--- a/src/components/AboutModal.tsx
+++ b/src/components/AboutModal.tsx
@@ -217,7 +217,7 @@ export function AboutModal(props: Props) {
           </Button>
         )}
 
-        {isSelfHosted() && (
+        {isSelfHosted() && installedVersion !== latestVersion && (
           <Button
             behavior="button"
             className="flex items-center"


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixing a bug with the `force_update` button. A user reported an issue where, even after updating the app version, they still had an available update `(https://github.com/invoiceninja/ui/issues/1625)`. The bug is not related to functionality, we simply missed one part of the logic, which involves removing the force_update button once the latest version is equal to the installed one. Screenshot:

<img width="326" alt="Screenshot 2024-04-03 at 23 41 38" src="https://github.com/invoiceninja/ui/assets/51542191/8e8957d1-61c4-48fe-bc49-7df8d6612e9b">

So, now the update button is only available if the latest and installed versions are different.

Let me know your thoughts.