### PR TITLE
[Feature] Implementing client_brevo Mailer

### DIFF
--- a/src/common/constants/blank-company-settings.ts
+++ b/src/common/constants/blank-company-settings.ts
@@ -184,4 +184,5 @@ export const defaultSettings = {
   default_expense_payment_type_id: '',
   classification: '',
   e_quote_type: '',
+  brevo_secret: '',
 };

--- a/src/common/interfaces/company.interface.ts
+++ b/src/common/interfaces/company.interface.ts
@@ -317,6 +317,7 @@ export interface Settings {
   payment_refund_design_id: string;
   enable_rappen_rounding: boolean;
   e_quote_type: string;
+  brevo_secret: string;
 }
 
 export interface TaxData {

--- a/src/pages/settings/email-settings/EmailSettings.tsx
+++ b/src/pages/settings/email-settings/EmailSettings.tsx
@@ -496,9 +496,30 @@ export function EmailSettings() {
           </>
         )}
 
+        {company?.settings.email_sending_method === 'client_brevo' && (
+          <Element
+            leftSide={
+              <PropertyCheckbox
+                propertyKey="brevo_secret"
+                labelElement={<SettingsLabel label={t('secret')} />}
+              />
+            }
+          >
+            <InputField
+              value={company?.settings.brevo_secret || ''}
+              onValueChange={(value) =>
+                handleChange('settings.brevo_secret', value)
+              }
+              disabled={disableSettingsField('brevo_secret')}
+              errorMessage={errors?.errors['settings.brevo_secret']}
+            />
+          </Element>
+        )}
+
         {(company?.settings.email_sending_method === 'client_mailgun' ||
           company?.settings.email_sending_method === 'client_postmark' ||
-          company?.settings.email_sending_method === 'smtp') && (
+          company?.settings.email_sending_method === 'smtp' ||
+          company?.settings.email_sending_method === 'client_brevo') && (
           <Element
             leftSide={
               <PropertyCheckbox

--- a/src/pages/settings/email-settings/common/hooks/useEmailProviders.ts
+++ b/src/pages/settings/email-settings/common/hooks/useEmailProviders.ts
@@ -60,6 +60,11 @@ export function useEmailProviders() {
       enabled: true,
     },
     {
+      value: 'client_brevo',
+      label: 'Brevo',
+      enabled: true,
+    },
+    {
       value: 'smtp',
       label: 'SMTP',
       enabled:
@@ -84,6 +89,11 @@ export function useEmailProviders() {
     {
       value: 'client_mailgun',
       label: 'Mailgun',
+      enabled: true,
+    },
+    {
+      value: 'client_brevo',
+      label: 'Brevo',
       enabled: true,
     },
     {


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of a new `client_brevo` mailer, which is exactly the same as `client_postmark` with field setup, except for the secret field, which will be saved in the `brevo_secret` property. Screenshot:

<img width="1262" alt="Screenshot 2024-04-04 at 21 01 22" src="https://github.com/invoiceninja/ui/assets/51542191/a602c74c-76a2-4b66-ad4c-9e4ee933ceae">

Let me know your thoughts.