### PR TITLE
[Cleanup] Updating Tinymce To 5.0.1 Version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@reduxjs/toolkit": "^1.9.1",
         "@sentry/react": "^7.77.0",
         "@sentry/tracing": "^7.77.0",
-        "@tinymce/tinymce-react": "^4.3.0",
+        "@tinymce/tinymce-react": "^5.0.1",
         "@tippyjs/react": "^4.2.6",
         "antd": "^5.6.1",
         "array-move": "^4.0.0",
@@ -2636,12 +2636,12 @@
       }
     },
     "node_modules/@tinymce/tinymce-react": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tinymce/tinymce-react/-/tinymce-react-4.3.0.tgz",
-      "integrity": "sha512-iB4cUsYfcJL4NGuKhqCGYuTmFTje3nPxyPv1HxprTsp/YMGuuiiSNWrv3zwI31QX5Cn8qeq9MrMDnbxuRugHyg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@tinymce/tinymce-react/-/tinymce-react-5.0.1.tgz",
+      "integrity": "sha512-tw6yNRqrMGP1iJNeY14wvGsUayC9fc1QpJa7tAvdmeBrUlllyF9PpsrbfvYd+2k8t+w0r2Hq+foTzLZ1d27Fyw==",
       "dependencies": {
         "prop-types": "^15.6.2",
-        "tinymce": "^6.3.1"
+        "tinymce": "^7.0.0 || ^6.0.0 || ^5.5.1"
       },
       "peerDependencies": {
         "react": "^18.0.0 || ^17.0.1 || ^16.7.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@reduxjs/toolkit": "^1.9.1",
     "@sentry/react": "^7.77.0",
     "@sentry/tracing": "^7.77.0",
-    "@tinymce/tinymce-react": "^4.3.0",
+    "@tinymce/tinymce-react": "^5.0.1",
     "@tippyjs/react": "^4.2.6",
     "antd": "^5.6.1",
     "array-move": "^4.0.0",

--- a/src/components/forms/MarkdownEditor.tsx
+++ b/src/components/forms/MarkdownEditor.tsx
@@ -92,7 +92,6 @@ export function MarkdownEditor(props: Props) {
           skin: colors.$0 === 'dark' ? 'oxide-dark' : 'oxide',
           paste_data_images: false,
           newline_behavior: 'invert',
-          license_key: undefined,
           browser_spellcheck: true,
         }}
         onEditorChange={handleChange}

--- a/src/components/forms/MarkdownEditor.tsx
+++ b/src/components/forms/MarkdownEditor.tsx
@@ -92,7 +92,7 @@ export function MarkdownEditor(props: Props) {
           skin: colors.$0 === 'dark' ? 'oxide-dark' : 'oxide',
           paste_data_images: false,
           newline_behavior: 'invert',
-          license_key: 'gpl',
+          license_key: undefined,
           browser_spellcheck: true,
         }}
         onEditorChange={handleChange}


### PR DESCRIPTION
@beganovich @turbo124 The PR includes updating the `TinyMCE` package to version `5.0.1`, the latest available version. David, you mentioned in the ticket to update the package to v7, but the part of the package that we have installed is actually with 5 versions. The entire TinyMCE package (https://www.npmjs.com/package/tinymce) has 7 versions, but the version specifically installed for React (https://www.npmjs.com/package/@tinymce/tinymce-react) has 5 versions. The second package that we use is specifically for React and is much lighter, weighing only 99.9 kB, while the entire package is 8.28 MB. Therefore, I believe that the main reason for using only a part of the package is its size.

Once I updated the version, the "license_key" prop, which was previously set to "gpl", is no longer available to be set to that value. I believe they excluded this kind of handling for licenses. Currently, the value of this prop is optional, and the only value that can be set is "undefined". Therefore, I entirely removed this prop because it does not make sense to set it to "undefined" if it is optional, it will be "undefined" in both cases. (https://www.tiny.cloud/docs/tinymce/latest/license-key/)

I suppose this was the main reason for updating the package to the latest version?
