### PR TITLE
[Cleanup] Cleaning up Payment Terms Pages

### DIFF
--- a/src/components/layouts/common/hooks.ts
+++ b/src/components/layouts/common/hooks.ts
@@ -54,7 +54,8 @@ export function useSettingsRoutes() {
       href: '/settings/online_payments',
       current:
         location.pathname.startsWith('/settings/online_payments') ||
-        location.pathname.startsWith('/settings/gateways'),
+        location.pathname.startsWith('/settings/gateways') ||
+        location.pathname.startsWith('/settings/payment_terms'),
       enabled: isAdmin || isOwner || false,
     },
     {

--- a/src/pages/settings/payment-terms/Create.tsx
+++ b/src/pages/settings/payment-terms/Create.tsx
@@ -19,7 +19,6 @@ import { useTitle } from '$app/common/hooks/useTitle';
 import { PaymentTerm } from '$app/common/interfaces/payment-term';
 import { ValidationBag } from '$app/common/interfaces/validation-bag';
 import { useBlankPaymentTermQuery } from '$app/common/queries/payment-terms';
-import { Breadcrumbs } from '$app/components/Breadcrumbs';
 import { Container } from '$app/components/Container';
 import { Icon } from '$app/components/icons/Icon';
 import { Settings } from '$app/components/layouts/Settings';
@@ -40,7 +39,7 @@ export function Create() {
 
   const pages = [
     { name: t('settings'), href: '/settings' },
-    { name: t('company_details'), href: '/settings/company_details' },
+    { name: t('payment_settings'), href: '/settings/online_payments' },
     { name: t('payment_terms'), href: '/settings/payment_terms' },
     { name: t('create_payment_term'), href: '/settings/payment_terms/create' },
   ];
@@ -105,10 +104,8 @@ export function Create() {
   }, [blankPaymentTerm]);
 
   return (
-    <Settings title={t('payment_terms')}>
-      <Container className="space-y-6">
-        <Breadcrumbs pages={pages} />
-
+    <Settings title={t('payment_terms')} breadcrumbs={pages}>
+      <Container>
         <Card
           title={documentTitle}
           withSaveButton

--- a/src/pages/settings/payment-terms/PaymentTerms.tsx
+++ b/src/pages/settings/payment-terms/PaymentTerms.tsx
@@ -22,7 +22,7 @@ export function PaymentTerms() {
 
   const pages = [
     { name: t('settings'), href: '/settings' },
-    { name: t('company_details'), href: '/settings/company_details' },
+    { name: t('payment_settings'), href: '/settings/online_payments' },
     { name: t('payment_terms'), href: '/settings/payment_terms' },
   ];
 

--- a/src/pages/settings/payment-terms/PaymentTerms.tsx
+++ b/src/pages/settings/payment-terms/PaymentTerms.tsx
@@ -8,31 +8,13 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
-import { Button, Link } from '$app/components/forms';
-import {
-  ColumnSortPayload,
-  Pagination,
-  Table,
-  Tbody,
-  Td,
-  Th,
-  Thead,
-  Tr,
-} from '$app/components/tables';
-import { PaymentTerm } from '$app/common/interfaces/payment-term';
-import { bulk, usePaymentTermsQuery } from '$app/common/queries/payment-terms';
-import { Breadcrumbs } from '$app/components/Breadcrumbs';
-import { Dropdown } from '$app/components/dropdown/Dropdown';
-import { DropdownElement } from '$app/components/dropdown/DropdownElement';
 import { Settings } from '$app/components/layouts/Settings';
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { route } from '$app/common/helpers/route';
-import { Icon } from '$app/components/icons/Icon';
-import { MdArchive, MdEdit } from 'react-icons/md';
 import { useTitle } from '$app/common/hooks/useTitle';
-import { toast } from '$app/common/helpers/toast/toast';
-import { $refetch } from '$app/common/hooks/useRefetch';
+import { DataTable, DataTableColumns } from '$app/components/DataTable';
+import { Link } from '$app/components/forms';
+import { route } from '$app/common/helpers/route';
+import { PaymentTerm } from '$app/common/interfaces/payment-term';
 
 export function PaymentTerms() {
   const { documentTitle } = useTitle('payment_terms');
@@ -44,90 +26,33 @@ export function PaymentTerms() {
     { name: t('payment_terms'), href: '/settings/payment_terms' },
   ];
 
-  const [currentPage, setCurrentPage] = useState<number>(1);
-  const [perPage, setPerPage] = useState<string>('10');
-  const [sort, setSort] = useState<string | undefined>(undefined);
-
-  const { data } = usePaymentTermsQuery({
-    currentPage,
-    perPage,
-    sort,
-  });
-
-  const archive = (id: string) => {
-    toast.processing();
-
-    bulk([id], 'archive')
-      .then(() => toast.success('archived_payment_term'))
-      .finally(() => $refetch(['payment_terms']));
-  };
+  const columns: DataTableColumns<PaymentTerm> = [
+    {
+      id: 'name',
+      label: t('number_of_days'),
+      format: (value, paymentTerm) => (
+        <Link
+          to={route('/settings/payment_terms/:id/edit', {
+            id: paymentTerm.id,
+          })}
+        >
+          {value}
+        </Link>
+      ),
+    },
+  ];
 
   return (
-    <Settings title={documentTitle}>
-      <Breadcrumbs pages={pages} />
-
-      <div className="flex justify-end">
-        <Button to="/settings/payment_terms/create">
-          <span>{t('new_payment_term')}</span>
-        </Button>
-      </div>
-
-      <Table>
-        <Thead>
-          <Th
-            isCurrentlyUsed={sort?.split('|')[0] === 'name'}
-            id="name"
-            onColumnClick={(data: ColumnSortPayload) => setSort(data.sort)}
-          >
-            {t('number_of_days')}
-          </Th>
-          <Th></Th>
-        </Thead>
-        <Tbody data={data} showHelperPlaceholders>
-          {data &&
-            data.data.data.map((paymentTerm: PaymentTerm) => (
-              <Tr key={paymentTerm.id}>
-                <Td>
-                  <Link
-                    to={route('/settings/payment_terms/:id/edit', {
-                      id: paymentTerm.id,
-                    })}
-                  >
-                    {paymentTerm.name}
-                  </Link>
-                </Td>
-                <Td>
-                  <Dropdown label={t('actions')}>
-                    <DropdownElement
-                      to={route('/settings/payment_terms/:id/edit', {
-                        id: paymentTerm.id,
-                      })}
-                      icon={<Icon element={MdEdit} />}
-                    >
-                      {t('edit')}
-                    </DropdownElement>
-
-                    <DropdownElement
-                      onClick={() => archive(paymentTerm.id)}
-                      icon={<Icon element={MdArchive} />}
-                    >
-                      {t('archive')}
-                    </DropdownElement>
-                  </Dropdown>
-                </Td>
-              </Tr>
-            ))}
-        </Tbody>
-      </Table>
-
-      {data && (
-        <Pagination
-          currentPage={currentPage}
-          onPageChange={setCurrentPage}
-          onRowsChange={setPerPage}
-          totalPages={data.data.meta.pagination.total_pages}
-        />
-      )}
+    <Settings breadcrumbs={pages} title={documentTitle}>
+      <DataTable
+        endpoint="/api/v1/payment_terms?sort=id|desc"
+        bulkRoute="/api/v1/payment_terms/bulk"
+        resource="payment_term"
+        columns={columns}
+        linkToCreate="/settings/payment_terms/create"
+        linkToEdit="/settings/payment_terms/:id/edit"
+        withResourcefulActions
+      />
     </Settings>
   );
 }

--- a/src/pages/settings/payment-terms/edit/Edit.tsx
+++ b/src/pages/settings/payment-terms/edit/Edit.tsx
@@ -72,7 +72,10 @@ export function Edit() {
   });
 
   return (
-    <Settings title={t('payment_terms')}>
+    <Settings
+      title={t('payment_terms')}
+      navigationTopRight={<Actions paymentTerm={data?.data.data} />}
+    >
       {!data && (
         <div className="flex justify-center">
           <Spinner />
@@ -87,7 +90,6 @@ export function Edit() {
             title={data.data.data.name}
             disableSubmitButton={formik.isSubmitting}
             onFormSubmit={formik.handleSubmit}
-            additionalAction={<Actions paymentTerm={data.data.data} />}
             withSaveButton
           >
             <Element leftSide="Status">

--- a/src/pages/settings/payment-terms/edit/Edit.tsx
+++ b/src/pages/settings/payment-terms/edit/Edit.tsx
@@ -74,7 +74,7 @@ export function Edit() {
   return (
     <Settings
       title={t('payment_terms')}
-      navigationTopRight={<Actions paymentTerm={data?.data.data} />}
+      navigationTopRight={data && <Actions paymentTerm={data.data.data} />}
     >
       {!data && (
         <div className="flex justify-center">

--- a/src/pages/settings/payment-terms/edit/Edit.tsx
+++ b/src/pages/settings/payment-terms/edit/Edit.tsx
@@ -17,7 +17,6 @@ import { useTitle } from '$app/common/hooks/useTitle';
 import { PaymentTerm } from '$app/common/interfaces/payment-term';
 import { usePaymentTermQuery } from '$app/common/queries/payment-terms';
 import { Badge } from '$app/components/Badge';
-import { Breadcrumbs } from '$app/components/Breadcrumbs';
 import { Container } from '$app/components/Container';
 import { Settings } from '$app/components/layouts/Settings';
 import { Spinner } from '$app/components/Spinner';
@@ -36,7 +35,7 @@ export function Edit() {
 
   const pages = [
     { name: t('settings'), href: '/settings' },
-    { name: t('company_details'), href: '/settings/company_details' },
+    { name: t('payment_settings'), href: '/settings/online_payments' },
     { name: t('payment_terms'), href: '/settings/payment_terms' },
     {
       name: t('edit_payment_term'),
@@ -74,6 +73,7 @@ export function Edit() {
   return (
     <Settings
       title={t('payment_terms')}
+      breadcrumbs={pages}
       navigationTopRight={data && <Actions paymentTerm={data.data.data} />}
     >
       {!data && (
@@ -83,9 +83,7 @@ export function Edit() {
       )}
 
       {data && (
-        <Container className="space-y-6">
-          <Breadcrumbs pages={pages} />
-
+        <Container>
           <Card
             title={data.data.data.name}
             disableSubmitButton={formik.isSubmitting}


### PR DESCRIPTION
@beganovich @turbo124 The PR includes two changes for payment terms. We've updated the payment terms table from a very old setup to the standard one used in the app. Additionally, we've moved the more_actions dropdown into the navigation, which is also the standard in the app. Screenshots:

![Screenshot 2024-06-07 at 19 28 06](https://github.com/invoiceninja/ui/assets/51542191/badc3c98-727a-43f5-bc71-94e8e4d49104)

![Screenshot 2024-06-07 at 19 33 15](https://github.com/invoiceninja/ui/assets/51542191/08aa981d-03b7-4324-a48d-16b175bd8c15)

Let me know your thoughts.