### PR TITLE
[Cleanup] Removing "All" Filter | Custom Filters

### DIFF
--- a/src/common/hooks/useDataTablePreferences.ts
+++ b/src/common/hooks/useDataTablePreferences.ts
@@ -91,7 +91,7 @@ export function useDataTablePreferences(params: Params) {
       user?.company_user?.react_settings.table_filters?.[tableKey];
 
     const defaultFilters = {
-      ...(customFilters && { customFilter: ['all'] }),
+      ...(customFilters && { customFilter: [] }),
       sort: apiEndpoint.searchParams.get('sort') || 'id|asc',
       status: ['active'],
       perPage: '10',
@@ -135,7 +135,7 @@ export function useDataTablePreferences(params: Params) {
         if ((getPreference('customFilter') as string[]).length) {
           setCustomFilter(getPreference('customFilter') as string[]);
         } else {
-          setCustomFilter(['all']);
+          setCustomFilter([]);
         }
       } else {
         setCustomFilter([]);

--- a/src/common/hooks/useDataTableUtilities.ts
+++ b/src/common/hooks/useDataTableUtilities.ts
@@ -57,7 +57,7 @@ export function useDataTableUtilities(params: Params) {
 
       const currentStatuses = preferenceCustomFilters?.length
         ? preferenceCustomFilters
-        : ['all'];
+        : [];
 
       return (
         customFilters.filter(({ value }) =>

--- a/src/pages/clients/show/hooks/useDocumentFilters.ts
+++ b/src/pages/clients/show/hooks/useDocumentFilters.ts
@@ -16,13 +16,6 @@ export function useDocumentFilters() {
 
   const filters: SelectOption[] = [
     {
-      label: t('all'),
-      value: 'all',
-      color: 'black',
-      backgroundColor: '#e4e4e4',
-      queryKey: 'type',
-    },
-    {
       label: t('public'),
       value: 'public',
       color: 'white',

--- a/src/pages/credits/common/hooks/useCreditsFilters.ts
+++ b/src/pages/credits/common/hooks/useCreditsFilters.ts
@@ -19,12 +19,6 @@ export function useCreditsFilters() {
 
   const filters: SelectOption[] = [
     {
-      label: t('all'),
-      value: 'all',
-      color: 'black',
-      backgroundColor: '#e4e4e4',
-    },
-    {
       label: t('draft'),
       value: 'draft',
       color: 'white',

--- a/src/pages/expenses/common/hooks.tsx
+++ b/src/pages/expenses/common/hooks.tsx
@@ -571,12 +571,6 @@ export function useExpenseFilters() {
 
   const filters: SelectOption[] = [
     {
-      label: t('all'),
-      value: 'all',
-      color: 'black',
-      backgroundColor: '#e4e4e4',
-    },
-    {
       label: t('logged'),
       value: 'logged',
       color: 'white',

--- a/src/pages/invoices/common/hooks/useInvoiceFilters.ts
+++ b/src/pages/invoices/common/hooks/useInvoiceFilters.ts
@@ -19,12 +19,6 @@ export function useInvoiceFilters() {
 
   const filters: SelectOption[] = [
     {
-      label: t('all'),
-      value: 'all',
-      color: 'black',
-      backgroundColor: '#e4e4e4',
-    },
-    {
       label: t('draft'),
       value: 'draft',
       color: 'white',

--- a/src/pages/payments/common/hooks/usePaymentFilters.tsx
+++ b/src/pages/payments/common/hooks/usePaymentFilters.tsx
@@ -19,12 +19,6 @@ export function usePaymentFilters() {
 
   const filters: SelectOption[] = [
     {
-      label: t('all'),
-      value: 'all',
-      color: 'black',
-      backgroundColor: '#e4e4e4',
-    },
-    {
       label: t('pending'),
       value: 'pending',
       color: 'white',

--- a/src/pages/purchase-orders/common/hooks.tsx
+++ b/src/pages/purchase-orders/common/hooks.tsx
@@ -393,12 +393,6 @@ export function usePurchaseOrderFilters() {
 
   const filters: SelectOption[] = [
     {
-      label: t('all'),
-      value: 'all',
-      color: 'black',
-      backgroundColor: '#e4e4e4',
-    },
-    {
       label: t('draft'),
       value: 'draft',
       color: 'white',

--- a/src/pages/quotes/common/hooks.tsx
+++ b/src/pages/quotes/common/hooks.tsx
@@ -968,12 +968,6 @@ export function useQuoteFilters() {
 
   const filters: SelectOption[] = [
     {
-      label: t('all'),
-      value: 'all',
-      color: 'black',
-      backgroundColor: '#e4e4e4',
-    },
-    {
       label: t('draft'),
       value: 'draft',
       color: 'white',

--- a/src/pages/recurring-invoices/common/hooks.tsx
+++ b/src/pages/recurring-invoices/common/hooks.tsx
@@ -771,12 +771,6 @@ export function useRecurringInvoiceFilters() {
 
   const filters: SelectOption[] = [
     {
-      label: t('all'),
-      value: 'all',
-      color: 'black',
-      backgroundColor: '#e4e4e4',
-    },
-    {
       label: t('active'),
       value: 'active',
       color: 'white',

--- a/src/pages/tasks/common/hooks.tsx
+++ b/src/pages/tasks/common/hooks.tsx
@@ -404,12 +404,6 @@ export function useTaskFilters() {
 
   const filters: SelectOption[] = [
     {
-      label: t('all'),
-      value: 'all',
-      color: 'black',
-      backgroundColor: '#e4e4e4',
-    },
-    {
       label: t('invoiced'),
       value: 'invoiced',
       color: 'white',

--- a/src/pages/transactions/common/hooks/useTransactionFilters.tsx
+++ b/src/pages/transactions/common/hooks/useTransactionFilters.tsx
@@ -19,12 +19,6 @@ export function useTransactionFilters() {
 
   const filters: SelectOption[] = [
     {
-      label: t('all'),
-      value: 'all',
-      color: 'black',
-      backgroundColor: '#e4e4e4',
-    },
-    {
       label: t('unmatched'),
       value: 'unmatched',
       color: 'white',


### PR DESCRIPTION
@beganovich @turbo124 The PR includes removing the 'All' filter from the selectors of the custom filters. So, from now on, to show all data in tables, the selector will be empty and nothing will be selected. Screenshot:

![Screenshot 2024-06-17 at 20 57 18](https://github.com/invoiceninja/ui/assets/51542191/ab0e96ad-3ef7-47cc-ad41-240e587d7d40)

Let me know your thoughts.