### PR TITLE
[Cleanup] Company Activity Banner | Self-Hosted

### DIFF
--- a/src/components/banners/ActivateCompany.tsx
+++ b/src/components/banners/ActivateCompany.tsx
@@ -12,7 +12,6 @@ import { useTranslation } from 'react-i18next';
 import { Banner } from '../Banner';
 import { Link } from 'react-router-dom';
 import { buttonStyles } from './VerifyEmail';
-import { isHosted } from '$app/common/helpers';
 import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { useCurrentUser } from '$app/common/hooks/useCurrentUser';
 
@@ -20,10 +19,6 @@ export function ActivateCompany() {
   const [t] = useTranslation();
   const company = useCurrentCompany();
   const user = useCurrentUser();
-
-  if (!isHosted()) {
-    return null;
-  }
 
   if (!company || !user?.email_verified_at) {
     return null;


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adjusting the logic to display the company activity banner on both platforms: hosted and self-hosted. Screenshot:

<img width="1261" alt="Screenshot 2024-05-30 at 16 53 01" src="https://github.com/invoiceninja/ui/assets/51542191/bf00d642-fe66-4c13-bc83-4295fd2af3d9">

Let me know your thoughts.