### PR TITLE
[Cleanup] Implementing 'Group' Column and Adjusting Show Page | Clients

### DIFF
--- a/src/pages/clients/common/hooks/useClientColumns.tsx
+++ b/src/pages/clients/common/hooks/useClientColumns.tsx
@@ -412,7 +412,7 @@ export function useClientColumns() {
       id: 'group_settings_id',
       label: t('group'),
       format: (value, client) =>
-        Boolean(client.group_settings_id) && (
+        Boolean(value) && (
           <Link
             to={route('/settings/group_settings/:id/edit', {
               id: value,

--- a/src/pages/clients/common/hooks/useClientColumns.tsx
+++ b/src/pages/clients/common/hooks/useClientColumns.tsx
@@ -77,7 +77,7 @@ export function useAllClientColumns() {
     fourthCustom,
     'documents',
     'entity_state',
-    //   'group',
+    'group',
     'id_number',
     'is_deleted',
     'language',
@@ -406,6 +406,21 @@ export function useClientColumns() {
           </Inline>
         </Link>
       ),
+    },
+    {
+      column: 'group',
+      id: 'group_settings_id',
+      label: t('group'),
+      format: (value, client) =>
+        Boolean(client.group_settings_id) && (
+          <Link
+            to={route('/settings/group_settings/:id/edit', {
+              id: value,
+            })}
+          >
+            {client.group_settings?.name}
+          </Link>
+        ),
     },
   ];
 

--- a/src/pages/clients/index/Clients.tsx
+++ b/src/pages/clients/index/Clients.tsx
@@ -60,7 +60,7 @@ export default function Clients() {
     >
       <DataTable
         resource="client"
-        endpoint="/api/v1/clients?sort=id|desc"
+        endpoint="/api/v1/clients?include=group_settings&sort=id|desc"
         bulkRoute="/api/v1/clients/bulk"
         columns={columns}
         linkToCreate="/clients/create"

--- a/src/pages/clients/show/components/Details.tsx
+++ b/src/pages/clients/show/components/Details.tsx
@@ -17,6 +17,7 @@ import { InfoCard } from '$app/components/InfoCard';
 import { EntityStatus } from '$app/components/EntityStatus';
 import { useTranslation } from 'react-i18next';
 import { useGetSetting } from '$app/common/hooks/useGetSetting';
+import { route } from '$app/common/helpers/route';
 
 interface Props {
   client: Client;
@@ -43,6 +44,18 @@ export function Details(props: Props) {
                 <Element leftSide={t('status')} noExternalPadding>
                   <EntityStatus entity={client} />
                 </Element>
+
+                {client.group_settings_id && (
+                  <Element leftSide={t('group')} noExternalPadding>
+                    <Link
+                      to={route('/settings/group_settings/:id/edit', {
+                        id: client.group_settings_id,
+                      })}
+                    >
+                      {client.group_settings?.name}
+                    </Link>
+                  </Element>
+                )}
 
                 <Link to={client.website} external>
                   {client.website}

--- a/src/pages/settings/account-management/component/Plan.tsx
+++ b/src/pages/settings/account-management/component/Plan.tsx
@@ -16,6 +16,7 @@ import { useTranslation } from 'react-i18next';
 import { License } from '.';
 import { Card, Element } from '../../../../components/cards';
 import { Link } from '../../../../components/forms';
+import dayjs from 'dayjs';
 
 export function Plan() {
   const [t] = useTranslation();
@@ -44,7 +45,9 @@ export function Plan() {
 
       {account?.plan_expires !== '' && (
         <Element leftSide={t('expires_on')}>
-          {date(account?.plan_expires, dateFormat)}
+          {dayjs(account.plan_expires).year() > 2000
+            ? date(account.plan_expires, dateFormat)
+            : t('forever_free')}
         </Element>
       )}
 

--- a/src/pages/settings/account-management/component/Plan.tsx
+++ b/src/pages/settings/account-management/component/Plan.tsx
@@ -44,7 +44,7 @@ export function Plan() {
 
       {account?.plan_expires !== '' && (
         <Element leftSide={t('expires_on')}>
-          {date(account.plan_expires, dateFormat)}
+          {date(account?.plan_expires, dateFormat)}
         </Element>
       )}
 

--- a/src/pages/settings/account-management/component/Plan.tsx
+++ b/src/pages/settings/account-management/component/Plan.tsx
@@ -16,7 +16,6 @@ import { useTranslation } from 'react-i18next';
 import { License } from '.';
 import { Card, Element } from '../../../../components/cards';
 import { Link } from '../../../../components/forms';
-import dayjs from 'dayjs';
 
 export function Plan() {
   const [t] = useTranslation();
@@ -45,9 +44,7 @@ export function Plan() {
 
       {account?.plan_expires !== '' && (
         <Element leftSide={t('expires_on')}>
-          {dayjs(account.plan_expires).year() > 2000
-            ? date(account.plan_expires, dateFormat)
-            : t('forever_free')}
+          {date(account.plan_expires, dateFormat)}
         </Element>
       )}
 

--- a/src/pages/settings/group-settings/edit/components/Clients.tsx
+++ b/src/pages/settings/group-settings/edit/components/Clients.tsx
@@ -26,9 +26,12 @@ export function Clients() {
     <div className="mt-8">
       <DataTable
         resource="client"
-        endpoint={route('/api/v1/clients?group=:groupId&sort=id|desc', {
-          groupId: id,
-        })}
+        endpoint={route(
+          '/api/v1/clients?include=group_settings&group=:groupId&sort=id|desc',
+          {
+            groupId: id,
+          }
+        )}
         bulkRoute="/api/v1/clients/bulk"
         linkToEdit="/clients/:id/edit"
         columns={columns}


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of the 'Group' column for clients and displaying the assigned group on the show page. Screenshots:

![Screenshot 2024-06-11 at 03 53 35](https://github.com/invoiceninja/ui/assets/51542191/91903c2c-c770-47e1-8506-da72e04a9c0a)

![Screenshot 2024-06-11 at 03 50 29](https://github.com/invoiceninja/ui/assets/51542191/1547e8ef-6768-423e-9a36-e11e79b96d8b)

Let me know your thoughts.