### PR TITLE
[Cleanup] Gateways Cards | Gateway Creation Page

### DIFF
--- a/src/pages/clients/show/components/GatewayTypeIcon.tsx
+++ b/src/pages/clients/show/components/GatewayTypeIcon.tsx
@@ -37,7 +37,7 @@ export const availableGatewayLogos = [
   'visa',
   'american_express',
   'mastercard',
-  'paypal',
+  'paypal_platform',
   'authorize',
   'braintree',
   'checkoutcom',
@@ -51,6 +51,7 @@ export const availableGatewayLogos = [
   'wepay',
   'eway',
   'forte',
+  'paypal_rest',
 ];
 
 export function GatewayTypeIcon(props: Props) {
@@ -82,11 +83,20 @@ export function GatewayTypeIcon(props: Props) {
         />
       );
 
-    case 'paypal':
+    case 'paypal_platform':
       return (
         <img
           src={paypalLogo}
           alt="PayPal"
+          style={props.style || { width: 40, height: 40 }}
+        />
+      );
+
+    case 'paypal_rest':
+      return (
+        <img
+          src={paypalLogo}
+          alt="PayPal Rest"
           style={props.style || { width: 40, height: 40 }}
         />
       );

--- a/src/pages/settings/gateways/create/Create.tsx
+++ b/src/pages/settings/gateways/create/Create.tsx
@@ -34,6 +34,7 @@ import { isHosted } from '$app/common/helpers';
 import { endpoint } from '$app/common/helpers';
 import { route } from '$app/common/helpers/route';
 import { request } from '$app/common/helpers/request';
+import { arrayMoveImmutable } from 'array-move';
 
 const gatewaysStyles = [
   { name: 'paypal_ppcp', width: 110 },
@@ -48,7 +49,8 @@ const gatewaysStyles = [
 export const gatewaysDetails = [
   { name: 'stripe', key: 'd14dd26a37cecc30fdd65700bfb55b23' },
   { name: 'stripe', key: 'd14dd26a47cecc30fdd65700bfb67b34' },
-  { name: 'paypal', key: '80af24a6a691230bbec33e930ab40666' },
+  { name: 'paypal_platform', key: '80af24a6a691230bbec33e930ab40666' },
+  { name: 'paypal_rest', key: '80af24a6a691230bbec33e930ab40665' },
   { name: 'braintree', key: 'f7ec488676d310683fb51802d076d713' },
   { name: 'paypal_ppcp', key: '80af24a6a691230bbec33e930ab40666' },
   { name: 'authorize', key: '3b6621f970ab18887c4f6dca78d3f8bb' },
@@ -173,7 +175,21 @@ export function Create() {
         });
         setFilteredGateways(mutated_gateways);
       } else {
-        setFilteredGateways(gateways);
+        const payPalRestIndex = gateways.findIndex(
+          ({ key }) => key === '80af24a6a691230bbec33e930ab40665'
+        );
+
+        if (payPalRestIndex >= 0) {
+          const sortedGateways: Gateway[] = arrayMoveImmutable(
+            gateways as Gateway[],
+            payPalRestIndex,
+            1
+          );
+
+          setFilteredGateways(sortedGateways);
+        } else {
+          setFilteredGateways(gateways);
+        }
       }
     }
   }, [gateways]);


### PR DESCRIPTION
@beganovich @turbo124 The PR includes ensuring that PayPal Rest is displayed through cards and ensuring that the PayPal card with the logo is always second (after the Stripe card). Screenshot of hosted:

![Screenshot 2024-05-02 at 18 34 13](https://github.com/invoiceninja/ui/assets/51542191/30143dd9-19f1-493a-993d-f6836b90c346)

Screenshot of self-hosted:

![Screenshot 2024-05-02 at 18 46 08](https://github.com/invoiceninja/ui/assets/51542191/bf46125c-3092-4f06-a565-c1ed4cfbbc97)

Let me know your thoughts.