### PR TITLE
[Bugfix] Account Management Plan Label Changes | Self-hosted

### DIFF
--- a/src/pages/settings/account-management/component/Licence.tsx
+++ b/src/pages/settings/account-management/component/Licence.tsx
@@ -68,7 +68,7 @@ export function License() {
         </form>
       </Modal>
 
-      <Divider />
+      <Divider withoutPadding />
 
       <ClickableElement href={link}>{t('purchase_license')}</ClickableElement>
 

--- a/src/pages/settings/account-management/component/Plan.tsx
+++ b/src/pages/settings/account-management/component/Plan.tsx
@@ -25,15 +25,21 @@ export function Plan() {
 
   return (
     <Card title={t('plan')}>
-      <Element leftSide={t('plan')}>
-        <span>
-          {account?.plan
-            ? `${t(account.plan)} ${t('plan')} `
-            : `${t('free')} ${t('plan')} `}
-        </span>
-        <span>
-          / {account.num_users} {t('users')}
-        </span>
+      <Element className="mb-3" leftSide={t('plan')}>
+        {isHosted() ? (
+          <>
+            <span>
+              {account?.plan
+                ? `${t(account.plan)} ${t('plan')} `
+                : `${t('free')} ${t('plan')} `}
+            </span>
+            <span>
+              / {account.num_users} {t('users')}
+            </span>
+          </>
+        ) : (
+          <span>{t('plan_free_self_hosted')}</span>
+        )}
       </Element>
 
       {account?.plan_expires !== '' && (


### PR DESCRIPTION
@beganovich @turbo124 The PR includes changes for the plan label on the account management page for self-hosted users. Screenshot:

<img width="792" alt="Screenshot 2024-04-30 at 20 26 42" src="https://github.com/invoiceninja/ui/assets/51542191/920658ae-e66d-407f-b9e4-d205610db653">

Let me know your thoughts.