### PR TITLE
[Bugfix] Implementing the missing tax selector for the Limits/Fees page

### DIFF
--- a/src/pages/settings/gateways/create/components/LimitsAndFees.tsx
+++ b/src/pages/settings/gateways/create/components/LimitsAndFees.tsx
@@ -193,7 +193,7 @@ export function LimitsAndFees(props: Props) {
             />
           </Element>
 
-          {company && company.enabled_tax_rates > 0 && (
+          {company && company.enabled_item_tax_rates > 0 && (
             <Element leftSide={t('tax')}>
               <TaxRateSelector
                 defaultValue={
@@ -219,7 +219,7 @@ export function LimitsAndFees(props: Props) {
             </Element>
           )}
 
-          {company && company.enabled_tax_rates > 1 && (
+          {company && company.enabled_item_tax_rates > 1 && (
             <Element leftSide={t('tax')}>
               <TaxRateSelector
                 defaultValue={
@@ -245,7 +245,7 @@ export function LimitsAndFees(props: Props) {
             </Element>
           )}
 
-          {company && company.enabled_tax_rates > 2 && (
+          {company && company.enabled_item_tax_rates > 2 && (
             <Element leftSide={t('tax')}>
               <TaxRateSelector
                 defaultValue={

--- a/src/pages/settings/gateways/create/components/LimitsAndFees.tsx
+++ b/src/pages/settings/gateways/create/components/LimitsAndFees.tsx
@@ -23,6 +23,10 @@ import { useTranslation } from 'react-i18next';
 import { useHandleFeesAndLimitsEntryChange } from '../hooks/useHandleFeesAndLimitsEntryChange';
 import { useResolveGatewayTypeTranslation } from '../hooks/useResolveGatewayTypeTranslation';
 import { atom, useAtom } from 'jotai';
+import { TaxRateSelector } from '$app/components/tax-rates/TaxRateSelector';
+import { Entry } from '$app/components/forms/Combobox';
+import { TaxRate } from '$app/common/interfaces/tax-rate';
+import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 
 interface Props {
   gateway: Gateway;
@@ -37,6 +41,9 @@ const currentGatewayTypeAtom = atom<string | undefined>(undefined);
 
 export function LimitsAndFees(props: Props) {
   const [t] = useTranslation();
+
+  const company = useCurrentCompany();
+
   const [currentGatewayTypeId, setCurrentGatewayTypeId] = useAtom(
     currentGatewayTypeAtom
   );
@@ -185,6 +192,84 @@ export function LimitsAndFees(props: Props) {
               errorMessage={props.errors?.errors.fee_amount}
             />
           </Element>
+
+          {company && company.enabled_tax_rates > 0 && (
+            <Element leftSide={t('tax')}>
+              <TaxRateSelector
+                defaultValue={
+                  props.companyGateway?.fees_and_limits[currentGatewayTypeId]
+                    ?.fee_tax_name1 || ''
+                }
+                onChange={(value: Entry<TaxRate>) => {
+                  handleEntryChange(
+                    'fee_tax_name1',
+                    value.resource?.name || ''
+                  );
+                  handleEntryChange('fee_tax_rate1', value.resource?.rate || 0);
+                }}
+                onClearButtonClick={() => {
+                  handleEntryChange('fee_tax_name1', '');
+                  handleEntryChange('fee_tax_rate1', 0);
+                }}
+                onTaxCreated={(taxRate) => {
+                  handleEntryChange('fee_tax_name1', taxRate.name);
+                  handleEntryChange('fee_tax_rate1', taxRate.rate);
+                }}
+              />
+            </Element>
+          )}
+
+          {company && company.enabled_tax_rates > 1 && (
+            <Element leftSide={t('tax')}>
+              <TaxRateSelector
+                defaultValue={
+                  props.companyGateway?.fees_and_limits[currentGatewayTypeId]
+                    ?.fee_tax_name2 || ''
+                }
+                onChange={(value: Entry<TaxRate>) => {
+                  handleEntryChange(
+                    'fee_tax_name2',
+                    value.resource?.name || ''
+                  );
+                  handleEntryChange('fee_tax_rate2', value.resource?.rate || 0);
+                }}
+                onClearButtonClick={() => {
+                  handleEntryChange('fee_tax_name2', '');
+                  handleEntryChange('fee_tax_rate2', 0);
+                }}
+                onTaxCreated={(taxRate) => {
+                  handleEntryChange('fee_tax_name2', taxRate.name);
+                  handleEntryChange('fee_tax_rate2', taxRate.rate);
+                }}
+              />
+            </Element>
+          )}
+
+          {company && company.enabled_tax_rates > 2 && (
+            <Element leftSide={t('tax')}>
+              <TaxRateSelector
+                defaultValue={
+                  props.companyGateway?.fees_and_limits[currentGatewayTypeId]
+                    ?.fee_tax_name3 || ''
+                }
+                onChange={(value: Entry<TaxRate>) => {
+                  handleEntryChange(
+                    'fee_tax_name3',
+                    value.resource?.name || ''
+                  );
+                  handleEntryChange('fee_tax_rate3', value.resource?.rate || 0);
+                }}
+                onClearButtonClick={() => {
+                  handleEntryChange('fee_tax_name3', '');
+                  handleEntryChange('fee_tax_rate3', 0);
+                }}
+                onTaxCreated={(taxRate) => {
+                  handleEntryChange('fee_tax_name3', taxRate.name);
+                  handleEntryChange('fee_tax_rate3', taxRate.rate);
+                }}
+              />
+            </Element>
+          )}
 
           <Element leftSide={t('fee_cap')}>
             <InputField


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of missing tax selectors on the gateway edit page within the limits/fees tab. Screenshot:

![Screenshot 2024-04-19 at 11 47 20](https://github.com/invoiceninja/ui/assets/51542191/ae945d72-3a01-414a-9535-852f205af017)

Let me know your thoughts.