### PR TITLE
[Bugfix] Fixes For onBlur Event When Value Is Not Selected | Tasks Table | #1718

### DIFF
--- a/src/pages/tasks/common/components/TaskTable.tsx
+++ b/src/pages/tasks/common/components/TaskTable.tsx
@@ -220,7 +220,12 @@ export function TaskTable(props: Props) {
                         type="date"
                         value={parseTimeToDate(stop)}
                         onValueChange={(value) =>
-                          handleDateChange(stop, value, index, LogPosition.End)
+                          handleDateChange(
+                            stop,
+                            value || parseTimeToDate(start) || '',
+                            index,
+                            LogPosition.End
+                          )
                         }
                       />
                     </Td>
@@ -231,9 +236,14 @@ export function TaskTable(props: Props) {
                       style={{ color: colors.$3, colorScheme: colors.$0 }}
                       type="time"
                       step="1"
-                      value={parseTime(stop) || 0}
+                      value={parseTime(stop)}
                       onValueChange={(value) =>
-                        handleTimeChange(stop, value, LogPosition.End, index)
+                        handleTimeChange(
+                          stop,
+                          value || parseTime(start) || '',
+                          LogPosition.End,
+                          index
+                        )
                       }
                     />
                   </Td>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for setting the value once it is not selected but the `onBlur` event is triggered. You can find the video of the broken behavior in the issue where the client made a video (https://github.com/invoiceninja/ui/issues/1718). The video of fixed behavior:

https://github.com/invoiceninja/ui/assets/51542191/12fd08ea-9aeb-4788-acb3-86795cc69519

Let me know your thoughts.