### PR TITLE
[Bugfix] Time Logs Parsing | Format Date Issue

### DIFF
--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -61,12 +61,6 @@ export function date(date: number | string, format: string) {
     return dayjs.unix(date).format(format);
   }
 
-  const formats = ['DD-MM-YYYY', 'D.MM.YYYY', 'DD/MM/YYYY'];
-
-  if (formats.includes(format)) {
-    return dayjs(date, format).format(format);
-  }
-
   return dayjs(date).format(format);
 }
 

--- a/src/pages/tasks/kanban/common/hooks.ts
+++ b/src/pages/tasks/kanban/common/hooks.ts
@@ -9,7 +9,6 @@
  */
 
 import { date } from '$app/common/helpers';
-import { useCurrentCompanyDateFormats } from '$app/common/hooks/useCurrentCompanyDateFormats';
 import { useTaskQuery } from '$app/common/queries/tasks';
 import { useSetAtom } from 'jotai';
 import { parseTimeLog } from '$app/pages/tasks/common/helpers/calculate-time';
@@ -32,7 +31,6 @@ export function useHandleCurrentTask(id: string | undefined) {
 }
 
 export function useFormatTimeLog() {
-  const { dateFormat } = useCurrentCompanyDateFormats();
   const { t } = useTranslation();
 
   return (log: string) => {
@@ -40,7 +38,7 @@ export function useFormatTimeLog() {
 
     parseTimeLog(log).map(([start, end]) => {
       logs.push([
-        date(start, dateFormat),
+        date(start, 'YYYY-MM-DD'),
         new Date(start * 1000).toLocaleTimeString(),
         end === 0 ? t('now') : new Date(end * 1000).toLocaleTimeString(),
       ]);


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for formatting dates in specific formats that Day.js handles differently. We need to always prepare dates in the 'YYYY-MM-DD' format for the Day.js format function. Let me know your thoughts.