### PR TITLE
[Bugfix] Saving Dark Mode Through react_settings

### DIFF
--- a/src/common/colors.ts
+++ b/src/common/colors.ts
@@ -10,6 +10,8 @@
 
 import { useAtom } from 'jotai';
 import { atomWithStorage } from 'jotai/utils';
+import { useEffect } from 'react';
+import { useReactSettings } from './hooks/useReactSettings';
 
 // export const $1 = {
 //   name: 'invoiceninja.dark',
@@ -62,7 +64,15 @@ export const $2 = {
 export const colorSchemeAtom = atomWithStorage('colorScheme', $2);
 
 export function useColorScheme() {
-  const [colorScheme] = useAtom(colorSchemeAtom);
+  const reactSettings = useReactSettings({ overwrite: false });
+
+  const [colorScheme, setColorScheme] = useAtom(colorSchemeAtom);
+
+  useEffect(() => {
+    if (reactSettings) {
+      reactSettings.dark_mode ? setColorScheme($1) : setColorScheme($2);
+    }
+  }, [reactSettings?.dark_mode]);
 
   return colorScheme;
 }

--- a/src/common/hooks/useInjectUserChanges.ts
+++ b/src/common/hooks/useInjectUserChanges.ts
@@ -21,12 +21,24 @@ export function useUserChanges() {
     | undefined;
 }
 
-export function useInjectUserChanges() {
+interface Options {
+  overwrite?: boolean;
+}
+
+export function useInjectUserChanges(options?: Options) {
   const user = useCurrentUser();
   const dispatch = useDispatch();
   const changes = useUserChanges();
 
   useEffect(() => {
+    if (changes && options?.overwrite === false) {
+      // We don't want to overwrite existing changes,
+      // so let's just not inject anything if we already have a value,
+      // and relative argument.
+
+      return;
+    }
+
     dispatch(injectInChanges());
   }, [user]);
 

--- a/src/common/hooks/useReactSettings.ts
+++ b/src/common/hooks/useReactSettings.ts
@@ -59,6 +59,7 @@ export interface ReactSettings {
   import_templates?: ImportTemplates;
   table_footer_columns?: Record<ReactTableColumns, string[]>;
   show_table_footer?: boolean;
+  dark_mode?: boolean;
 }
 
 export type ReactTableColumns =
@@ -94,8 +95,12 @@ export const preferencesDefaults: Preferences = {
   },
 };
 
-export function useReactSettings() {
-  const user = useInjectUserChanges();
+interface Options {
+  overwrite?: boolean;
+}
+
+export function useReactSettings(options?: Options) {
+  const user = useInjectUserChanges({ overwrite: options?.overwrite });
 
   const reactSettings =
     useSelector(

--- a/src/pages/settings/user/components/Preferences.tsx
+++ b/src/pages/settings/user/components/Preferences.tsx
@@ -23,8 +23,6 @@ import { Inline } from '$app/components/Inline';
 import { X } from 'react-feather';
 import { get } from 'lodash';
 import { ReactNode } from 'react';
-import { $1, $2, colorSchemeAtom } from '$app/common/colors';
-import { useAtom } from 'jotai';
 
 export function Preferences() {
   const [t] = useTranslation();
@@ -39,8 +37,6 @@ export function Preferences() {
       })
     );
   };
-
-  const [colorScheme, setColorScheme] = useAtom(colorSchemeAtom);
 
   return (
     <div className="space-y-4">
@@ -107,8 +103,10 @@ export function Preferences() {
 
         <Element leftSide={t('dark_mode')}>
           <Toggle
-            checked={JSON.stringify(colorScheme) === JSON.stringify($1)}
-            onChange={(v) => (v ? setColorScheme($1) : setColorScheme($2))}
+            checked={Boolean(reactSettings?.dark_mode)}
+            onChange={(value) =>
+              handleChange('company_user.react_settings.dark_mode', value)
+            }
           />
         </Element>
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of saving the `dark_mode` boolean value into `react_settings` instead of saving it into the atom through one user's session. Let me know your toughts.