### PR TITLE
[Feature] Implementing Links To Entities | Expenses

### DIFF
--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -131,15 +131,3 @@ export function checkJsonObject(text: string) {
     return false;
   }
 }
-
-export function url(route: string) {
-  let url = window.location.origin;
-
-  if (import.meta.env.VITE_ROUTER === 'hash') {
-    url += '/#';
-  }
-
-  url += route;
-
-  return url;
-}

--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -131,3 +131,15 @@ export function checkJsonObject(text: string) {
     return false;
   }
 }
+
+export function url(route: string) {
+  let url = window.location.origin;
+
+  if (import.meta.env.VITE_ROUTER === 'hash') {
+    url += '/#';
+  }
+
+  url += route;
+
+  return url;
+}

--- a/src/pages/expenses/create/components/Details.tsx
+++ b/src/pages/expenses/create/components/Details.tsx
@@ -25,6 +25,9 @@ import { ExpenseStatus } from '../../common/components/ExpenseStatus';
 import { CustomField } from '$app/components/CustomField';
 import { useCalculateExpenseAmount } from '../../common/hooks/useCalculateExpenseAmount';
 import { useFormatMoney } from '$app/common/hooks/money/useFormatMoney';
+import { Icon } from '$app/components/icons/Icon';
+import { MdLaunch } from 'react-icons/md';
+import { route } from '$app/common/helpers/route';
 
 export interface ExpenseCardProps {
   expense: Expense | undefined;
@@ -83,7 +86,28 @@ export function Details(props: Props) {
         )}
 
         {expense && (
-          <Element leftSide={t('vendor')}>
+          <Element
+            leftSide={
+              <div className="flex items-center space-x-2">
+                <span>{t('vendor')}</span>
+
+                {expense.vendor_id && (
+                  <Icon
+                    className="cursor-pointer"
+                    element={MdLaunch}
+                    size={18}
+                    onClick={() =>
+                      window.open(
+                        route('/vendors/:id', {
+                          id: expense.vendor_id,
+                        })
+                      )
+                    }
+                  />
+                )}
+              </div>
+            }
+          >
             <VendorSelector
               value={expense.vendor_id}
               onChange={(vendor) => handleChange('vendor_id', vendor.id)}
@@ -94,7 +118,28 @@ export function Details(props: Props) {
         )}
 
         {expense && (
-          <Element leftSide={t('client')}>
+          <Element
+            leftSide={
+              <div className="flex items-center space-x-2">
+                <span>{t('client')}</span>
+
+                {expense.client_id && (
+                  <Icon
+                    className="cursor-pointer"
+                    element={MdLaunch}
+                    size={18}
+                    onClick={() =>
+                      window.open(
+                        route('/clients/:id', {
+                          id: expense.client_id,
+                        })
+                      )
+                    }
+                  />
+                )}
+              </div>
+            }
+          >
             <ClientSelector
               value={expense.client_id}
               clearButton={Boolean(expense.client_id)}
@@ -106,7 +151,28 @@ export function Details(props: Props) {
         )}
 
         {expense && (
-          <Element leftSide={t('project')}>
+          <Element
+            leftSide={
+              <div className="flex items-center space-x-2">
+                <span>{t('project')}</span>
+
+                {expense.project_id && (
+                  <Icon
+                    className="cursor-pointer"
+                    element={MdLaunch}
+                    size={18}
+                    onClick={() =>
+                      window.open(
+                        route('/projects/:id', {
+                          id: expense.project_id,
+                        })
+                      )
+                    }
+                  />
+                )}
+              </div>
+            }
+          >
             <ProjectSelector
               value={expense.project_id}
               clearButton={Boolean(expense.project_id)}

--- a/src/pages/expenses/create/components/Details.tsx
+++ b/src/pages/expenses/create/components/Details.tsx
@@ -28,7 +28,7 @@ import { useFormatMoney } from '$app/common/hooks/money/useFormatMoney';
 import { Icon } from '$app/components/icons/Icon';
 import { MdLaunch } from 'react-icons/md';
 import { route } from '$app/common/helpers/route';
-import { url } from '$app/common/helpers';
+import { Link } from 'react-router-dom';
 
 export interface ExpenseCardProps {
   expense: Expense | undefined;
@@ -93,22 +93,14 @@ export function Details(props: Props) {
                 <span>{t('vendor')}</span>
 
                 {expense.vendor_id && (
-                  <div>
-                    <Icon
-                      className="cursor-pointer"
-                      element={MdLaunch}
-                      size={18}
-                      onClick={() =>
-                        window.open(
-                          url(
-                            route('/vendors/:id', {
-                              id: expense.vendor_id,
-                            })
-                          )
-                        )
-                      }
-                    />
-                  </div>
+                  <Link
+                    to={route('/vendors/:id', {
+                      id: expense.vendor_id,
+                    })}
+                    target="_blank"
+                  >
+                    <Icon element={MdLaunch} size={18} />
+                  </Link>
                 )}
               </div>
             }
@@ -129,22 +121,14 @@ export function Details(props: Props) {
                 <span>{t('client')}</span>
 
                 {expense.client_id && (
-                  <div>
-                    <Icon
-                      className="cursor-pointer"
-                      element={MdLaunch}
-                      size={18}
-                      onClick={() =>
-                        window.open(
-                          url(
-                            route('/clients/:id', {
-                              id: expense.client_id,
-                            })
-                          )
-                        )
-                      }
-                    />
-                  </div>
+                  <Link
+                    to={route('/clients/:id', {
+                      id: expense.client_id,
+                    })}
+                    target="_blank"
+                  >
+                    <Icon element={MdLaunch} size={18} />
+                  </Link>
                 )}
               </div>
             }
@@ -166,22 +150,14 @@ export function Details(props: Props) {
                 <span>{t('project')}</span>
 
                 {expense.project_id && (
-                  <div>
-                    <Icon
-                      className="cursor-pointer"
-                      element={MdLaunch}
-                      size={18}
-                      onClick={() =>
-                        window.open(
-                          url(
-                            route('/projects/:id', {
-                              id: expense.project_id,
-                            })
-                          )
-                        )
-                      }
-                    />
-                  </div>
+                  <Link
+                    to={route('/projects/:id', {
+                      id: expense.project_id,
+                    })}
+                    target="_blank"
+                  >
+                    <Icon element={MdLaunch} size={18} />
+                  </Link>
                 )}
               </div>
             }

--- a/src/pages/expenses/create/components/Details.tsx
+++ b/src/pages/expenses/create/components/Details.tsx
@@ -28,6 +28,7 @@ import { useFormatMoney } from '$app/common/hooks/money/useFormatMoney';
 import { Icon } from '$app/components/icons/Icon';
 import { MdLaunch } from 'react-icons/md';
 import { route } from '$app/common/helpers/route';
+import { url } from '$app/common/helpers';
 
 export interface ExpenseCardProps {
   expense: Expense | undefined;
@@ -92,18 +93,22 @@ export function Details(props: Props) {
                 <span>{t('vendor')}</span>
 
                 {expense.vendor_id && (
-                  <Icon
-                    className="cursor-pointer"
-                    element={MdLaunch}
-                    size={18}
-                    onClick={() =>
-                      window.open(
-                        route('/vendors/:id', {
-                          id: expense.vendor_id,
-                        })
-                      )
-                    }
-                  />
+                  <div>
+                    <Icon
+                      className="cursor-pointer"
+                      element={MdLaunch}
+                      size={18}
+                      onClick={() =>
+                        window.open(
+                          url(
+                            route('/vendors/:id', {
+                              id: expense.vendor_id,
+                            })
+                          )
+                        )
+                      }
+                    />
+                  </div>
                 )}
               </div>
             }
@@ -124,18 +129,22 @@ export function Details(props: Props) {
                 <span>{t('client')}</span>
 
                 {expense.client_id && (
-                  <Icon
-                    className="cursor-pointer"
-                    element={MdLaunch}
-                    size={18}
-                    onClick={() =>
-                      window.open(
-                        route('/clients/:id', {
-                          id: expense.client_id,
-                        })
-                      )
-                    }
-                  />
+                  <div>
+                    <Icon
+                      className="cursor-pointer"
+                      element={MdLaunch}
+                      size={18}
+                      onClick={() =>
+                        window.open(
+                          url(
+                            route('/clients/:id', {
+                              id: expense.client_id,
+                            })
+                          )
+                        )
+                      }
+                    />
+                  </div>
                 )}
               </div>
             }
@@ -157,18 +166,22 @@ export function Details(props: Props) {
                 <span>{t('project')}</span>
 
                 {expense.project_id && (
-                  <Icon
-                    className="cursor-pointer"
-                    element={MdLaunch}
-                    size={18}
-                    onClick={() =>
-                      window.open(
-                        route('/projects/:id', {
-                          id: expense.project_id,
-                        })
-                      )
-                    }
-                  />
+                  <div>
+                    <Icon
+                      className="cursor-pointer"
+                      element={MdLaunch}
+                      size={18}
+                      onClick={() =>
+                        window.open(
+                          url(
+                            route('/projects/:id', {
+                              id: expense.project_id,
+                            })
+                          )
+                        )
+                      }
+                    />
+                  </div>
                 )}
               </div>
             }


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of icons on the left side that will open new tab to the show pages of entities. In this case, for Expenses, the icons are implemented for the 'Vendor', 'Client', and 'Project' selectors. The icon will only be displayed if there is a selected value in the selector. Screenshot:

<img width="580" alt="Screenshot 2024-05-27 at 16 09 25" src="https://github.com/invoiceninja/ui/assets/51542191/efdd8802-9eb8-40c9-a621-2b8f22d61fee">

Let me know your thoughts.