### PR TITLE
[Cleanup] Adding Max Date For Date Type Input Fields

### DIFF
--- a/src/components/forms/InputField.tsx
+++ b/src/components/forms/InputField.tsx
@@ -84,6 +84,7 @@ export function InputField(props: Props) {
             ...props.style,
           }}
           min={props.min}
+          max={props.type === 'date' ? '9999-12-31' : undefined}
           maxLength={props.maxLength}
           autoComplete={props.autoComplete || 'new-password'}
           disabled={props.disabled}


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adding the `9999-12-31` date as the maximum date for date input fields to prevent invalid dates larger than this one, which are unrealistic. Let me know your thoughts.