### PR TITLE
[Bugfix] Position Fixes Quick Create Popover When Mini Sidebar Is Displayed

### DIFF
--- a/src/components/QuickCreatePopover.tsx
+++ b/src/components/QuickCreatePopover.tsx
@@ -11,6 +11,7 @@ import { isHosted, isSelfHosted } from '$app/common/helpers';
 import { MdArrowDropDown } from 'react-icons/md';
 import { useColorScheme } from '$app/common/colors';
 import { styled } from 'styled-components';
+import { useInjectUserChanges } from '$app/common/hooks/useInjectUserChanges';
 
 const Div = styled.div`
   &:hover {
@@ -22,10 +23,17 @@ export function QuickCreatePopover() {
   const [t] = useTranslation();
 
   const navigate = useNavigate();
+
+  const colors = useColorScheme();
   const accentColor = useAccentColor();
   const actions = useQuickCreateActions();
   const sections = useQuickCreateSections();
-  const colors = useColorScheme();
+
+  const user = useInjectUserChanges();
+
+  const isMiniSidebar = Boolean(
+    user?.company_user?.react_settings.show_mini_sidebar
+  );
 
   return (
     <Popover className="relative mt-2">
@@ -53,10 +61,16 @@ export function QuickCreatePopover() {
           >
             <Popover.Panel
               className={classNames(
-                'absolute left-5 lg:left-full z-10 mt-3 w-screen max-w-md -translate-x-1/2 transform px-2',
+                'absolute z-10 mt-3 w-screen max-w-md -translate-x-1/2 transform px-2',
                 {
-                  'md:-left-20 md:max-w-2xl lg:max-w-3xl': isHosted(),
-                  'md:left-8 lg:max-w-lg': isSelfHosted(),
+                  'left-14 md:-left-12 md:max-w-2xl lg:max-w-3xl lg:left-full':
+                    isHosted() && !isMiniSidebar,
+                  'left-14 md:left-52 md:max-w-2xl lg:max-w-3xl':
+                    isHosted() && isMiniSidebar,
+                  'left-14 md:left-8 lg:max-w-lg lg:left-full':
+                    isSelfHosted() && !isMiniSidebar,
+                  'left-14 md:left-8 lg:max-w-lg lg:left-20':
+                    isSelfHosted() && isMiniSidebar,
                 }
               )}
             >


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for the position of the quick create popover once the `show_mini_sidebar` is set to true. Screenshot:

![Screenshot 2024-04-23 at 19 47 07](https://github.com/invoiceninja/ui/assets/51542191/b96ac39e-edcf-4320-86e4-9d89980193c9)

Let me know your thoughts.