### PR TITLE
[Bugfix] Adjusting Dark Mode For Some Selectors

### DIFF
--- a/src/pages/reports/common/components/ProductItemsSelector.tsx
+++ b/src/pages/reports/common/components/ProductItemsSelector.tsx
@@ -13,7 +13,7 @@ import { Element } from '$app/components/cards';
 import { SelectOption } from '$app/components/datatables/Actions';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import Select, { MultiValue, StylesConfig } from 'react-select';
+import Select, { MultiValue } from 'react-select';
 import { useColorScheme } from '$app/common/colors';
 import { Alert } from '$app/components/Alert';
 import { request } from '$app/common/helpers/request';
@@ -21,6 +21,7 @@ import { endpoint } from '$app/common/helpers';
 import { Product } from '$app/common/interfaces/product';
 import { useQuery, useQueryClient } from 'react-query';
 import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-api-response';
+import { useSelectorCustomStyles } from '../hooks/useSelectorCustomStyles';
 
 interface Props {
   value?: string;
@@ -31,6 +32,8 @@ export function ProductItemsSelector(props: Props) {
   const [t] = useTranslation();
   const colors = useColorScheme();
   const queryClient = useQueryClient();
+
+  const customStyles = useSelectorCustomStyles();
 
   const { value, onValueChange, errorMessage } = props;
 
@@ -131,49 +134,6 @@ export function ProductItemsSelector(props: Props) {
     return (products as SelectOption[])
       .map((option: { value: string; label: string }) => option.value)
       .join(',');
-  };
-
-  const customStyles: StylesConfig<SelectOption, true> = {
-    multiValue: (styles, { data }) => {
-      return {
-        ...styles,
-        backgroundColor: data.backgroundColor,
-        color: data.color,
-        borderRadius: '3px',
-      };
-    },
-    multiValueLabel: (styles, { data }) => ({
-      ...styles,
-      color: data.color,
-    }),
-    multiValueRemove: (styles) => ({
-      ...styles,
-      ':hover': {
-        color: 'white',
-      },
-      color: '#999999',
-    }),
-    menu: (base) => ({
-      ...base,
-      width: 'max-content',
-      minWidth: '100%',
-      backgroundColor: colors.$4,
-      borderColor: colors.$4,
-    }),
-    control: (base) => ({
-      ...base,
-      borderRadius: '3px',
-      backgroundColor: colors.$1,
-      color: colors.$3,
-      borderColor: colors.$5,
-    }),
-    option: (base) => ({
-      ...base,
-      backgroundColor: colors.$1,
-      ':hover': {
-        backgroundColor: colors.$7,
-      },
-    }),
   };
 
   return (

--- a/src/pages/reports/common/components/StatusSelector.tsx
+++ b/src/pages/reports/common/components/StatusSelector.tsx
@@ -13,7 +13,7 @@ import { SelectOption } from '$app/components/datatables/Actions';
 import { useInvoiceFilters } from '$app/pages/invoices/common/hooks/useInvoiceFilters';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import Select, { MultiValue, StylesConfig } from 'react-select';
+import Select, { MultiValue } from 'react-select';
 import { Identifier } from '../useReports';
 import { useCreditsFilters } from '$app/pages/credits/common/hooks/useCreditsFilters';
 import { useExpenseFilters } from '$app/pages/expenses/common/hooks';
@@ -22,6 +22,7 @@ import { useQuoteFilters } from '$app/pages/quotes/common/hooks';
 import { useRecurringInvoiceFilters } from '$app/pages/recurring-invoices/common/hooks';
 import { usePaymentFilters } from '$app/pages/payments/common/hooks/usePaymentFilters';
 import { useTaskFilters } from '$app/pages/tasks/common/hooks';
+import { useSelectorCustomStyles } from '../hooks/useSelectorCustomStyles';
 
 interface Props {
   report: Identifier;
@@ -32,6 +33,10 @@ interface Props {
 export function StatusSelector(props: Props) {
   const [t] = useTranslation();
 
+  const { value, onValueChange, errorMessage, report } = props;
+
+  const customStyles = useSelectorCustomStyles();
+
   const taskFilters = useTaskFilters();
   const quoteFilters = useQuoteFilters();
   const creditFilters = useCreditsFilters();
@@ -41,31 +46,7 @@ export function StatusSelector(props: Props) {
   const purchaseOrderFilters = usePurchaseOrderFilters();
   const recurringInvoiceFilters = useRecurringInvoiceFilters();
 
-  const { value, onValueChange, errorMessage, report } = props;
-
   const [options, setOptions] = useState<SelectOption[]>([]);
-
-  const customStyles: StylesConfig<SelectOption, true> = {
-    multiValue: (styles, { data }) => {
-      return {
-        ...styles,
-        backgroundColor: data.backgroundColor,
-        color: data.color,
-        borderRadius: '3px',
-      };
-    },
-    multiValueLabel: (styles, { data }) => ({
-      ...styles,
-      color: data.color,
-    }),
-    multiValueRemove: (styles) => ({
-      ...styles,
-      ':hover': {
-        color: 'white',
-      },
-      color: '#999999',
-    }),
-  };
 
   const handleStatusChange = (
     statuses: MultiValue<{ value: string; label: string }>

--- a/src/pages/settings/gateways/common/components/GatewaysTable.tsx
+++ b/src/pages/settings/gateways/common/components/GatewaysTable.tsx
@@ -42,11 +42,11 @@ import { useGatewayUtilities } from '../hooks/useGatewayUtilities';
 import { useHandleCompanySave } from '$app/pages/settings/common/hooks/useHandleCompanySave';
 import { useCompanyChanges } from '$app/common/hooks/useCompanyChanges';
 import { SelectOption } from '$app/components/datatables/Actions';
-import Select, { StylesConfig } from 'react-select';
-import { useColorScheme } from '$app/common/colors';
+import Select from 'react-select';
 import { Settings } from '$app/common/interfaces/company.interface';
 import { useHandleCurrentCompanyChangeProperty } from '$app/pages/settings/common/hooks/useHandleCurrentCompanyChange';
 import { useCurrentSettingsLevel } from '$app/common/hooks/useCurrentSettingsLevel';
+import { useSelectorCustomStyles } from '$app/pages/reports/common/hooks/useSelectorCustomStyles';
 
 interface Params {
   includeRemoveAction: boolean;
@@ -55,7 +55,7 @@ interface Params {
 export function GatewaysTable(params: Params) {
   const [t] = useTranslation();
 
-  const colors = useColorScheme();
+  const customStyles = useSelectorCustomStyles();
 
   const { isCompanySettingsActive } = useCurrentSettingsLevel();
 
@@ -163,49 +163,6 @@ export function GatewaysTable(params: Params) {
       backgroundColor: '#c95f53',
     },
   ];
-
-  const customStyles: StylesConfig<SelectOption, true> = {
-    multiValue: (styles, { data }) => {
-      return {
-        ...styles,
-        backgroundColor: data.backgroundColor,
-        color: data.color,
-        borderRadius: '3px',
-      };
-    },
-    multiValueLabel: (styles, { data }) => ({
-      ...styles,
-      color: data.color,
-    }),
-    multiValueRemove: (styles) => ({
-      ...styles,
-      ':hover': {
-        color: 'white',
-      },
-      color: '#999999',
-    }),
-    menu: (base) => ({
-      ...base,
-      width: 'max-content',
-      minWidth: '100%',
-      backgroundColor: colors.$4,
-      borderColor: colors.$4,
-    }),
-    control: (base) => ({
-      ...base,
-      borderRadius: '3px',
-      backgroundColor: colors.$1,
-      color: colors.$3,
-      borderColor: colors.$5,
-    }),
-    option: (base) => ({
-      ...base,
-      backgroundColor: colors.$1,
-      ':hover': {
-        backgroundColor: colors.$7,
-      },
-    }),
-  };
 
   useEffect(() => {
     if (updateCompany) {


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for dark mode on the status selectors on the Reports page, along with setting same styles for some selectors where we did not have it. Screenshot:

<img width="522" alt="Screenshot 2024-06-14 at 13 45 37" src="https://github.com/invoiceninja/ui/assets/51542191/6083e69e-f95e-4fdd-9cea-250521472c8b">

Let me know your thoughts.