### PR TITLE
[Bugfix] Refetch Tasks Query After Invoicing Task && Kanban List Filter For Invoiced Tasks

### DIFF
--- a/src/pages/invoices/create/hooks/useHandleCreate.ts
+++ b/src/pages/invoices/create/hooks/useHandleCreate.ts
@@ -64,7 +64,7 @@ export function useHandleCreate(params: Params) {
 
         toast.success('created_invoice');
 
-        $refetch(['products']);
+        $refetch(['products', 'tasks']);
 
         navigate(
           route('/invoices/:id/edit?table=:table', {

--- a/src/pages/tasks/kanban/Kanban.tsx
+++ b/src/pages/tasks/kanban/Kanban.tsx
@@ -139,21 +139,23 @@ export default function Kanban() {
         columns.push({ id: taskStatus.id, title: taskStatus.name, cards: [] })
       );
 
-      tasks.data.map((task) => {
-        const index = columns.findIndex(
-          (column) => column.id === task.status_id
-        );
+      tasks.data
+        .filter(({ invoice_id }) => !invoice_id)
+        .map((task) => {
+          const index = columns.findIndex(
+            (column) => column.id === task.status_id
+          );
 
-        if (index >= 0) {
-          columns[index].cards.push({
-            id: task.id,
-            title: task.description,
-            description: calculateHours(task.time_log).toString(),
-            sortOrder: task.status_order,
-            task,
-          });
-        }
-      });
+          if (index >= 0) {
+            columns[index].cards.push({
+              id: task.id,
+              title: task.description,
+              description: calculateHours(task.time_log).toString(),
+              sortOrder: task.status_order,
+              task,
+            });
+          }
+        });
 
       columns.map(
         (c) => (c.cards = c.cards.sort((a, b) => a.sortOrder - b.sortOrder))


### PR DESCRIPTION
@beganovich @turbo124 The PR includes two fixes: one for refetching the tasks query after the task is invoiced, and another for filtering the list in Kanban so that invoiced tasks are not displayed. Let me know your thoughts.