### PR TITLE
[Cleanup] Updating VITE_WHITELABEL_INVOICE_URL In the .env.example file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ VITE_APP_TITLE="Invoice Ninja"
 
 # Supported values: "browser", "hash"
 # VITE_ROUTER=hash
-VITE_WHITELABEL_INVOICE_URL=https://app.invoiceninja.com/buy_now/?account_key=AsFmBAeLXF0IKf7tmi0eiyZfmWW9hxMT&product_id=3
+VITE_WHITELABEL_INVOICE_URL=https://invoiceninja.invoicing.co/client/subscriptions/O5xe7Rwd7r/purchase
 
 VITE_GOOGLE_CLIENT_ID=
 VITE_MICROSOFT_CLIENT_ID=


### PR DESCRIPTION
@beganovich @turbo124 The PR includes updating the `VITE_WHITELABEL_INVOICE_URL` variable in the `.env.example` file regarding the issue that the client experienced with purchasing the plan as a self-hosted user (#1746). Let me know your thoughts.