### PR TITLE
[Cleanup] Creating "Subdomain" Value From "Company Name" Field

### DIFF
--- a/src/pages/settings/company/edit/CompanyEdit.tsx
+++ b/src/pages/settings/company/edit/CompanyEdit.tsx
@@ -60,6 +60,18 @@ export function CompanyEdit(props: Props) {
 
   const handleChange = useHandleCurrentCompanyChangeProperty();
 
+  const handleChangeName = (value: string) => {
+    handleChange('settings.name', value);
+
+    const subDomainValue = value
+      .split('')
+      .filter((c) => /[a-zA-Z]/.test(c))
+      .join('')
+      .toLowerCase();
+
+    handleChange('subdomain', subDomainValue);
+  };
+
   const handleUpdateCompany = (isWizard: boolean) => {
     request(
       'PUT',
@@ -159,8 +171,9 @@ export function CompanyEdit(props: Props) {
             <InputField
               label={t('company_name')}
               value={companyChanges?.settings?.name}
-              onValueChange={(value) => handleChange('settings.name', value)}
+              onValueChange={(value) => handleChangeName(value)}
               errorMessage={errors?.errors?.name}
+              changeOverride
             />
 
             {isHosted() && (
@@ -168,6 +181,7 @@ export function CompanyEdit(props: Props) {
                 label={t('subdomain')}
                 value={companyChanges?.subdomain}
                 onValueChange={(value) => handleChange('subdomain', value)}
+                changeOverride
               />
             )}
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes slight improvements to the UX on the Company Edit modal. So, once you enter the `company_name`, the logic will automatically update the `subdomain` using the logic of taking only characters and combining them into a lowercase string. Also, to achieve a better UX, I've changed it here to update values on the `onChange` event rather than the `onBlur` event, so I've overridden the default behavior. Screenshot:

![Screenshot 2024-04-10 at 19 39 15](https://github.com/invoiceninja/ui/assets/51542191/87104fd7-4086-4c17-ac54-caf74c4e65a9)

Let me know your thoughts.