### PR TITLE
[Bugfix] Disabling "Portal Mode" | Client Portal

### DIFF
--- a/src/pages/settings/client-portal/components/Settings.tsx
+++ b/src/pages/settings/client-portal/components/Settings.tsx
@@ -22,12 +22,13 @@ import { companySettingsErrorsAtom } from '../../common/atoms';
 import { request } from '$app/common/helpers/request';
 import { useState } from 'react';
 import { useInjectCompanyChanges } from '$app/common/hooks/useInjectCompanyChanges';
-import { freePlan } from '$app/common/guards/guards/free-plan';
 import { useCurrentSettingsLevel } from '$app/common/hooks/useCurrentSettingsLevel';
 import classNames from 'classnames';
 import { PropertyCheckbox } from '$app/components/PropertyCheckbox';
 import { useDisableSettingsField } from '$app/common/hooks/useDisableSettingsField';
 import { SettingsLabel } from '$app/components/SettingsLabel';
+import { enterprisePlan } from '$app/common/guards/guards/enterprise-plan';
+import { freePlan } from '$app/common/guards/guards/free-plan';
 
 export function Settings() {
   const [t] = useTranslation();
@@ -68,20 +69,28 @@ export function Settings() {
             leftSide={t('portal_mode')}
             leftSideHelp={t('subdomain_guide')}
           >
-            <SelectField
-              disabled={freePlan()}
-              id="portal_mode"
-              value={company?.portal_mode || 'subdomain'}
-              onValueChange={(value) => handleChange('portal_mode', value)}
-              errorMessage={errors?.errors.portal_mode}
-            >
-              <option value="subdomain" key="subdomain">
-                {t('subdomain')}
-              </option>
-              <option value="domain" key="domain">
-                {t('domain')}
-              </option>
-            </SelectField>
+            <div className="flex flex-col space-y-2">
+              <SelectField
+                disabled={!enterprisePlan()}
+                id="portal_mode"
+                value={company?.portal_mode || 'subdomain'}
+                onValueChange={(value) => handleChange('portal_mode', value)}
+                errorMessage={errors?.errors.portal_mode}
+              >
+                <option value="subdomain" key="subdomain">
+                  {t('subdomain')}
+                </option>
+                <option value="domain" key="domain">
+                  {t('domain')}
+                </option>
+              </SelectField>
+
+              {!enterprisePlan() && (
+                <span className="text-xs font-medium">
+                  * {t('requires_an_enterprise_plan')}
+                </span>
+              )}
+            </div>
           </Element>
 
           {company?.portal_mode === 'subdomain' && (


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes on the client portal page for the "Portal Mode" field. The field will only be allowed to enter a value for enterprise-hosted users for everyone else the field will be disabled. In addition, we've added text indicating that the user needs to upgrade their plan. Screenshot:

<img width="998" alt="Screenshot 2024-06-13 at 10 37 15" src="https://github.com/invoiceninja/ui/assets/51542191/b6310c99-7266-4eba-848a-68dfe3a58983">

Let me know your thoughts.