### PR TITLE
[Bugfix] Displaying Product Cost Instead Of Product Price | Purchase Orders Line Items | #1747

### DIFF
--- a/src/pages/invoices/common/hooks/useHandleProductChange.ts
+++ b/src/pages/invoices/common/hooks/useHandleProductChange.ts
@@ -13,9 +13,13 @@ import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { useResolveCurrency } from '$app/common/hooks/useResolveCurrency';
 import { InvoiceItem } from '$app/common/interfaces/invoice-item';
 import { Product } from '$app/common/interfaces/product';
-import { ProductTableResource } from '../components/ProductsTable';
+import {
+  ProductTableResource,
+  RelationType,
+} from '../components/ProductsTable';
 
 interface Props {
+  relationType: RelationType;
   resource: ProductTableResource;
   type: 'product' | 'task';
   onChange: (index: number, lineItem: InvoiceItem) => unknown;
@@ -41,6 +45,11 @@ export function useHandleProductChange(props: Props) {
       return props.onChange(index, lineItem);
     }
 
+    const currentPrice =
+      product?.cost > 0 && props.relationType === 'vendor_id'
+        ? product?.cost
+        : product?.price || 0;
+
     if (company.fill_products) {
       lineItem.quantity = company?.default_quantity
         ? 1
@@ -61,15 +70,15 @@ export function useHandleProductChange(props: Props) {
 
             if (clientCurrency && companyCurrency) {
               lineItem.cost =
-                (product?.price || 0) *
+                currentPrice *
                 (clientCurrency.exchange_rate / companyCurrency.exchange_rate);
             }
           } else {
-            lineItem.cost = product?.price || 0;
+            lineItem.cost = currentPrice;
           }
         });
       } else {
-        lineItem.cost = product?.price || 0;
+        lineItem.cost = currentPrice;
       }
     }
 

--- a/src/pages/invoices/common/hooks/useResolveInputField.tsx
+++ b/src/pages/invoices/common/hooks/useResolveInputField.tsx
@@ -149,6 +149,7 @@ export function useResolveInputField(props: Props) {
   );
 
   const handleProductChange = useHandleProductChange({
+    relationType: props.relationType,
     resource: props.resource,
     type: props.type,
     onChange: props.onLineItemChange,


### PR DESCRIPTION
@beganovich @turbo124 The PR includes logic changes for displaying the value in the `unit_cost` column. So, if `product.cost` is greater than zero (0), then the `product.cost` will be displayed in the `unit_cost` column instead of `product.price`. This will only happen for Purchase Orders. Let me know your thoughts.