### PR TITLE
[Feature] New Lock Invoices Option

### DIFF
--- a/src/pages/settings/workflow-settings/components/Invoices.tsx
+++ b/src/pages/settings/workflow-settings/components/Invoices.tsx
@@ -155,6 +155,7 @@ export function Invoices() {
           <option value="off">{t('off')}</option>
           <option value="when_sent">{t('when_sent')}</option>
           <option value="when_paid">{t('when_paid')}</option>
+          <option value="end_of_month">{t('end_of_month')}</option>
         </SelectField>
       </Element>
     </Card>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of the new lock_invoices option (end_of_month). Screenshot:

<img width="801" alt="Screenshot 2024-06-07 at 12 25 45" src="https://github.com/invoiceninja/ui/assets/51542191/7ea05328-310c-4275-94e2-ab209529fafa">

`Note`: We are missing the "end_of_month" keyword in the translation files, so please just add it there.

Let me know your thoughts.