### PR TITLE
[Bugfix] Checking The Toggle

### DIFF
--- a/src/components/forms/InputCustomField.tsx
+++ b/src/components/forms/InputCustomField.tsx
@@ -61,7 +61,7 @@ export function InputCustomField(props: Props) {
           onChange={props.onValueChange}
           checked={
             typeof props.defaultValue === 'string'
-              ? props.defaultValue === 'true'
+              ? props.defaultValue === 'true' || props.defaultValue === '1'
               : props.defaultValue
           }
         />


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for checking the toggle across the app where there is a possibility to return a `"1"` value instead of `"true"` or `true` as a boolean. While working on the `bulk_update` action for clients, I discovered a bug when updating values for `custom fields`. If the custom field is chosen as a toggle/switch, then when we send `true` as a boolean in the payload, the API's response is a string value `("1")`. We had not covered that case earlier, but it is covered now. Let me know your thoughts.