### PR TITLE
[Cleanup] Refactoring Clearing Mapped Values

### DIFF
--- a/src/components/import/UploadImport.tsx
+++ b/src/components/import/UploadImport.tsx
@@ -180,10 +180,12 @@ export function UploadImport(props: Props) {
   };
 
   const handleClearMapping = (index: number) => {
-    payload.column_map[props.entity].mapping[index] = '';
+    if (payload.column_map[props.entity].mapping[index]) {
+      payload.column_map[props.entity].mapping[index] = '';
 
-    setSelectedTemplate('');
-    setPayloadData({ ...payload });
+      setSelectedTemplate('');
+      setPayloadData({ ...payload });
+    }
   };
 
   const formik = useFormik({

--- a/src/components/import/UploadImport.tsx
+++ b/src/components/import/UploadImport.tsx
@@ -30,6 +30,7 @@ import { ImportTemplateModal } from './ImportTemplateModal';
 import { useEntityImportTemplates } from './common/hooks/useEntityImportTemplates';
 import { useReactSettings } from '$app/common/hooks/useReactSettings';
 import { ImportTemplate } from './ImportTemplate';
+import { Icon } from '../icons/Icon';
 
 interface Props {
   entity: string;
@@ -178,10 +179,8 @@ export function UploadImport(props: Props) {
       });
   };
 
-  const handleClearMapping = () => {
-    Object.keys(payload.column_map[props.entity].mapping).forEach((key) => {
-      payload.column_map[props.entity].mapping[key] = '';
-    });
+  const handleClearMapping = (index: number) => {
+    payload.column_map[props.entity].mapping[index] = '';
 
     setSelectedTemplate('');
     setPayloadData({ ...payload });
@@ -481,20 +480,31 @@ export function UploadImport(props: Props) {
                     </span>
                   </Td>
                   <Td>
-                    <SelectField
-                      id={index}
-                      value={getColumnValue(index)}
-                      onChange={handleChange}
-                      withBlank
-                    >
-                      {mapData.mappings[props.entity].available.map(
-                        (mapping: any, index: number) => (
-                          <option value={mapping} key={index}>
-                            {decorateMapping(mapping)}
-                          </option>
-                        )
-                      )}
-                    </SelectField>
+                    <div className="flex items-center space-x-2">
+                      <div className="flex-1">
+                        <SelectField
+                          id={index}
+                          value={getColumnValue(index)}
+                          onChange={handleChange}
+                          withBlank
+                        >
+                          {mapData.mappings[props.entity].available.map(
+                            (mapping: any, index: number) => (
+                              <option value={mapping} key={index}>
+                                {decorateMapping(mapping)}
+                              </option>
+                            )
+                          )}
+                        </SelectField>
+                      </div>
+
+                      <Icon
+                        className="cursor-pointer"
+                        element={MdClose}
+                        size={24}
+                        onClick={() => handleClearMapping(index)}
+                      />
+                    </div>
                   </Td>
                 </Tr>
               )
@@ -526,21 +536,11 @@ export function UploadImport(props: Props) {
             )}
             <Tr>
               <Td colSpan={2}>
-                <div className="flex justify-end space-x-4">
-                  <Button
-                    type="secondary"
-                    behavior="button"
-                    onClick={handleClearMapping}
-                  >
-                    {t('clear')}
-                  </Button>
-
-                  <ImportTemplateModal
-                    entity={props.entity}
-                    importMap={payload}
-                    onImport={processImport}
-                  />
-                </div>
+                <ImportTemplateModal
+                  entity={props.entity}
+                  importMap={payload}
+                  onImport={processImport}
+                />
               </Td>
             </Tr>
           </Tbody>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adjustments to the functionality for clearing mapped values for imports. Instead of having a 'Clear' button to clear the whole form, we now have an 'X' button for each select field to remove the mapped value. Screenshot:

<img width="866" alt="Screenshot 2024-05-27 at 10 39 03" src="https://github.com/invoiceninja/ui/assets/51542191/35e28987-60e5-4b49-9151-8898fe174a5c">

Let me know your thoughts.