### PR TITLE
[Bugfix] "Purchase License" Button Link

### DIFF
--- a/src/components/layouts/Default.tsx
+++ b/src/components/layouts/Default.tsx
@@ -420,7 +420,7 @@ export function Default(props: Props) {
                     window.open(
                       isSelfHosted()
                         ? import.meta.env.VITE_WHITELABEL_INVOICE_URL ||
-                            'https://app.invoiceninja.com/buy_now/?account_key=AsFmBAeLXF0IKf7tmi0eiyZfmWW9hxMT&product_id=3'
+                            'https://invoiceninja.invoicing.co/client/subscriptions/O5xe7Rwd7r/purchase'
                         : user?.company_user?.ninja_portal_url,
                       '_blank'
                     )

--- a/src/pages/settings/account-management/component/Licence.tsx
+++ b/src/pages/settings/account-management/component/Licence.tsx
@@ -23,7 +23,7 @@ export function License() {
   const [t] = useTranslation();
   const link =
     import.meta.env.VITE_WHITELABEL_INVOICE_URL ||
-    'https://app.invoiceninja.com/buy_now/?account_key=AsFmBAeLXF0IKf7tmi0eiyZfmWW9hxMT&product_id=3';
+    'https://invoiceninja.invoicing.co/client/subscriptions/O5xe7Rwd7r/purchase';
 
   const [isModalVisible, setIsModalVisible] = useState(false);
 

--- a/src/pages/settings/account-management/component/Licence.tsx
+++ b/src/pages/settings/account-management/component/Licence.tsx
@@ -21,7 +21,9 @@ import { toast } from '$app/common/helpers/toast/toast';
 
 export function License() {
   const [t] = useTranslation();
-  const link = import.meta.env.VITE_WHITELABEL_INVOICE_URL as unknown as string;
+  const link =
+    import.meta.env.VITE_WHITELABEL_INVOICE_URL ||
+    'https://app.invoiceninja.com/buy_now/?account_key=AsFmBAeLXF0IKf7tmi0eiyZfmWW9hxMT&product_id=3';
 
   const [isModalVisible, setIsModalVisible] = useState(false);
 


### PR DESCRIPTION
@beganovich @turbo124 The reason the user experienced this issue (https://github.com/invoiceninja/ui/issues/1746) is because the `VITE_WHITELABEL_INVOICE_URL` environment variable is not populated. However, the 'Purchase White Label' button in the navigation bar has a fallback to a fixed URL, so when the variable is not populated, the button still has a URL to navigate to.

Now, I have set the newest URL as a fallback value for both buttons. So, even if the environment variable is not populated, the tab will be opened with: `https://invoiceninja.invoicing.co/client/subscriptions/O5xe7Rwd7r/purchase`.

Let me know your thoughts.