### PR TITLE
[Feature] Implementing Expense Preview | Scaffold

### DIFF
--- a/src/components/FileIcon.tsx
+++ b/src/components/FileIcon.tsx
@@ -10,17 +10,23 @@
 
 import { File, Jpg, Pdf, Png, Svg } from './icons';
 
-export function FileIcon(props: { type: string }) {
+interface Props {
+  size?: number;
+  type: string;
+}
+export function FileIcon(props: Props) {
   const supported = ['jpg', 'svg', 'png', 'pdf'];
+
+  const { size = 26, type } = props;
 
   return (
     <>
-      {props.type === 'jpg' && <Jpg height={26} />}
-      {props.type === 'svg' && <Svg height={26} />}
-      {props.type === 'png' && <Png height={26} />}
-      {props.type === 'pdf' && <Pdf height={26} />}
+      {type === 'jpg' && <Jpg height={size} />}
+      {type === 'svg' && <Svg height={size} />}
+      {type === 'png' && <Png height={size} />}
+      {type === 'pdf' && <Pdf height={size} />}
 
-      {!supported.includes(props.type) && <File height={26} />}
+      {!supported.includes(type) && <File height={size} />}
     </>
   );
 }

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -26,6 +26,7 @@ interface Props {
   tabs: Tab[];
   disableBackupNavigation?: boolean;
   visible?: boolean;
+  rightSide?: ReactNode;
 }
 
 export type Tab = {
@@ -112,7 +113,10 @@ export function Tabs(props: Props) {
       </div>
 
       <div className="hidden sm:block">
-        <div className="border-b" style={{ borderColor: colors.$5 }}>
+        <div
+          className="flex justify-between border-b"
+          style={{ borderColor: colors.$5 }}
+        >
           <nav
             ref={tabBar}
             className="-mb-px flex space-x-8 relative scroll-smooth overflow-x-auto"
@@ -137,6 +141,8 @@ export function Tabs(props: Props) {
                 )
             )}
           </nav>
+
+          {props.rightSide}
         </div>
       </div>
     </div>

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -91,7 +91,7 @@ export function Tabs(props: Props) {
 
   return visible ? (
     <div className={props.className} data-cy="tabs">
-      <div className="sm:hidden">
+      <div className="flex flex-col space-y-5 sm:hidden">
         <label htmlFor="tabs" className="sr-only">
           Select a tab
         </label>
@@ -110,6 +110,8 @@ export function Tabs(props: Props) {
               )
           )}
         </select>
+
+        {props.rightSide}
       </div>
 
       <div className="hidden sm:block">

--- a/src/components/cards/Divider.tsx
+++ b/src/components/cards/Divider.tsx
@@ -13,6 +13,7 @@ import classNames from 'classnames';
 
 interface Props {
   withoutPadding?: boolean;
+  borderColor?: string;
 }
 
 export function Divider(props: Props) {
@@ -20,7 +21,7 @@ export function Divider(props: Props) {
 
   return (
     <div
-      style={{ borderColor: colors.$4 }}
+      style={{ borderColor: props.borderColor || colors.$4 }}
       className={classNames('border-b', {
         'pt-6 mb-4 border-b': !props.withoutPadding,
       })}

--- a/src/components/cards/Divider.tsx
+++ b/src/components/cards/Divider.tsx
@@ -9,9 +9,10 @@
  */
 
 import { useColorScheme } from '$app/common/colors';
+import CommonProps from '$app/common/interfaces/common-props.interface';
 import classNames from 'classnames';
 
-interface Props {
+interface Props extends CommonProps {
   withoutPadding?: boolean;
   borderColor?: string;
 }
@@ -22,9 +23,13 @@ export function Divider(props: Props) {
   return (
     <div
       style={{ borderColor: props.borderColor || colors.$4 }}
-      className={classNames('border-b', {
-        'pt-6 mb-4 border-b': !props.withoutPadding,
-      })}
+      className={classNames(
+        'border-b',
+        {
+          'pt-6 mb-4 border-b': !props.withoutPadding,
+        },
+        props.className ?? ''
+      )}
     ></div>
   );
 }

--- a/src/components/resizable-panels/Panel.tsx
+++ b/src/components/resizable-panels/Panel.tsx
@@ -10,18 +10,15 @@
 
 import { ReactNode } from 'react';
 import { Panel as PanelBase } from 'react-resizable-panels';
-import { useMediaQuery } from 'react-responsive';
 
 interface Props {
   children: ReactNode;
-  renderBasePanel?: boolean;
+  renderBasePanel: boolean;
 }
 export function Panel(props: Props) {
-  const isLargeScreen = useMediaQuery({ query: '(min-width: 1024px)' });
-
   const { children, renderBasePanel } = props;
 
-  return isLargeScreen || Boolean(renderBasePanel) ? (
+  return renderBasePanel ? (
     <PanelBase defaultSize={50} minSize={25}>
       {children}
     </PanelBase>

--- a/src/components/resizable-panels/PanelGroup.tsx
+++ b/src/components/resizable-panels/PanelGroup.tsx
@@ -1,0 +1,28 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { ReactNode } from 'react';
+import { PanelGroup as PanelGroupBase } from 'react-resizable-panels';
+
+interface Props {
+  children: ReactNode;
+  renderBasePanelGroup: boolean;
+}
+export function PanelGroup(props: Props) {
+  const { children, renderBasePanelGroup } = props;
+
+  return renderBasePanelGroup ? (
+    <PanelGroupBase direction="horizontal" className="gap-4 mt-4">
+      {children}
+    </PanelGroupBase>
+  ) : (
+    <div className="flex flex-col gap-4">{children}</div>
+  );
+}

--- a/src/components/resizable-panels/PanelResizeHandle.tsx
+++ b/src/components/resizable-panels/PanelResizeHandle.tsx
@@ -1,0 +1,40 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { useColorScheme } from '$app/common/colors';
+import { PanelResizeHandle as PanelResizeHandleBase } from 'react-resizable-panels';
+import styled from 'styled-components';
+
+const PanelResizeHandleBaseStyled = styled(PanelResizeHandleBase)`
+  background-color: ${(props) => props.theme.backgroundColor};
+  &:hover {
+    background-color: ${(props) => props.theme.hoverColor};
+  }
+`;
+
+interface Props {
+  renderBasePanelResizeHandler: boolean;
+}
+
+export function PanelResizeHandle(props: Props) {
+  const colors = useColorScheme();
+
+  const { renderBasePanelResizeHandler } = props;
+
+  return renderBasePanelResizeHandler ? (
+    <PanelResizeHandleBaseStyled
+      className="flex items-center"
+      theme={{ hoverColor: '#3366CC', backgroundColor: colors.$5 }}
+      style={{ width: '2.5px' }}
+    />
+  ) : (
+    <></>
+  );
+}

--- a/src/pages/expenses/Expense.tsx
+++ b/src/pages/expenses/Expense.tsx
@@ -27,6 +27,9 @@ import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission
 import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
 import { DocumentsTabLabel } from '$app/components/DocumentsTabLabel';
 import Toggle from '$app/components/forms/Toggle';
+import { Panel } from '$app/components/resizable-panels/Panel';
+import { PanelGroup } from '$app/components/resizable-panels/PanelGroup';
+import { PanelResizeHandle } from '$app/components/resizable-panels/PanelResizeHandle';
 
 export default function Expense() {
   const [t] = useTranslation();
@@ -66,6 +69,7 @@ export default function Expense() {
   );
 
   const [errors, setErrors] = useState<ValidationBag>();
+  const [isPreviewMode, setIsPreviewMode] = useState<boolean>(false);
 
   const actions = useActions();
 
@@ -102,21 +106,37 @@ export default function Expense() {
             rightSide={
               <div className="flex items-center space-x-3">
                 <span className="text-sm">{t('preview')}</span>
-                <Toggle />
+                <Toggle
+                  checked={isPreviewMode}
+                  onValueChange={(value) => setIsPreviewMode(value)}
+                />
               </div>
             }
           />
 
-          <Outlet
-            context={{
-              errors,
-              setErrors,
-              expense,
-              setExpense,
-              taxInputType,
-              setTaxInputType,
-            }}
-          />
+          <PanelGroup renderBasePanelGroup={isPreviewMode}>
+            <Panel renderBasePanel={isPreviewMode}>
+              <Outlet
+                context={{
+                  errors,
+                  setErrors,
+                  expense,
+                  setExpense,
+                  taxInputType,
+                  setTaxInputType,
+                  isPreviewMode,
+                }}
+              />
+            </Panel>
+
+            <PanelResizeHandle renderBasePanelResizeHandler={isPreviewMode} />
+
+            <Panel renderBasePanel={isPreviewMode}>
+              {isPreviewMode && (
+                <div className="w-full bg-gray-200" style={{ height: 1500 }} />
+              )}
+            </Panel>
+          </PanelGroup>
         </div>
       ) : (
         <Spinner />

--- a/src/pages/expenses/Expense.tsx
+++ b/src/pages/expenses/Expense.tsx
@@ -26,6 +26,7 @@ import { Spinner } from '$app/components/Spinner';
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
 import { DocumentsTabLabel } from '$app/components/DocumentsTabLabel';
+import Toggle from '$app/components/forms/Toggle';
 
 export default function Expense() {
   const [t] = useTranslation();
@@ -96,7 +97,15 @@ export default function Expense() {
     >
       {expense ? (
         <div className="space-y-4">
-          <Tabs tabs={tabs} />
+          <Tabs
+            tabs={tabs}
+            rightSide={
+              <div className="flex items-center space-x-3">
+                <span className="text-sm">{t('preview')}</span>
+                <Toggle />
+              </div>
+            }
+          />
 
           <Outlet
             context={{

--- a/src/pages/expenses/Expense.tsx
+++ b/src/pages/expenses/Expense.tsx
@@ -136,7 +136,11 @@ export default function Expense() {
             />
 
             {isPreviewMode && !isLargeScreen && (
-              <Divider withoutPadding borderColor={colors.$5} />
+              <Divider
+                className="pt-4"
+                withoutPadding
+                borderColor={colors.$5}
+              />
             )}
 
             <Panel renderBasePanel={isPreviewMode && isLargeScreen}>

--- a/src/pages/expenses/Expense.tsx
+++ b/src/pages/expenses/Expense.tsx
@@ -30,6 +30,10 @@ import Toggle from '$app/components/forms/Toggle';
 import { Panel } from '$app/components/resizable-panels/Panel';
 import { PanelGroup } from '$app/components/resizable-panels/PanelGroup';
 import { PanelResizeHandle } from '$app/components/resizable-panels/PanelResizeHandle';
+import { DocumentPreview } from './common/components/DocumentPreview';
+import { useMediaQuery } from 'react-responsive';
+import { Divider } from '$app/components/cards/Divider';
+import { useColorScheme } from '$app/common/colors';
 
 export default function Expense() {
   const [t] = useTranslation();
@@ -37,8 +41,10 @@ export default function Expense() {
   const { documentTitle } = useTitle('edit_expense');
 
   const { id } = useParams();
-
+  const actions = useActions();
+  const colors = useColorScheme();
   const { data } = useExpenseQuery({ id });
+  const isLargeScreen = useMediaQuery({ query: '(min-width: 1024px)' });
 
   const hasPermission = useHasPermission();
   const entityAssigned = useEntityAssigned();
@@ -62,16 +68,12 @@ export default function Expense() {
     },
   ];
 
+  const [errors, setErrors] = useState<ValidationBag>();
   const [expense, setExpense] = useState<ExpenseType>();
-
+  const [isPreviewMode, setIsPreviewMode] = useState<boolean>(false);
   const [taxInputType, setTaxInputType] = useState<'by_rate' | 'by_amount'>(
     'by_rate'
   );
-
-  const [errors, setErrors] = useState<ValidationBag>();
-  const [isPreviewMode, setIsPreviewMode] = useState<boolean>(false);
-
-  const actions = useActions();
 
   const save = useSave({ setErrors });
 
@@ -104,7 +106,7 @@ export default function Expense() {
           <Tabs
             tabs={tabs}
             rightSide={
-              <div className="flex items-center space-x-3">
+              <div className="flex items-center justify-end space-x-3">
                 <span className="text-sm">{t('preview')}</span>
                 <Toggle
                   checked={isPreviewMode}
@@ -114,8 +116,8 @@ export default function Expense() {
             }
           />
 
-          <PanelGroup renderBasePanelGroup={isPreviewMode}>
-            <Panel renderBasePanel={isPreviewMode}>
+          <PanelGroup renderBasePanelGroup={isPreviewMode && isLargeScreen}>
+            <Panel renderBasePanel={isPreviewMode && isLargeScreen}>
               <Outlet
                 context={{
                   errors,
@@ -129,11 +131,17 @@ export default function Expense() {
               />
             </Panel>
 
-            <PanelResizeHandle renderBasePanelResizeHandler={isPreviewMode} />
+            <PanelResizeHandle
+              renderBasePanelResizeHandler={isPreviewMode && isLargeScreen}
+            />
 
-            <Panel renderBasePanel={isPreviewMode}>
+            {isPreviewMode && !isLargeScreen && (
+              <Divider withoutPadding borderColor={colors.$5} />
+            )}
+
+            <Panel renderBasePanel={isPreviewMode && isLargeScreen}>
               {isPreviewMode && (
-                <div className="w-full bg-gray-200" style={{ height: 1500 }} />
+                <DocumentPreview documents={expense.documents} />
               )}
             </Panel>
           </PanelGroup>

--- a/src/pages/expenses/common/components/DocumentPreview.tsx
+++ b/src/pages/expenses/common/components/DocumentPreview.tsx
@@ -1,0 +1,167 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { endpoint } from '$app/common/helpers';
+import { request } from '$app/common/helpers/request';
+import { Document } from '$app/common/interfaces/document.interface';
+import { defaultHeaders } from '$app/common/queries/common/headers';
+import { Spinner } from '$app/components/Spinner';
+import { Icon } from '$app/components/icons/Icon';
+import { android } from '$app/pages/invoices/common/components/InvoiceViewer';
+import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  MdFirstPage,
+  MdLastPage,
+  MdNavigateBefore,
+  MdNavigateNext,
+} from 'react-icons/md';
+import { useQueryClient } from 'react-query';
+
+interface Props {
+  documents: Document[];
+}
+export function DocumentPreview(props: Props) {
+  const [t] = useTranslation();
+  const queryClient = useQueryClient();
+
+  const { documents } = props;
+
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  const [documentUrl, setDocumentUrl] = useState<string>('');
+  const [isFormBusy, setIsFormBusy] = useState<boolean>(false);
+  const [documentIndex, setDocumentIndex] = useState<number>(0);
+
+  const isDocumentPicture = () => {
+    const documentType = documents[documentIndex]?.type;
+
+    return (
+      documentType === 'png' || documentType === 'jpg' || documentType === 'gif'
+    );
+  };
+
+  const isDocumentPdf = () => {
+    const documentType = documents[documentIndex]?.type;
+
+    return documentType === 'pdf';
+  };
+
+  useEffect(() => {
+    if (documents.length) {
+      setIsFormBusy(true);
+
+      if (documents[documentIndex]) {
+        queryClient
+          .fetchQuery(
+            ['/api/v1/documents', documents[documentIndex]?.hash],
+            () =>
+              request(
+                'GET',
+                endpoint('/documents/:hash', {
+                  hash: documents[documentIndex]?.hash,
+                }),
+                { headers: defaultHeaders() },
+                { responseType: 'arraybuffer' }
+              ),
+            { staleTime: Infinity }
+          )
+          .then((response) => {
+            const blob = new Blob([response.data], {
+              type: response.headers['content-type'],
+            });
+
+            if (isDocumentPicture()) {
+              setDocumentUrl(URL.createObjectURL(blob));
+            }
+
+            if (!android && iframeRef.current && isDocumentPdf()) {
+              console.log(URL.createObjectURL(blob));
+              iframeRef.current.src = URL.createObjectURL(blob);
+            }
+          })
+          .finally(() => setIsFormBusy(false));
+      } else {
+        setDocumentIndex(0);
+      }
+    }
+
+    return () => {
+      setDocumentUrl('');
+      setIsFormBusy(false);
+    };
+  }, [documents, documentIndex]);
+
+  if (android) {
+    return <p>Unable to preview PDF. &nbsp;</p>;
+  }
+
+  return (
+    <>
+      {documents.length ? (
+        <div className="flex flex-col">
+          {!isFormBusy && (
+            <div className="flex self-end pb-1">
+              <Icon
+                className="cursor-pointer"
+                element={MdFirstPage}
+                size={25}
+                onClick={() => setDocumentIndex(0)}
+              />
+              <Icon
+                className="cursor-pointer"
+                element={MdNavigateBefore}
+                size={25}
+                onClick={() =>
+                  documentIndex !== 0 &&
+                  setDocumentIndex((current) => current - 1)
+                }
+              />
+
+              <Icon
+                className="cursor-pointer"
+                element={MdNavigateNext}
+                size={25}
+                onClick={() =>
+                  documentIndex !== documents.length - 1 &&
+                  setDocumentIndex((current) => current + 1)
+                }
+              />
+              <Icon
+                className="cursor-pointer"
+                element={MdLastPage}
+                size={25}
+                onClick={() => setDocumentIndex(documents.length - 1)}
+              />
+            </div>
+          )}
+
+          {isDocumentPicture() && !isFormBusy && (
+            <img className="w-full" src={documentUrl} />
+          )}
+
+          <iframe
+            ref={iframeRef}
+            width="100%"
+            height={isFormBusy || !isDocumentPdf() ? 0 : 1500}
+          />
+        </div>
+      ) : (
+        <div className="flex justify-center">{t('no_records_found')}.</div>
+      )}
+
+      {isFormBusy && (
+        <div className="flex justify-center items-center h-full">
+          <Spinner />
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/pages/expenses/documents/Documents.tsx
+++ b/src/pages/expenses/documents/Documents.tsx
@@ -16,11 +16,12 @@ import { Context } from '../edit/Edit';
 import { $refetch } from '$app/common/hooks/useRefetch';
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
+import classNames from 'classnames';
 
 export default function Documents() {
   const context: Context = useOutletContext();
 
-  const { expense } = context;
+  const { expense, isPreviewMode } = context;
 
   const hasPermission = useHasPermission();
   const entityAssigned = useEntityAssigned();
@@ -30,7 +31,12 @@ export default function Documents() {
   };
 
   return (
-    <div className="w-2/3">
+    <div
+      className={classNames({
+        'w-2/3': !isPreviewMode,
+        'w-full': isPreviewMode,
+      })}
+    >
       <Upload
         widgetOnly
         endpoint={endpoint('/api/v1/expenses/:id/upload', { id: expense.id })}

--- a/src/pages/expenses/edit/Edit.tsx
+++ b/src/pages/expenses/edit/Edit.tsx
@@ -17,6 +17,7 @@ import { AdditionalInfo } from '../create/components/AdditionalInfo';
 import { Details } from '../create/components/Details';
 import { Notes } from '../create/components/Notes';
 import { TaxSettings } from '../create/components/Taxes';
+import classNames from 'classnames';
 
 export interface Context {
   errors: ValidationBag | undefined;
@@ -25,6 +26,7 @@ export interface Context {
   setExpense: Dispatch<SetStateAction<Expense | undefined>>;
   taxInputType: 'by_rate' | 'by_amount';
   setTaxInputType: Dispatch<SetStateAction<'by_rate' | 'by_amount'>>;
+  isPreviewMode: boolean;
 }
 
 export default function Edit() {
@@ -37,13 +39,18 @@ export default function Edit() {
     errors,
     taxInputType,
     setTaxInputType,
+    isPreviewMode,
   } = context;
 
   const handleChange = useHandleChange({ setExpense, setErrors });
 
   return (
     <div className="grid grid-cols-12 gap-4">
-      <div className="col-span-12 xl:col-span-4">
+      <div
+        className={classNames('col-span-12', {
+          'xl:col-span-4': !isPreviewMode,
+        })}
+      >
         <Details
           expense={expense}
           handleChange={handleChange}
@@ -53,11 +60,19 @@ export default function Edit() {
         />
       </div>
 
-      <div className="col-span-12 xl:col-span-4">
+      <div
+        className={classNames('col-span-12', {
+          'xl:col-span-4': !isPreviewMode,
+        })}
+      >
         <Notes expense={expense} handleChange={handleChange} errors={errors} />
       </div>
 
-      <div className="col-span-12 xl:col-span-4 space-y-4">
+      <div
+        className={classNames('col-span-12 space-y-4', {
+          'xl:col-span-4': !isPreviewMode,
+        })}
+      >
         <AdditionalInfo
           expense={expense}
           handleChange={handleChange}


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of a "preview" mode for documents on the Expense edit page. Therefore, I believe that we are only able to natively preview jpg, jpeg, svg, webp, tiff, png, and pdf file types. All other types require the extension for displaying them. Here is a screenshot of how the preview looks when we can display the file:

<img width="1512" alt="Screenshot 2024-04-05 at 20 37 54" src="https://github.com/invoiceninja/ui/assets/51542191/d1e73c51-89c8-48ab-9b66-73acdb81773c">

Here is the screenshot when the file type cannot be shown natively in React:

<img width="1261" alt="Screenshot 2024-04-05 at 20 44 24" src="https://github.com/invoiceninja/ui/assets/51542191/78802ebe-fbd3-4219-a5ed-00a4a3ae123c">

Let me know your thoughts.