### PR TITLE
Disable TinyMCE auto link convert

### DIFF
--- a/src/components/forms/MarkdownEditor.tsx
+++ b/src/components/forms/MarkdownEditor.tsx
@@ -93,6 +93,7 @@ export function MarkdownEditor(props: Props) {
           paste_data_images: false,
           newline_behavior: 'invert',
           browser_spellcheck: true,
+          convert_urls: false,
         }}
         onEditorChange={handleChange}
         disabled={props.disabled}


### PR DESCRIPTION
This fixes an issue with relative URLs for the current window href.