### PR TITLE
[Bugfix] Enabling "Health Check" Endpoint Only On Self-Hosted

### DIFF
--- a/src/components/AboutModal.tsx
+++ b/src/components/AboutModal.tsx
@@ -115,6 +115,7 @@ export function AboutModal(props: Props) {
         (response) => response.data
       ),
     staleTime: Infinity,
+    enabled: isSelfHosted(),
   });
 
   const handleHealthCheck = (allowAction?: boolean) => {


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes to enable the `/health_check` route only for self-hosted platforms. Let me know your thoughts.