### PR TITLE
[Bugfix] Formatting Dates

### DIFF
--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -61,6 +61,12 @@ export function date(date: number | string, format: string) {
     return dayjs.unix(date).format(format);
   }
 
+  const formats = ['DD-MM-YYYY', 'D.MM.YYYY', 'DD/MM/YYYY'];
+
+  if (formats.includes(format)) {
+    return dayjs(date, format).format(format);
+  }
+
   return dayjs(date).format(format);
 }
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for formatting dates in the app for three formats that should be treated differently from others in the `dayjs` function for formatting. The `'DD-MM-YYYY'`, `'D.MM.YYYY'`, and `'DD/MM/YYYY'` formats had an issue, others worked well. Let me know your thoughts.