### PR TITLE
[Feature] Implementing always_show_required_fields Field | Company Gateways

### DIFF
--- a/src/common/interfaces/company-gateway.ts
+++ b/src/common/interfaces/company-gateway.ts
@@ -37,6 +37,7 @@ export interface CompanyGateway {
   label: string;
   token_billing: string;
   test_mode: boolean;
+  always_show_required_fields: boolean;
 }
 
 export interface FeesAndLimitsEntry {

--- a/src/pages/settings/gateways/create/components/RequiredFields.tsx
+++ b/src/pages/settings/gateways/create/components/RequiredFields.tsx
@@ -100,6 +100,15 @@ export function RequiredFields(props: Props) {
           onChange={(value) => handleChange('update_details', value)}
         />
       </Element>
+
+      <Element leftSide={t('always_show_required_fields')}>
+        <Toggle
+          checked={props.companyGateway.always_show_required_fields ?? true}
+          onChange={(value) =>
+            handleChange('always_show_required_fields', value)
+          }
+        />
+      </Element>
     </Card>
   );
 }

--- a/src/pages/settings/gateways/create/components/RequiredFields.tsx
+++ b/src/pages/settings/gateways/create/components/RequiredFields.tsx
@@ -103,6 +103,7 @@ export function RequiredFields(props: Props) {
 
       <Element leftSide={t('always_show_required_fields')}>
         <Toggle
+          label={t('always_show_required_fields_help')}
           checked={props.companyGateway.always_show_required_fields ?? true}
           onChange={(value) =>
             handleChange('always_show_required_fields', value)


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of the "always_show_required_fields" field on the Company Gateway page under the "Required Fields" tab. Screenshot:

![Screenshot 2024-04-24 at 19 22 09](https://github.com/invoiceninja/ui/assets/51542191/5e68adb1-0102-44b1-a5e1-108c338e0212)

`Note`: We're missing the "always_show_required_fields" translation keyword in the files. If you agree, please just add it to the files.

Let me know your thoughts.