### PR TITLE
[Cleanup] Implementing "Changes Status" And "View Invoice" Tooltips

### DIFF
--- a/src/pages/tasks/common/components/TaskStatus.tsx
+++ b/src/pages/tasks/common/components/TaskStatus.tsx
@@ -22,6 +22,7 @@ import { useRef, useState } from 'react';
 import { useClickAway } from 'react-use';
 import { TaskStatusesDropdown } from './TaskStatusesDropdown';
 import { useStatusThemeColorScheme } from '$app/pages/settings/user/components/StatusColorTheme';
+import { Tooltip } from '$app/components/Tooltip';
 
 interface Props {
   entity: Task;
@@ -86,17 +87,24 @@ export function TaskStatus(props: Props) {
 
     return (
       <div ref={ref} onClick={(event) => event.stopPropagation()}>
-        <StatusBadge
-          for={{}}
-          code={status.name}
-          style={{
-            color: adjustColorDarkness(hex, darknessAmount),
-            backgroundColor: status.color,
-          }}
-          onClick={() =>
-            !isFormBusy && setVisibleDropdown((current) => !current)
-          }
-        />
+        <Tooltip
+          width="auto"
+          message={t('change_status') as string}
+          withoutArrow
+          placement="bottom"
+        >
+          <StatusBadge
+            for={{}}
+            code={status.name}
+            style={{
+              color: adjustColorDarkness(hex, darknessAmount),
+              backgroundColor: status.color,
+            }}
+            onClick={() =>
+              !isFormBusy && setVisibleDropdown((current) => !current)
+            }
+          />
+        </Tooltip>
 
         <TaskStatusesDropdown
           visible={visibleDropdown}
@@ -111,11 +119,20 @@ export function TaskStatus(props: Props) {
 
   return (
     <div ref={ref} onClick={(event) => event.stopPropagation()}>
-      <StatusBadge
-        for={{}}
-        code="logged"
-        onClick={() => !isFormBusy && setVisibleDropdown((current) => !current)}
-      />
+      <Tooltip
+        width="auto"
+        message={t('change_status') as string}
+        withoutArrow
+        placement="bottom"
+      >
+        <StatusBadge
+          for={{}}
+          code="logged"
+          onClick={() =>
+            !isFormBusy && setVisibleDropdown((current) => !current)
+          }
+        />
+      </Tooltip>
 
       <TaskStatusesDropdown
         visible={visibleDropdown}

--- a/src/pages/tasks/common/hooks.tsx
+++ b/src/pages/tasks/common/hooks.tsx
@@ -188,14 +188,21 @@ export function useTaskColumns() {
           <TaskStatus entity={task} />
 
           {task.invoice_id && (
-            <MdTextSnippet
-              className="cursor-pointer"
-              fontSize={19}
-              color={accentColor}
-              onClick={() =>
-                navigate(route('/invoices/:id/edit', { id: task.invoice_id }))
-              }
-            />
+            <Tooltip
+              width="auto"
+              message={t('view_invoice') as string}
+              withoutArrow
+              placement="bottom"
+            >
+              <MdTextSnippet
+                className="cursor-pointer"
+                fontSize={19}
+                color={accentColor}
+                onClick={() =>
+                  navigate(route('/invoices/:id/edit', { id: task.invoice_id }))
+                }
+              />
+            </Tooltip>
           )}
         </div>
       ),


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of "Change Status" and "View Invoice" tooltips for the status badge and icon for the tasks. Screenshots:

<img width="427" alt="Screenshot 2024-06-24 at 18 01 09" src="https://github.com/invoiceninja/ui/assets/51542191/1e875d3a-4ea8-4ff8-9b08-f523ab2a403e">

<img width="419" alt="Screenshot 2024-06-24 at 18 01 19" src="https://github.com/invoiceninja/ui/assets/51542191/2adb7e6f-4511-4f25-a05b-a9dce34c234e">

Let me know your thoughts.