### PR TITLE
[Cleanup] Transforming Client Create Slider Into Customizable Modal

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -27,6 +27,31 @@ interface Props {
   overflowVisible?: boolean;
   closeButtonCypressRef?: string;
   stopPropagationInHeader?: boolean;
+  renderTransitionChildAsFragment?: boolean;
+}
+
+interface TransitionChildProps {
+  renderFragmentOnly: boolean;
+  children: ReactNode;
+}
+function TransitionChild(props: TransitionChildProps) {
+  const { renderFragmentOnly, children } = props;
+
+  return renderFragmentOnly ? (
+    <>{children}</>
+  ) : (
+    <Transition.Child
+      as={Fragment}
+      enter="ease-out duration-300"
+      enterFrom="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+      enterTo="opacity-100 translate-y-0 sm:scale-100"
+      leave="ease-in duration-200"
+      leaveFrom="opacity-100 translate-y-0 sm:scale-100"
+      leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+    >
+      {children}
+    </Transition.Child>
+  );
 }
 
 export function Modal(props: Props) {
@@ -68,14 +93,10 @@ export function Modal(props: Props) {
           >
             &#8203;
           </span>
-          <Transition.Child
-            as={Fragment}
-            enter="ease-out duration-300"
-            enterFrom="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
-            enterTo="opacity-100 translate-y-0 sm:scale-100"
-            leave="ease-in duration-200"
-            leaveFrom="opacity-100 translate-y-0 sm:scale-100"
-            leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+          <TransitionChild
+            renderFragmentOnly={
+              Boolean(props.renderTransitionChildAsFragment) && open
+            }
           >
             <div
               style={{
@@ -164,7 +185,7 @@ export function Modal(props: Props) {
                 </div>
               )}
             </div>
-          </Transition.Child>
+          </TransitionChild>
         </div>
       </Dialog>
     </Transition.Root>

--- a/src/pages/invoices/common/components/ClientCreate.tsx
+++ b/src/pages/invoices/common/components/ClientCreate.tsx
@@ -81,6 +81,7 @@ export function ClientCreate({
   };
 
   const handleClose = (value: boolean) => {
+    setFundamentalConceptVisible(true);
     setIsModalOpen(value);
     setErrors(undefined);
     setClient(undefined);

--- a/src/pages/invoices/common/components/ClientCreate.tsx
+++ b/src/pages/invoices/common/components/ClientCreate.tsx
@@ -28,6 +28,7 @@ import { toast } from '$app/common/helpers/toast/toast';
 import { $refetch } from '$app/common/hooks/useRefetch';
 import { Modal } from '$app/components/Modal';
 import { CurrencySelector } from '$app/components/CurrencySelector';
+import classNames from 'classnames';
 
 interface Props {
   isModalOpen: boolean;
@@ -262,7 +263,12 @@ export function ClientCreate({
           <Spinner />
         )}
 
-        <div className="flex justify-between">
+        <div
+          className={classNames('flex', {
+            'justify-between': fundamentalConceptVisible,
+            'justify-end space-x-5': !fundamentalConceptVisible,
+          })}
+        >
           <Button
             behavior="button"
             type="secondary"

--- a/src/pages/invoices/common/components/ClientCreate.tsx
+++ b/src/pages/invoices/common/components/ClientCreate.tsx
@@ -274,7 +274,7 @@ export function ClientCreate({
             type="secondary"
             onClick={() => setFundamentalConceptVisible((current) => !current)}
           >
-            {fundamentalConceptVisible ? t('show_more') : t('show_less')}
+            {fundamentalConceptVisible ? t('more_fields') : t('less_fields')}
           </Button>
 
           <Button behavior="button" onClick={onSave}>

--- a/src/pages/invoices/common/components/ClientCreate.tsx
+++ b/src/pages/invoices/common/components/ClientCreate.tsx
@@ -170,7 +170,7 @@ export function ClientCreate({
                 />
 
                 <InputField
-                  label={t('first_name')}
+                  label={`${t('contact')} ${t('first_name')}`}
                   value={contacts[0].first_name}
                   onValueChange={(value) =>
                     handleContactsChange(value, 'first_name')
@@ -179,7 +179,7 @@ export function ClientCreate({
                 />
 
                 <InputField
-                  label={t('last_name')}
+                  label={`${t('contact')} ${t('last_name')}`}
                   value={contacts[0].last_name}
                   onValueChange={(value) =>
                     handleContactsChange(value, 'last_name')
@@ -188,7 +188,7 @@ export function ClientCreate({
                 />
 
                 <InputField
-                  label={t('email')}
+                  label={`${t('contact')} ${t('email')}`}
                   value={contacts[0].email}
                   onValueChange={(value) =>
                     handleContactsChange(value, 'email')
@@ -197,7 +197,7 @@ export function ClientCreate({
                 />
 
                 <InputField
-                  label={t('phone')}
+                  label={`${t('contact')} ${t('phone')}`}
                   value={contacts[0].phone}
                   onValueChange={(value) =>
                     handleContactsChange(value, 'phone')
@@ -211,6 +211,7 @@ export function ClientCreate({
                   onChange={(value) => {
                     const $client = cloneDeep(client)!;
                     set($client, 'settings.currency_id', value);
+                    setClient($client);
                   }}
                   errorMessage={errors?.errors['settings.currency_id']}
                   dismissable
@@ -260,7 +261,7 @@ export function ClientCreate({
           <Spinner />
         )}
 
-        <div className="flex justify-end space-x-5">
+        <div className="flex justify-between">
           <Button
             behavior="button"
             type="secondary"


### PR DESCRIPTION
@beganovich @turbo124 The PR includes UX improvements for client creation, so we changed the implementation through the modal with the possibility of adjusting how many fields the user wants to see: the fundamental ones or all of them. Screenshot:

<img width="1260" alt="Screenshot 2024-04-04 at 20 26 32" src="https://github.com/invoiceninja/ui/assets/51542191/2ef32588-7d79-46f1-8c0a-6593b642d812">

`Note:` We're missing the translation keywords 'show_more' and 'show_less' from the files. If you agree with the implementation, please add them there.

Let me know your thoughts.