### PR TITLE
[Cleanup] Hiding "Copy to Clipboard" Icon When Context Is Not Secure

### DIFF
--- a/src/components/CopyToClipboard.tsx
+++ b/src/components/CopyToClipboard.tsx
@@ -21,11 +21,9 @@ export function CopyToClipboard(props: Props) {
   const value = props.text || '';
 
   const handleClick = () => {
-    if (navigator.clipboard && window.isSecureContext) {
-      navigator.clipboard.writeText(value);
+    navigator.clipboard.writeText(value);
 
-      toast.success('copied_to_clipboard', { value: '' });
-    }
+    toast.success('copied_to_clipboard', { value: '' });
   };
 
   return (

--- a/src/components/CopyToClipboard.tsx
+++ b/src/components/CopyToClipboard.tsx
@@ -21,16 +21,18 @@ export function CopyToClipboard(props: Props) {
   const value = props.text || '';
 
   const handleClick = () => {
-    navigator.clipboard.writeText(value);
+    if (navigator.clipboard && window.isSecureContext) {
+      navigator.clipboard.writeText(value);
 
-    toast.success('copied_to_clipboard', { value: '' });
+      toast.success('copied_to_clipboard', { value: '' });
+    }
   };
 
   return (
     <div className={`inline-flex space-x-2 ${props.className}`}>
       <span>{props.secure ? props.text.split('').map(() => '*') : value}</span>
 
-      {value.length > 0 && (
+      {value.length > 0 && navigator.clipboard && window.isSecureContext && (
         <button type="button" onClick={handleClick}>
           <MdOutlineContentCopy size={18} />
         </button>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for hiding the "Copy to Clipboard" icon when the context is not secure. Let me know your thoughts.