### PR TITLE
[Bugfix] Non-marking Settings Menu Item

### DIFF
--- a/src/components/layouts/common/hooks.ts
+++ b/src/components/layouts/common/hooks.ts
@@ -52,13 +52,17 @@ export function useSettingsRoutes() {
     {
       name: t('payment_settings'),
       href: '/settings/online_payments',
-      current: location.pathname.startsWith('/settings/online_payments'),
+      current:
+        location.pathname.startsWith('/settings/online_payments') ||
+        location.pathname.startsWith('/settings/gateways'),
       enabled: isAdmin || isOwner || false,
     },
     {
       name: t('tax_settings'),
       href: '/settings/tax_settings',
-      current: location.pathname.startsWith('/settings/tax_settings'),
+      current:
+        location.pathname.startsWith('/settings/tax_settings') ||
+        location.pathname.startsWith('/settings/tax_rates'),
       enabled: isAdmin || isOwner || false,
     },
     {
@@ -70,13 +74,17 @@ export function useSettingsRoutes() {
     {
       name: t('task_settings'),
       href: '/settings/task_settings',
-      current: location.pathname.startsWith('/settings/task_settings'),
+      current:
+        location.pathname.startsWith('/settings/task_settings') ||
+        location.pathname.startsWith('/settings/task_statuses'),
       enabled: isAdmin || isOwner || false,
     },
     {
       name: t('expense_settings'),
       href: '/settings/expense_settings',
-      current: location.pathname.startsWith('/settings/expense_settings'),
+      current:
+        location.pathname.startsWith('/settings/expense_settings') ||
+        location.pathname.startsWith('/settings/expense_categories'),
       enabled: ((isAdmin || isOwner) && isCompanySettingsActive) || false,
     },
     {
@@ -115,7 +123,7 @@ export function useSettingsRoutes() {
     {
       name: t('custom_fields'),
       href: '/settings/custom_fields',
-      current: location.pathname.endsWith('/settings/custom_fields'),
+      current: location.pathname.startsWith('/settings/custom_fields'),
       enabled: ((isAdmin || isOwner) && isCompanySettingsActive) || false,
     },
     {


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for the non-marking of the settings menu item once the user joins the page, which is related to that settings item. The method of recreating the bug is:

- Join the "Expense Settings" page
- Join the "Expense Category" creation page
- Check the "Expense Settings" item in the settings menu will not be marked with a darker background color

Fixes have been made for the "Payment Settings," "Tax Settings," "Task Settings," "Expense Settings," and "Custom Fields" menu items.

Let me know your thoughts.