### PR TITLE
[Cleanup] Changing Tooltip "reconnect_account" Keyword

### DIFF
--- a/src/pages/settings/bank-accounts/common/hooks/useBankAccountColumns.tsx
+++ b/src/pages/settings/bank-accounts/common/hooks/useBankAccountColumns.tsx
@@ -62,7 +62,7 @@ export const useBankAccountColumns = () => {
           {bankAccount.integration_type === IntegrationType.Nordigen &&
             bankAccount.disabled_upstream && (
               <Tooltip
-                message={t('reconnect_account') as string}
+                message={t('reconnect') as string}
                 width="auto"
                 placement="top"
               >


### PR DESCRIPTION
@beganovich @turbo124 The PR includes changing the "reconnect_account" translation keyword to "reconnect". Let me know your thoughts.