### PR TITLE
[Bugfix] Adding Missing Fields "Replay to Email/Name" | Smtp Configuration

### DIFF
--- a/src/pages/settings/email-settings/EmailSettings.tsx
+++ b/src/pages/settings/email-settings/EmailSettings.tsx
@@ -559,45 +559,41 @@ export function EmailSettings() {
           />
         </Element>
 
-        {company?.settings.email_sending_method !== 'smtp' && (
-          <Element
-            leftSide={
-              <PropertyCheckbox
-                propertyKey="reply_to_name"
-                labelElement={<SettingsLabel label={t('reply_to_name')} />}
-              />
-            }
-          >
-            <InputField
-              value={company?.settings.reply_to_name || ''}
-              onValueChange={(value) =>
-                handleChange('settings.reply_to_name', value)
-              }
-              disabled={disableSettingsField('reply_to_name')}
-              errorMessage={errors?.errors['settings.reply_to_name']}
+        <Element
+          leftSide={
+            <PropertyCheckbox
+              propertyKey="reply_to_name"
+              labelElement={<SettingsLabel label={t('reply_to_name')} />}
             />
-          </Element>
-        )}
+          }
+        >
+          <InputField
+            value={company?.settings.reply_to_name || ''}
+            onValueChange={(value) =>
+              handleChange('settings.reply_to_name', value)
+            }
+            disabled={disableSettingsField('reply_to_name')}
+            errorMessage={errors?.errors['settings.reply_to_name']}
+          />
+        </Element>
 
-        {company?.settings.email_sending_method !== 'smtp' && (
-          <Element
-            leftSide={
-              <PropertyCheckbox
-                propertyKey="reply_to_email"
-                labelElement={<SettingsLabel label={t('reply_to_email')} />}
-              />
-            }
-          >
-            <InputField
-              value={company?.settings.reply_to_email || ''}
-              onValueChange={(value) =>
-                handleChange('settings.reply_to_email', value)
-              }
-              disabled={disableSettingsField('reply_to_email')}
-              errorMessage={errors?.errors['settings.reply_to_email']}
+        <Element
+          leftSide={
+            <PropertyCheckbox
+              propertyKey="reply_to_email"
+              labelElement={<SettingsLabel label={t('reply_to_email')} />}
             />
-          </Element>
-        )}
+          }
+        >
+          <InputField
+            value={company?.settings.reply_to_email || ''}
+            onValueChange={(value) =>
+              handleChange('settings.reply_to_email', value)
+            }
+            disabled={disableSettingsField('reply_to_email')}
+            errorMessage={errors?.errors['settings.reply_to_email']}
+          />
+        </Element>
 
         {company?.settings.email_sending_method !== 'smtp' && (
           <Element


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for displaying the two missing fields for SMTP configuration, "Reply to Email" and "Reply to Name." Screenshot:

![Screenshot 2024-06-13 at 15 39 27](https://github.com/invoiceninja/ui/assets/51542191/90f9465e-2953-4efa-a787-16bdb59d8d5b)

Let me know your thoughts.