### PR TITLE
[Cleanup] Adjusting "Expires On" Label | Account Management

### DIFF
--- a/src/pages/settings/account-management/component/Plan.tsx
+++ b/src/pages/settings/account-management/component/Plan.tsx
@@ -16,6 +16,7 @@ import { useTranslation } from 'react-i18next';
 import { License } from '.';
 import { Card, Element } from '../../../../components/cards';
 import { Link } from '../../../../components/forms';
+import dayjs from 'dayjs';
 
 export function Plan() {
   const [t] = useTranslation();
@@ -44,7 +45,9 @@ export function Plan() {
 
       {account?.plan_expires !== '' && (
         <Element leftSide={t('expires_on')}>
-          {date(account?.plan_expires, dateFormat)}
+          {dayjs(account.plan_expires).year() > 2000
+            ? date(account.plan_expires, dateFormat)
+            : t('forever_free')}
         </Element>
       )}
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adjustments for the "Expires On" label under "Account Management". If the year of the `plan_expires` property is before `2000`, we will display the translated text from the "forever_free" keyword. Otherwise, the date when the plan expires will be displayed. Screenshot:

<img width="820" alt="Screenshot 2024-06-11 at 11 40 09" src="https://github.com/invoiceninja/ui/assets/51542191/8ecde3c0-6f7d-49ea-9ac6-81704443d683">

`Note`: We are missing the "forever_free" translation keyword from the files. If you agree, please add it there.

Let me know your thoughts.