### PR TITLE
[Bugfix] "Per Page" Query Parameter | Dashboard Tables

### DIFF
--- a/src/common/hooks/useDataTablePreferences.ts
+++ b/src/common/hooks/useDataTablePreferences.ts
@@ -37,6 +37,7 @@ interface Params {
   setSortedBy: Dispatch<SetStateAction<string | undefined>>;
   setStatus: Dispatch<SetStateAction<string[]>>;
   setPerPage: Dispatch<SetStateAction<PerPage>>;
+  withoutStoringPerPage: boolean;
 }
 
 export function useDataTablePreferences(params: Params) {
@@ -56,6 +57,7 @@ export function useDataTablePreferences(params: Params) {
     setSortedBy,
     setStatus,
     setPerPage,
+    withoutStoringPerPage,
   } = params;
 
   const getPreference = useDataTablePreference({ tableKey });
@@ -94,7 +96,7 @@ export function useDataTablePreferences(params: Params) {
       ...(customFilters && { customFilter: [] }),
       sort: apiEndpoint.searchParams.get('sort') || 'id|asc',
       status: ['active'],
-      perPage: '10',
+      ...(!withoutStoringPerPage && { perPage: '10' }),
     };
 
     const cleanedUpFilters = {
@@ -102,8 +104,12 @@ export function useDataTablePreferences(params: Params) {
       ...(customFilters && { customFilter }),
       sort,
       status,
-      perPage,
+      ...(!withoutStoringPerPage && { perPage }),
     };
+
+    if (currentTableFilters && withoutStoringPerPage) {
+      delete currentTableFilters.perPage;
+    }
 
     storeSessionTableFilters(filter, currentPage);
 
@@ -140,7 +146,8 @@ export function useDataTablePreferences(params: Params) {
       } else {
         setCustomFilter([]);
       }
-      setPerPage((getPreference('perPage') as PerPage) || '10');
+      !withoutStoringPerPage &&
+        setPerPage((getPreference('perPage') as PerPage) || '10');
       setCurrentPage((getPreference('currentPage') as number) || 1);
       setSort((getPreference('sort') as string) || 'id|asc');
       setSortedBy((getPreference('sortedBy') as string) || undefined);

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -149,6 +149,7 @@ interface Props<T> extends CommonProps {
   queryIdentificator?: string;
   disableQuery?: boolean;
   footerColumns?: FooterColumns;
+  withoutPerPageAsPreference?: boolean;
 }
 
 export type ResourceAction<T> = (resource: T) => ReactElement;
@@ -187,6 +188,7 @@ export function DataTable<T extends object>(props: Props<T>) {
     disableQuery,
     footerColumns = [],
     bottomActionsKeys = [],
+    withoutPerPageAsPreference = false,
   } = props;
 
   const companyUpdateTimeOut = useRef<NodeJS.Timeout | undefined>(undefined);
@@ -197,7 +199,7 @@ export function DataTable<T extends object>(props: Props<T>) {
   );
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [perPage, setPerPage] = useState<PerPage>(
-    (apiEndpoint.searchParams.get('perPage') as PerPage) || '10'
+    (apiEndpoint.searchParams.get('per_page') as PerPage) || '10'
   );
   const [sort, setSort] = useState<string>(
     apiEndpoint.searchParams.get('sort') || 'id|asc'
@@ -228,6 +230,7 @@ export function DataTable<T extends object>(props: Props<T>) {
     setStatus,
     tableKey,
     customFilters,
+    withoutStoringPerPage: withoutPerPageAsPreference,
   });
 
   const {

--- a/src/pages/dashboard/components/ExpiredQuotes.tsx
+++ b/src/pages/dashboard/components/ExpiredQuotes.tsx
@@ -86,6 +86,7 @@ export function ExpiredQuotes() {
           withoutActions
           withoutPagination
           withoutPadding
+          withoutPerPageAsPreference
           styleOptions={{
             addRowSeparator: true,
             withoutBottomBorder: true,

--- a/src/pages/dashboard/components/PastDueInvoices.tsx
+++ b/src/pages/dashboard/components/PastDueInvoices.tsx
@@ -92,6 +92,7 @@ export function PastDueInvoices() {
           withoutActions
           withoutPagination
           withoutPadding
+          withoutPerPageAsPreference
           styleOptions={{
             addRowSeparator: true,
             withoutBottomBorder: true,

--- a/src/pages/dashboard/components/RecentPayments.tsx
+++ b/src/pages/dashboard/components/RecentPayments.tsx
@@ -105,6 +105,7 @@ export function RecentPayments() {
           withoutActions
           withoutPagination
           withoutPadding
+          withoutPerPageAsPreference
           styleOptions={{
             addRowSeparator: true,
             withoutBottomBorder: true,

--- a/src/pages/dashboard/components/UpcomingInvoices.tsx
+++ b/src/pages/dashboard/components/UpcomingInvoices.tsx
@@ -95,6 +95,7 @@ export function UpcomingInvoices() {
           withoutActions
           withoutPagination
           withoutPadding
+          withoutPerPageAsPreference
           styleOptions={{
             addRowSeparator: true,
             withoutBottomBorder: true,

--- a/src/pages/dashboard/components/UpcomingQuotes.tsx
+++ b/src/pages/dashboard/components/UpcomingQuotes.tsx
@@ -86,6 +86,7 @@ export function UpcomingQuotes() {
           withoutActions
           withoutPagination
           withoutPadding
+          withoutPerPageAsPreference
           styleOptions={{
             addRowSeparator: true,
             withoutBottomBorder: true,

--- a/src/pages/dashboard/components/UpcomingRecurringInvoices.tsx
+++ b/src/pages/dashboard/components/UpcomingRecurringInvoices.tsx
@@ -92,6 +92,7 @@ export function UpcomingRecurringInvoices() {
           withoutActions
           withoutPagination
           withoutPadding
+          withoutPerPageAsPreference
           styleOptions={{
             addRowSeparator: true,
             withoutBottomBorder: true,


### PR DESCRIPTION
@beganovich @turbo124 The PR includes setting the "per_page" parameter through the endpoint to a fixed value of 50, instead of storing it in the preferences where it was always 10. Let me know your thoughts.