### PR TITLE
[Cleanup] Group Settings Plan Alert Banner

### DIFF
--- a/src/pages/settings/group-settings/create/Create.tsx
+++ b/src/pages/settings/group-settings/create/Create.tsx
@@ -21,11 +21,15 @@ import { useTitle } from '$app/common/hooks/useTitle';
 import { useTranslation } from 'react-i18next';
 import { useHandleCreate } from '../common/hooks/useHandleCreate';
 import { Card } from '$app/components/cards';
+import { useShouldDisableAdvanceSettings } from '$app/common/hooks/useShouldDisableAdvanceSettings';
+import { AdvancedSettingsPlanAlert } from '$app/components/AdvancedSettingsPlanAlert';
 
 export function Create() {
   const [t] = useTranslation();
 
   const { documentTitle } = useTitle('new_group');
+
+  const showPlanAlert = useShouldDisableAdvanceSettings();
 
   const pages = [
     { name: t('settings'), href: '/settings' },
@@ -59,8 +63,10 @@ export function Create() {
       title={documentTitle}
       breadcrumbs={pages}
       onSaveClick={handleSave}
-      disableSaveButton={isFormBusy || !groupSettings}
+      disableSaveButton={isFormBusy || !groupSettings || showPlanAlert}
     >
+      {showPlanAlert && <AdvancedSettingsPlanAlert />}
+
       {groupSettings && (
         <Card title={t('new_group')}>
           <GroupSettingsForm


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of a plan alert banner on the group settings creation page. Screenshot:

<img width="1512" alt="Screenshot 2024-06-09 at 18 40 55" src="https://github.com/invoiceninja/ui/assets/51542191/1ad72b58-d172-4901-a607-94332bb3d58f">

Let me know your thoughts.