### PR TITLE
[Cleanup] Implementing Tooltip For Copy Portal URL Icon

### DIFF
--- a/src/pages/invoices/common/components/ClientSelector.tsx
+++ b/src/pages/invoices/common/components/ClientSelector.tsx
@@ -124,7 +124,7 @@ export function ClientSelector(props: Props) {
                     <Tooltip
                       width="auto"
                       placement="bottom"
-                      message={t('copy_portal_url') as string}
+                      message={t('copy_link') as string}
                       withoutArrow
                     >
                       <CopyToClipboardIconOnly

--- a/src/pages/invoices/common/components/ClientSelector.tsx
+++ b/src/pages/invoices/common/components/ClientSelector.tsx
@@ -20,6 +20,7 @@ import { CopyToClipboardIconOnly } from '$app/components/CopyToClipBoardIconOnly
 import { useColorScheme } from '$app/common/colors';
 import { UserUnsubscribedTooltip } from '$app/pages/clients/common/components/UserUnsubscribedTooltip';
 import { ClientActionButtons } from './ClientActionButtons';
+import { Tooltip } from '$app/components/Tooltip';
 
 interface Props {
   readonly?: boolean;
@@ -104,7 +105,7 @@ export function ClientSelector(props: Props) {
                 }
               />
 
-              <div>
+              <div className="relative">
                 {contact.first_name && (
                   <p className="text-sm" style={{ color: colors.$3 }}>
                     {contact.email}
@@ -112,17 +113,25 @@ export function ClientSelector(props: Props) {
                 )}
 
                 {resource.invitations.length >= 1 && (
-                  <>
+                  <div className="flex space-x-2 mt-1">
                     <Link
                       to={`${resource.invitations[0].link}?silent=true&client_hash=${client.client_hash}`}
                       external
                     >
                       {t('view_in_portal')}
                     </Link>
-                    <CopyToClipboardIconOnly
-                      text={resource.invitations[0].link}
-                    />
-                  </>
+
+                    <Tooltip
+                      width="auto"
+                      placement="bottom"
+                      message={t('copy_portal_url') as string}
+                      withoutArrow
+                    >
+                      <CopyToClipboardIconOnly
+                        text={resource.invitations[0].link}
+                      />
+                    </Tooltip>
+                  </div>
                 )}
               </div>
             </div>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of a tooltip for the copy portal URL icon. Screenshot:

<img width="351" alt="Screenshot 2024-06-14 at 20 25 52" src="https://github.com/invoiceninja/ui/assets/51542191/8e551063-a406-4e12-bbc7-b5a48f72e59f">

`Note`: I've used the "copy_portal_url" translation keyword for the message in the tooltip. The translation keyword should give us the message like "Copy Portal URL." If you agree, please add this keyword to the translation files.

Let me know your thoughts.