### PR TITLE
[Feature] Implementing Bulk Updates Action | Clients

### DIFF
--- a/src/common/hooks/useBulkUpdatesColumns.ts
+++ b/src/common/hooks/useBulkUpdatesColumns.ts
@@ -1,0 +1,26 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { useEffect, useState } from 'react';
+import { useStaticsQuery } from '../queries/statics';
+
+export function useBulkUpdatesColumns() {
+  const { data: statics } = useStaticsQuery();
+
+  const [bulkUpdates, setBulkUpdates] = useState<Record<string, string[]>>();
+
+  useEffect(() => {
+    if (statics?.bulk_updates) {
+      setBulkUpdates(statics.bulk_updates);
+    }
+  }, [statics]);
+
+  return bulkUpdates;
+}

--- a/src/common/interfaces/statics.ts
+++ b/src/common/interfaces/statics.ts
@@ -24,6 +24,7 @@ export interface Statics {
   sizes: Industry[];
   timezones: Timezone[];
   templates: Templates;
+  bulk_updates: Record<string, string[]>;
 }
 
 export interface Bank {

--- a/src/common/queries/clients.ts
+++ b/src/common/queries/clients.ts
@@ -82,23 +82,34 @@ export function useClientQuery({ id, enabled }: GenericQueryOptions) {
 
 const successMessages = {
   assign_group: 'updated_group',
+  bulk_update: 'updated_records',
 };
+
+interface Details {
+  groupSettingsId?: string;
+  column?: string;
+  newValue?: string;
+}
 
 export function useBulk() {
   const queryClient = useQueryClient();
   const invalidateQueryValue = useAtomValue(invalidationQueryAtom);
 
-  return (
+  return async (
     ids: string[],
-    action: 'archive' | 'restore' | 'delete' | 'assign_group',
-    groupSettingsId?: string
+    action: 'archive' | 'restore' | 'delete' | 'assign_group' | 'bulk_update',
+    details?: Details
   ) => {
+    const { groupSettingsId, column, newValue } = details || {};
+
     toast.processing();
 
     return request('POST', endpoint('/api/v1/clients/bulk'), {
       action,
       ids,
       ...(groupSettingsId && { group_settings_id: groupSettingsId }),
+      ...(column && { column }),
+      ...(action === 'bulk_update' && { new_value: newValue }),
     }).then(() => {
       const message =
         successMessages[action as keyof typeof successMessages] ||

--- a/src/common/queries/clients.ts
+++ b/src/common/queries/clients.ts
@@ -88,7 +88,7 @@ const successMessages = {
 interface Details {
   groupSettingsId?: string;
   column?: string;
-  newValue?: string;
+  newValue?: string | number | boolean;
 }
 
 export function useBulk() {

--- a/src/components/forms/InputCustomField.tsx
+++ b/src/components/forms/InputCustomField.tsx
@@ -31,7 +31,7 @@ export function InputCustomField(props: Props) {
       : [props.value, 'multi_line_text'];
 
     setType(fieldType);
-  }, []);
+  }, [props.field]);
 
   return (
     <>

--- a/src/pages/clients/common/components/AssignToGroupBulkAction.tsx
+++ b/src/pages/clients/common/components/AssignToGroupBulkAction.tsx
@@ -65,7 +65,7 @@ export function AssignToGroupBulkAction(props: Props) {
             bulk(
               clients.map(({ id }) => id),
               'assign_group',
-              groupSettingsId
+              { groupSettingsId }
             ).then(() => handleOnClose());
 
             setSelected([]);

--- a/src/pages/clients/common/components/BulkUpdatesAction.tsx
+++ b/src/pages/clients/common/components/BulkUpdatesAction.tsx
@@ -98,11 +98,11 @@ export function BulkUpdatesAction(props: Props) {
         onClick={() => setIsModalOpen(true)}
         icon={<Icon element={MdCached} />}
       >
-        {t('update_records')}
+        {t('bulk_update')}
       </DropdownElement>
 
       <Modal
-        title={t('update_records')}
+        title={t('bulk_update')}
         size="regular"
         visible={isModalOpen}
         onClose={handleOnClose}

--- a/src/pages/clients/common/components/BulkUpdatesAction.tsx
+++ b/src/pages/clients/common/components/BulkUpdatesAction.tsx
@@ -21,7 +21,7 @@ import { MarkdownEditor } from '$app/components/forms/MarkdownEditor';
 import { Icon } from '$app/components/icons/Icon';
 import { Dispatch, SetStateAction, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { MdUpdate } from 'react-icons/md';
+import { MdCached } from 'react-icons/md';
 
 interface Props {
   entity: 'client';
@@ -96,7 +96,7 @@ export function BulkUpdatesAction(props: Props) {
     <>
       <DropdownElement
         onClick={() => setIsModalOpen(true)}
-        icon={<Icon element={MdUpdate} />}
+        icon={<Icon element={MdCached} />}
       >
         {t('update_records')}
       </DropdownElement>

--- a/src/pages/clients/common/components/BulkUpdatesAction.tsx
+++ b/src/pages/clients/common/components/BulkUpdatesAction.tsx
@@ -1,0 +1,199 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { useBulkUpdatesColumns } from '$app/common/hooks/useBulkUpdatesColumns';
+import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
+import { Client } from '$app/common/interfaces/client';
+import { useBulk } from '$app/common/queries/clients';
+import { useStaticsQuery } from '$app/common/queries/statics';
+import { CountrySelector } from '$app/components/CountrySelector';
+import { CustomField } from '$app/components/CustomField';
+import { Modal } from '$app/components/Modal';
+import { DropdownElement } from '$app/components/dropdown/DropdownElement';
+import { Button, InputLabel, SelectField } from '$app/components/forms';
+import { MarkdownEditor } from '$app/components/forms/MarkdownEditor';
+import { Icon } from '$app/components/icons/Icon';
+import { Dispatch, SetStateAction, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { MdUpdate } from 'react-icons/md';
+
+interface Props {
+  entity: 'client';
+  resources: Client[];
+  setSelected: Dispatch<SetStateAction<string[]>>;
+}
+
+interface BulkUpdateField {
+  key: string;
+  type:
+    | 'markdownEditor'
+    | 'industrySelector'
+    | 'sizeSelector'
+    | 'countrySelector'
+    | 'customField';
+}
+
+const bulkUpdateFieldsTypes: BulkUpdateField[] = [
+  { key: 'public_notes', type: 'markdownEditor' },
+  { key: 'industry_id', type: 'industrySelector' },
+  { key: 'size_id', type: 'sizeSelector' },
+  { key: 'country_id', type: 'countrySelector' },
+  { key: 'custom_value1', type: 'customField' },
+  { key: 'custom_value2', type: 'customField' },
+  { key: 'custom_value3', type: 'customField' },
+  { key: 'custom_value4', type: 'customField' },
+];
+
+export function BulkUpdatesAction(props: Props) {
+  const [t] = useTranslation();
+
+  const { setSelected } = props;
+
+  const bulk = useBulk();
+
+  const { data: statics } = useStaticsQuery();
+
+  const company = useCurrentCompany();
+  const bulkUpdatesColumns = useBulkUpdatesColumns();
+
+  const [column, setColumn] = useState<string>('');
+  const [newColumnValue, setNewColumnValue] = useState<
+    string | number | boolean
+  >('');
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+
+  const handleOnClose = () => {
+    setIsModalOpen(false);
+    setColumn('');
+    setNewColumnValue('');
+  };
+
+  const getFieldType = () => {
+    return bulkUpdateFieldsTypes.find(({ key }) => key === column)?.type || '';
+  };
+
+  const getCustomFieldKey = () => {
+    return column.replace('custom_value', props.entity);
+  };
+
+  return (
+    <>
+      <DropdownElement
+        onClick={() => setIsModalOpen(true)}
+        icon={<Icon element={MdUpdate} />}
+      >
+        {t('update_records')}
+      </DropdownElement>
+
+      <Modal
+        title={t('update')}
+        size="regular"
+        visible={isModalOpen}
+        onClose={handleOnClose}
+        overflowVisible
+      >
+        <div className="flex flex-col space-y-5">
+          <SelectField
+            label={t('column')}
+            value={column}
+            onValueChange={(value) => {
+              setColumn(value);
+              setNewColumnValue('');
+            }}
+            withBlank
+          >
+            {bulkUpdatesColumns?.[props.entity].map((column) => (
+              <option key={column} value={column}>
+                {t(column)}
+              </option>
+            ))}
+          </SelectField>
+
+          <div className="flex flex-col">
+            {Boolean(getFieldType()) && (
+              <InputLabel className="mb-2">{t('value')}</InputLabel>
+            )}
+
+            {getFieldType() === 'markdownEditor' && (
+              <MarkdownEditor
+                value={newColumnValue as string}
+                onChange={(value) => setNewColumnValue(value)}
+              />
+            )}
+
+            {getFieldType() === 'industrySelector' && (
+              <SelectField
+                value={newColumnValue}
+                onValueChange={(value) => setNewColumnValue(value)}
+                withBlank
+              >
+                {statics?.industries.map(
+                  (industry: { id: string; name: string }) => (
+                    <option key={industry.id} value={industry.id}>
+                      {industry.name}
+                    </option>
+                  )
+                )}
+              </SelectField>
+            )}
+
+            {getFieldType() === 'sizeSelector' && (
+              <SelectField
+                value={newColumnValue}
+                onValueChange={(value) => setNewColumnValue(value)}
+                withBlank
+              >
+                {statics?.sizes.map(
+                  (size: { id: string; name: string }, index: number) => (
+                    <option key={index} value={size.id}>
+                      {size.name}
+                    </option>
+                  )
+                )}
+              </SelectField>
+            )}
+
+            {getFieldType() === 'countrySelector' && (
+              <CountrySelector
+                value={newColumnValue as string}
+                onChange={(value) => setNewColumnValue(value)}
+                dismissable
+              />
+            )}
+
+            {getFieldType() === 'customField' &&
+              company?.custom_fields?.[getCustomFieldKey()] && (
+                <CustomField
+                  field={getCustomFieldKey()}
+                  defaultValue={newColumnValue}
+                  value={company.custom_fields[getCustomFieldKey()]}
+                  onValueChange={(value) => setNewColumnValue(value)}
+                  fieldOnly
+                />
+              )}
+          </div>
+
+          <div className="flex self-end">
+            <Button
+              behavior="button"
+              onClick={() => {
+                setSelected([]);
+              }}
+              disableWithoutIcon
+            >
+              {t('update')}
+            </Button>
+          </div>
+        </div>
+      </Modal>
+    </>
+  );
+}

--- a/src/pages/clients/common/hooks/useCustomBulkActions.tsx
+++ b/src/pages/clients/common/hooks/useCustomBulkActions.tsx
@@ -94,10 +94,10 @@ export const useCustomBulkActions = () => {
           setSelected={setSelected}
         />
       ),
-    ({ selectedResources, setSelected }) => (
+    ({ selectedIds, setSelected }) => (
       <BulkUpdatesAction
         entity="client"
-        resources={selectedResources}
+        resourceIds={selectedIds}
         setSelected={setSelected}
       />
     ),

--- a/src/pages/clients/common/hooks/useCustomBulkActions.tsx
+++ b/src/pages/clients/common/hooks/useCustomBulkActions.tsx
@@ -19,6 +19,7 @@ import { useDocumentsBulk } from '$app/common/queries/documents';
 import { Dispatch, SetStateAction } from 'react';
 import { useChangeTemplate } from '$app/pages/settings/invoice-design/pages/custom-designs/components/ChangeTemplate';
 import { AssignToGroupBulkAction } from '../components/AssignToGroupBulkAction';
+import { BulkUpdatesAction } from '../components/BulkUpdatesAction';
 
 export const useCustomBulkActions = () => {
   const [t] = useTranslation();
@@ -93,6 +94,13 @@ export const useCustomBulkActions = () => {
           setSelected={setSelected}
         />
       ),
+    ({ selectedResources, setSelected }) => (
+      <BulkUpdatesAction
+        entity="client"
+        resources={selectedResources}
+        setSelected={setSelected}
+      />
+    ),
   ];
 
   return customBulkActions;


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of bulk_update client action. Screenshots:

![Screenshot 2024-05-29 at 21 20 48](https://github.com/invoiceninja/ui/assets/51542191/6fd8d302-dde2-4748-a1a4-a598f8f92c8b)

![Screenshot 2024-05-29 at 21 16 17](https://github.com/invoiceninja/ui/assets/51542191/49138a5b-5c7e-4087-98d7-376c3b51e89c)

`Note`: We are missing the `update_records` translation keyword that I used in the solution to get the final translation for "Update Records." If you would agree, please just add it to the files.

Let me know your thoughts.