### PR TITLE
[Cleanup] Payment Types Order | A-Z | Payment Pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3936,9 +3936,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001559",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001559.tgz",
-      "integrity": "sha512-cPiMKZgqgkg5LY3/ntGeLFUpi6tzddBNS58A4tnTgQw1zON7u2sZMU7SzOeVH4tj20++9ggL+V6FDOFMTaFFYA==",
+      "version": "1.0.30001612",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001612.tgz",
+      "integrity": "sha512-lFgnZ07UhaCcsSZgWW0K5j4e69dK1u/ltrL9lTUiFOwNHs12S3UMIEYgBV0Z6C6hRDev7iRnMzzYmKabYdXF9g==",
       "dev": true,
       "funding": [
         {

--- a/src/common/hooks/usePaymentTypes.ts
+++ b/src/common/hooks/usePaymentTypes.ts
@@ -1,0 +1,30 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { useTranslation } from 'react-i18next';
+import paymentType from '$app/common/constants/payment-type';
+
+export function usePaymentTypes() {
+  const [t] = useTranslation();
+
+  let translatedPaymentTypeList: Record<string, string> = {};
+
+  translatedPaymentTypeList = Object.entries(paymentType).reduce(
+    (translatedTypes, [key, value]) => {
+      translatedTypes[key as keyof typeof translatedTypes] = t(value);
+      return translatedTypes;
+    },
+    {}
+  );
+
+  const paymentTypeKeyValueArray = Object.entries(translatedPaymentTypeList);
+
+  return paymentTypeKeyValueArray.sort((a, b) => a[1].localeCompare(b[1]));
+}

--- a/src/pages/payments/create/Create.tsx
+++ b/src/pages/payments/create/Create.tsx
@@ -11,7 +11,6 @@
 import { Card, Element } from '$app/components/cards';
 import { Button, InputField, SelectField } from '$app/components/forms';
 import collect from 'collect.js';
-import paymentType from '$app/common/constants/payment-type';
 import { useCreditResolver } from '$app/common/hooks/credits/useCreditResolver';
 import { useInvoiceResolver } from '$app/common/hooks/invoices/useInvoiceResolver';
 import { useFormatMoney } from '$app/common/hooks/money/useFormatMoney';
@@ -43,6 +42,7 @@ import { ComboboxAsync } from '$app/components/forms/Combobox';
 import { endpoint } from '$app/common/helpers';
 import { useAtom } from 'jotai';
 import { paymentAtom } from '../common/atoms';
+import { usePaymentTypes } from '$app/common/hooks/usePaymentTypes';
 
 export interface PaymentOnCreation
   extends Omit<Payment, 'invoices' | 'credits'> {
@@ -74,9 +74,11 @@ export default function Create() {
   ];
 
   const company = useCurrentCompany();
-  const invoiceResolver = useInvoiceResolver();
   const creditResolver = useCreditResolver();
+  const invoiceResolver = useInvoiceResolver();
+
   const formatMoney = useFormatMoney();
+  const paymentTypes = usePaymentTypes();
 
   const [payment, setPayment] = useAtom(paymentAtom);
   const [errors, setErrors] = useState<ValidationBag>();
@@ -521,9 +523,9 @@ export default function Create() {
               errorMessage={errors?.errors.type_id}
               withBlank
             >
-              {Object.entries(paymentType).map(([id, type], index) => (
-                <option value={id} key={index}>
-                  {t(type)}
+              {paymentTypes.map(([key, value], index) => (
+                <option value={key} key={index}>
+                  {value}
                 </option>
               ))}
             </SelectField>

--- a/src/pages/payments/edit/Edit.tsx
+++ b/src/pages/payments/edit/Edit.tsx
@@ -10,7 +10,6 @@
 
 import { Card, Element } from '$app/components/cards';
 import { InputField, SelectField } from '$app/components/forms';
-import paymentType from '$app/common/constants/payment-type';
 import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { useTitle } from '$app/common/hooks/useTitle';
 import { Payment } from '$app/common/interfaces/payment';
@@ -25,6 +24,7 @@ import { PaymentOverview } from './PaymentOverview';
 import { ClientCard } from '$app/pages/clients/show/components/ClientCard';
 import { ValidationBag } from '$app/common/interfaces/validation-bag';
 import { useColorScheme } from '$app/common/colors';
+import { usePaymentTypes } from '$app/common/hooks/usePaymentTypes';
 
 interface Context {
   errors: ValidationBag | undefined;
@@ -36,6 +36,8 @@ interface Context {
 export default function Edit() {
   const { documentTitle } = useTitle('edit_payment');
   const [t] = useTranslation();
+
+  const paymentTypes = usePaymentTypes();
 
   const context = useOutletContext<Context>();
 
@@ -96,13 +98,11 @@ export default function Edit() {
           errorMessage={errors?.errors.type_id}
           withBlank
         >
-          {Object.entries(paymentType).map((value: any, index: any) => {
-            return (
-              <option key={index} value={String(value[0])}>
-                {t(value[1])}
-              </option>
-            );
-          })}
+          {paymentTypes.map(([key, value], index) => (
+            <option value={key} key={index}>
+              {value}
+            </option>
+          ))}
         </SelectField>
       </Element>
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes improvements for the select field dropdown of `payment_types`. Instead of being in random order, it is now sorted alphabetically A-Z once it is translated. This means it will be sorted correctly for any language. Screenshot:

![Screenshot 2024-04-22 at 19 21 10](https://github.com/invoiceninja/ui/assets/51542191/d68ebee6-7456-49f1-a907-8c45db2f7edf)

Let me know your thoughts.