### PR TITLE
[Bugfix] NaN Values On Limits/Fees Page

### DIFF
--- a/src/components/forms/InputField.tsx
+++ b/src/components/forms/InputField.tsx
@@ -101,6 +101,11 @@ export function InputField(props: Props) {
           )}
           placeholder={props.placeholder || ''}
           onBlur={(event) => {
+            event.target.value =
+              event.target.value === '' && props.type === 'number'
+                ? '0'
+                : event.target.value;
+
             props.onValueChange && props.onValueChange(event.target.value);
             props.onChange && props.onChange(event);
           }}

--- a/src/pages/settings/gateways/create/components/LimitsAndFees.tsx
+++ b/src/pages/settings/gateways/create/components/LimitsAndFees.tsx
@@ -97,16 +97,17 @@ export function LimitsAndFees(props: Props) {
           <Element leftSide={`${t('min')} ${t('limit')}`}>
             <div className="space-y-4">
               <InputField
-                disabled={
-                  props.companyGateway.fees_and_limits?.[currentGatewayTypeId]
-                    .min_limit === -1
-                }
+                type="number"
                 value={
                   props.companyGateway.fees_and_limits?.[currentGatewayTypeId]
                     .min_limit
                 }
                 onValueChange={(value) =>
                   handleEntryChange('min_limit', parseFloat(value) || -1)
+                }
+                disabled={
+                  props.companyGateway.fees_and_limits?.[currentGatewayTypeId]
+                    .min_limit === -1
                 }
                 errorMessage={props.errors?.errors.min_limit}
               />
@@ -127,16 +128,17 @@ export function LimitsAndFees(props: Props) {
           <Element leftSide={`${t('max')} ${t('limit')}`}>
             <div className="space-y-4">
               <InputField
-                disabled={
-                  props.companyGateway.fees_and_limits?.[currentGatewayTypeId]
-                    .max_limit === -1
-                }
+                type="number"
                 value={
                   props.companyGateway.fees_and_limits?.[currentGatewayTypeId]
                     .max_limit
                 }
                 onValueChange={(value) =>
                   handleEntryChange('max_limit', parseFloat(value) || -1)
+                }
+                disabled={
+                  props.companyGateway.fees_and_limits?.[currentGatewayTypeId]
+                    .max_limit === -1
                 }
                 errorMessage={props.errors?.errors.max_limit}
               />
@@ -158,6 +160,7 @@ export function LimitsAndFees(props: Props) {
 
           <Element leftSide={t('fee_percent')}>
             <InputField
+              type="number"
               value={
                 props.companyGateway.fees_and_limits?.[currentGatewayTypeId]
                   .fee_percent
@@ -171,6 +174,7 @@ export function LimitsAndFees(props: Props) {
 
           <Element leftSide={t('fee_amount')}>
             <InputField
+              type="number"
               value={
                 props.companyGateway.fees_and_limits?.[currentGatewayTypeId]
                   .fee_amount
@@ -184,6 +188,7 @@ export function LimitsAndFees(props: Props) {
 
           <Element leftSide={t('fee_cap')}>
             <InputField
+              type="number"
               value={
                 props.companyGateway.fees_and_limits?.[currentGatewayTypeId]
                   .fee_cap


### PR DESCRIPTION
@beganovich @turbo124 The PR involves fixing bugs for `NaN` values on the `Limits/Fees` page. In fact, the bug can be divided into two parts: the fields on this page were not of the `number` type, they were text/string fields. While specifying them, I also added a small part of the logic which should be the reason for resolving NaN values for input fields. This part of the logic was added globally under the `InputField` component. Let me know your thoughts.