### PR TITLE
[Bugfix] Auto-Fill Quantity/Hours | Products/Tasks Tables

### DIFF
--- a/src/pages/invoices/common/hooks/useHandleProductChange.ts
+++ b/src/pages/invoices/common/hooks/useHandleProductChange.ts
@@ -41,9 +41,11 @@ export function useHandleProductChange(props: Props) {
       return props.onChange(index, lineItem);
     }
 
-    lineItem.quantity = company?.default_quantity ? 1 : product?.quantity ?? 0;
-
     if (company.fill_products) {
+      lineItem.quantity = company?.default_quantity
+        ? 1
+        : product?.quantity ?? 0;
+
       if (resource.client_id) {
         resolveClient.find(resource.client_id).then((client) => {
           const clientCurrencyId = client.settings.currency_id;


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixing a bug for auto-filling the quantity/hours for the products/tasks table when the `fill_products` property is turned off. Now, the quantity/hours will be the same as the user entered earlier. Let me know your thoughts.