### PR TITLE
[Cleanup] Implementing "Clear" Button For Import Mappings To Unselect All Of Them

### DIFF
--- a/src/components/import/UploadImport.tsx
+++ b/src/components/import/UploadImport.tsx
@@ -178,6 +178,15 @@ export function UploadImport(props: Props) {
       });
   };
 
+  const handleClearMapping = () => {
+    Object.keys(payload.column_map[props.entity].mapping).forEach((key) => {
+      payload.column_map[props.entity].mapping[key] = '';
+    });
+
+    setSelectedTemplate('');
+    setPayloadData({ ...payload });
+  };
+
   const formik = useFormik({
     enableReinitialize: true,
     initialValues: {},
@@ -195,15 +204,17 @@ export function UploadImport(props: Props) {
             response.data?.mappings[props.entity]?.hints.forEach(
               (mapping: number, index: number) => {
                 payload.column_map[props.entity].mapping[index] =
-                  response.data?.mappings[props.entity].available[mapping];
+                  response.data?.mappings[props.entity].available[mapping] ??
+                  '';
                 setPayloadData(payload);
                 setDefaultMapping({
                   ...payload?.column_map?.[props.entity]?.mapping,
                 });
-                setSelectedTemplate('');
               }
             );
           }
+
+          setSelectedTemplate('');
         })
         .catch((error: AxiosError<ValidationBag>) => {
           if (error.response?.status === 422) {
@@ -515,11 +526,21 @@ export function UploadImport(props: Props) {
             )}
             <Tr>
               <Td colSpan={2}>
-                <ImportTemplateModal
-                  entity={props.entity}
-                  importMap={payload}
-                  onImport={processImport}
-                />
+                <div className="flex justify-end space-x-4">
+                  <Button
+                    type="secondary"
+                    behavior="button"
+                    onClick={handleClearMapping}
+                  >
+                    {t('clear')}
+                  </Button>
+
+                  <ImportTemplateModal
+                    entity={props.entity}
+                    importMap={payload}
+                    onImport={processImport}
+                  />
+                </div>
               </Td>
             </Tr>
           </Tbody>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of a "Clear" button on the import page for mappings that sometimes become incorrect. Screenshot:

<img width="1262" alt="Screenshot 2024-05-09 at 13 08 17" src="https://github.com/invoiceninja/ui/assets/51542191/7fa4994a-2c9e-4839-9739-c013b6b4c674">

Let me know your thoughts.