### PR TITLE
[Bugfix] Matching Tax Rates From PDF Preview And Tax Selector

### DIFF
--- a/src/components/tax-rates/TaxRateSelector.tsx
+++ b/src/components/tax-rates/TaxRateSelector.tsx
@@ -23,6 +23,8 @@ interface Props {
   onChange?: (value: Entry<TaxRate>) => unknown;
   onClearButtonClick?: () => unknown;
   onTaxCreated?: (taxRate: TaxRate) => unknown;
+  resourceTaxName?: string;
+  resourceTaxRate?: number;
 }
 
 export function TaxRateSelector(props: Props) {
@@ -30,6 +32,8 @@ export function TaxRateSelector(props: Props) {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const { isAdmin, isOwner } = useAdmin();
+
+  const { resourceTaxName, resourceTaxRate } = props;
 
   return (
     <>
@@ -49,8 +53,15 @@ export function TaxRateSelector(props: Props) {
           value: 'name',
           label: 'name',
           inputLabelFn: (taxRate) =>
-            taxRate ? `${taxRate.name} ${taxRate.rate}%` : '',
-          dropdownLabelFn: (taxRate) => `${taxRate.name} ${taxRate.rate}%`,
+            taxRate
+              ? resourceTaxName === taxRate.name
+                ? `${taxRate.name} ${resourceTaxRate}%`
+                : `${taxRate.name} ${taxRate.rate}%`
+              : '',
+          dropdownLabelFn: (taxRate) =>
+            resourceTaxName === taxRate.name
+              ? `${taxRate.name} ${resourceTaxRate}%`
+              : `${taxRate.name} ${taxRate.rate}%`,
         }}
         sortBy="name|asc"
         onDismiss={props.onClearButtonClick}

--- a/src/pages/invoices/common/components/InvoiceTotals.tsx
+++ b/src/pages/invoices/common/components/InvoiceTotals.tsx
@@ -50,8 +50,7 @@ export function InvoiceTotals(props: Props) {
     <Card className="col-span-12 xl:col-span-4 h-max">
       {variables.map(
         (variable, index) =>
-          (variable === '$subtotal'  ||
-            variable === '$taxes') && (
+          (variable === '$subtotal' || variable === '$taxes') && (
             <Fragment key={index}>{resolveVariable(variable)}</Fragment>
           )
       )}
@@ -72,6 +71,8 @@ export function InvoiceTotals(props: Props) {
               handleChange('tax_name1', taxRate.name);
               handleChange('tax_rate1', taxRate.rate);
             }}
+            resourceTaxName={resource.tax_name1}
+            resourceTaxRate={resource.tax_rate1}
           />
         </Element>
       )}
@@ -92,6 +93,8 @@ export function InvoiceTotals(props: Props) {
               handleChange('tax_name2', taxRate.name);
               handleChange('tax_rate2', taxRate.rate);
             }}
+            resourceTaxName={resource.tax_name2}
+            resourceTaxRate={resource.tax_rate2}
           />
         </Element>
       )}
@@ -112,6 +115,8 @@ export function InvoiceTotals(props: Props) {
               handleChange('tax_name3', taxRate.name);
               handleChange('tax_rate3', taxRate.rate);
             }}
+            resourceTaxName={resource.tax_name3}
+            resourceTaxRate={resource.tax_rate3}
           />
         </Element>
       )}


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for adjusting the label on the tax selector when the tax_rate is changed but already selected on the resource. Let me know your thoughts.