### PR TITLE
Set twig as default language for custom designs 

### DIFF
--- a/src/pages/settings/invoice-design/pages/custom-designs/CustomDesign.tsx
+++ b/src/pages/settings/invoice-design/pages/custom-designs/CustomDesign.tsx
@@ -29,6 +29,7 @@ import { PanelResizeHandle } from './pages/edit/components/PanelResizeHandle';
 import { Tabs } from '$app/components/Tabs';
 import { useTabs } from './pages/edit/common/hooks/useTabs';
 import { useTitle } from '$app/common/hooks/useTitle';
+import { Alert } from '$app/components/Alert';
 
 export interface PreviewPayload {
   design: Design | null;
@@ -118,6 +119,13 @@ export default function CustomDesign() {
       <PanelGroup>
         <Panel>
           <div className="space-y-4 h-full max-h-[80vh] overflow-y-auto">
+            {errors?.errors.syntax ? (
+              <Alert type="danger">
+                <p>{errors.message}</p>
+                <small>{errors.errors.syntax}</small>
+              </Alert>
+            ) : null}
+
             <Outlet
               context={{
                 errors,
@@ -144,6 +152,18 @@ export default function CustomDesign() {
                 method="POST"
                 withToast
                 renderAsHTML={shouldRenderHTML}
+                onError={(error: AxiosError<ArrayBuffer>) => {
+                  if (error.response?.status === 422 && error.response.data) {
+                    const response = new TextDecoder('utf-8').decode(
+                      error.response.data
+                    );
+
+                    const body = JSON.parse(response) as ValidationBag;
+
+                    setErrors(body);
+                  }
+                }}
+                onRequest={() => setErrors(undefined)}
               />
             ) : null}
           </div>

--- a/src/pages/settings/invoice-design/pages/custom-designs/CustomDesign.tsx
+++ b/src/pages/settings/invoice-design/pages/custom-designs/CustomDesign.tsx
@@ -119,10 +119,10 @@ export default function CustomDesign() {
       <PanelGroup>
         <Panel>
           <div className="space-y-4 h-full max-h-[80vh] overflow-y-auto">
-            {errors?.errors.syntax ? (
+            {errors?.errors['design.design.body'] ? (
               <Alert type="danger">
                 <p>{errors.message}</p>
-                <small>{errors.errors.syntax}</small>
+                <small>{errors.errors['design.design.body']}</small>
               </Alert>
             ) : null}
 

--- a/src/pages/settings/invoice-design/pages/custom-designs/pages/edit/components/Body.tsx
+++ b/src/pages/settings/invoice-design/pages/custom-designs/pages/edit/components/Body.tsx
@@ -35,7 +35,8 @@ export default function Body() {
     <Card title={t('body')} padding="small" height="full">
       <Editor
         theme={colors.name === 'invoiceninja.dark' ? 'vs-dark' : 'light'}
-        defaultLanguage="html"
+        defaultLanguage="twig"
+        language="twig"
         value={payload.design?.design.body}
         options={{
           minimap: {

--- a/src/pages/settings/invoice-design/pages/custom-designs/pages/edit/components/Footer.tsx
+++ b/src/pages/settings/invoice-design/pages/custom-designs/pages/edit/components/Footer.tsx
@@ -45,7 +45,8 @@ export default function Footer() {
     <Card title={t('footer')} padding="small" height="full">
       <Editor
         theme={colors.name === 'invoiceninja.dark' ? 'vs-dark' : 'light'}
-        defaultLanguage="html"
+        defaultLanguage="twig"
+        language="twig"
         value={payload.design?.design.footer}
         options={{
           minimap: {

--- a/src/pages/settings/invoice-design/pages/custom-designs/pages/edit/components/Headers.tsx
+++ b/src/pages/settings/invoice-design/pages/custom-designs/pages/edit/components/Headers.tsx
@@ -35,7 +35,8 @@ export default function Header() {
     <Card title={t('header')} padding="small" height="full">
       <Editor
         theme={colors.name === 'invoiceninja.dark' ? 'vs-dark' : 'light'}
-        defaultLanguage="html"
+        defaultLanguage="twig"
+        language="twig"
         value={payload.design?.design.header}
         options={{
           minimap: {

--- a/src/pages/settings/invoice-design/pages/custom-designs/pages/edit/components/Includes.tsx
+++ b/src/pages/settings/invoice-design/pages/custom-designs/pages/edit/components/Includes.tsx
@@ -44,7 +44,8 @@ export default function Includes() {
   return (
     <Card title={t('includes')} padding="small" height="full">
       <Editor
-        defaultLanguage="html"
+        defaultLanguage="twig"
+        language="twig"
         value={payload.design?.design.includes}
         theme={colors.name === 'invoiceninja.dark' ? 'vs-dark' : 'light'}
         options={{


### PR DESCRIPTION
This improves syntax highlighting for custom design components that render Twig tags and shows the validation errors for syntax issues.