### PR TITLE
[Bugfix] "Cancel" Action Order

### DIFF
--- a/src/pages/invoices/edit/components/Actions.tsx
+++ b/src/pages/invoices/edit/components/Actions.tsx
@@ -444,9 +444,7 @@ export function useActions(params?: Params) {
       (invoice.status_id === InvoiceStatus.Sent ||
         invoice.status_id === InvoiceStatus.Partial) && (
         <EntityActionElement
-          {...(!dropdown && {
-            key: 'cancel_invoice',
-          })}
+          key="cancel_invoice"
           entity="invoice"
           actionKey="cancel_invoice"
           isCommonActionSection={!dropdown}


### PR DESCRIPTION
@beganovich @turbo124 I've accidentally adjusted one prop that should not be conditionally added, which caused a bug with the placement of the `cancel` action in the dropdown on the table. I've just fixed it. Screenshot of the bug:

<img width="267" alt="Screenshot 2024-06-12 at 10 35 13" src="https://github.com/invoiceninja/ui/assets/51542191/c662b5eb-0452-4b14-9a0f-558a4f088232">

Let me know your thoughts.