### PR TITLE
[Feature] Implementing private_notes On The Project Show Page

### DIFF
--- a/src/components/InfoCard.tsx
+++ b/src/components/InfoCard.tsx
@@ -9,6 +9,7 @@
  */
 
 import { useColorScheme } from '$app/common/colors';
+import classNames from 'classnames';
 import { CSSProperties, ReactNode } from 'react';
 
 interface Props {
@@ -17,6 +18,7 @@ interface Props {
   children?: ReactNode;
   className?: string;
   style?: CSSProperties;
+  withoutTruncate?: boolean;
 }
 
 export function InfoCard(props: Props) {
@@ -32,7 +34,11 @@ export function InfoCard(props: Props) {
       }}
     >
       <dd className="text-xl font-medium">{props.title}</dd>
-      <dt className="text-sm truncate">
+      <dt
+        className={classNames('text-sm', {
+          truncate: !props.withoutTruncate,
+        })}
+      >
         {props.value} {props.children}
       </dt>
     </div>

--- a/src/pages/projects/show/Show.tsx
+++ b/src/pages/projects/show/Show.tsx
@@ -45,10 +45,7 @@ import { useEnabled } from '$app/common/guards/guards/enabled';
 import { ModuleBitmask } from '$app/pages/settings';
 import { EntityStatus } from '$app/components/EntityStatus';
 import { useColorScheme } from '$app/common/colors';
-import {
-  useAdmin,
-  useHasPermission,
-} from '$app/common/hooks/permissions/useHasPermission';
+import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
 import { Invoice } from '$app/common/interfaces/invoice';
 import { Expense } from '$app/common/interfaces/expense';
@@ -67,8 +64,6 @@ export default function Show() {
   const { t } = useTranslation();
   const { id } = useParams();
   const { dateFormat } = useCurrentCompanyDateFormats();
-
-  const { isAdmin, isOwner } = useAdmin();
 
   const hasPermission = useHasPermission();
   const entityAssigned = useEntityAssigned();
@@ -185,7 +180,7 @@ export default function Show() {
         <InfoCard title={t('notes')} className="h-56" withoutTruncate>
           <p className="break-all">{project.public_notes}</p>
 
-          {(isAdmin || isOwner) && project.private_notes && (
+          {project.private_notes && (
             <div className="flex items-center space-x-1 mt-2 break-all">
               <div>
                 <Icon element={MdLockOutline} size={24} />

--- a/src/pages/projects/show/Show.tsx
+++ b/src/pages/projects/show/Show.tsx
@@ -45,7 +45,10 @@ import { useEnabled } from '$app/common/guards/guards/enabled';
 import { ModuleBitmask } from '$app/pages/settings';
 import { EntityStatus } from '$app/components/EntityStatus';
 import { useColorScheme } from '$app/common/colors';
-import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
+import {
+  useAdmin,
+  useHasPermission,
+} from '$app/common/hooks/permissions/useHasPermission';
 import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
 import { Invoice } from '$app/common/interfaces/invoice';
 import { Expense } from '$app/common/interfaces/expense';
@@ -54,6 +57,8 @@ import {
   ChangeTemplateModal,
   useChangeTemplate,
 } from '$app/pages/settings/invoice-design/pages/custom-designs/components/ChangeTemplate';
+import { Icon } from '$app/components/icons/Icon';
+import { MdLockOutline } from 'react-icons/md';
 
 dayjs.extend(duration);
 
@@ -62,6 +67,8 @@ export default function Show() {
   const { t } = useTranslation();
   const { id } = useParams();
   const { dateFormat } = useCurrentCompanyDateFormats();
+
+  const { isAdmin, isOwner } = useAdmin();
 
   const hasPermission = useHasPermission();
   const entityAssigned = useEntityAssigned();
@@ -175,8 +182,21 @@ export default function Show() {
           </p>
         </InfoCard>
 
-        <InfoCard title={t('notes')} className="h-56">
-          <p>{project.public_notes}</p>
+        <InfoCard title={t('notes')} className="h-56" withoutTruncate>
+          <p className="break-all">{project.public_notes}</p>
+
+          {(isAdmin || isOwner) && project.private_notes && (
+            <div className="flex items-center space-x-1 mt-2 break-all">
+              <div>
+                <Icon element={MdLockOutline} size={24} />
+              </div>
+
+              <span
+                className="whitespace-normal"
+                dangerouslySetInnerHTML={{ __html: project.private_notes }}
+              />
+            </div>
+          )}
 
           <div className="mt-3">
             {project?.invoices?.map((invoice: Invoice, index: number) => (


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of the "private_notes" on the project show page, but the notes will only be displayed if the user is an `ADMIN` or `OWNER`. Screenshot:

<img width="1262" alt="Screenshot 2024-04-24 at 20 19 08" src="https://github.com/invoiceninja/ui/assets/51542191/ec3fab0d-63e4-4c10-b058-f359e15c4cfa">

Let me know your thoughts.