### PR TITLE
[Bugfix] Hours Calculation When Task Running | Amount Money Formatting

### DIFF
--- a/src/pages/projects/common/hooks/useInvoiceProject.tsx
+++ b/src/pages/projects/common/hooks/useInvoiceProject.tsx
@@ -36,12 +36,14 @@ export const calculateTaskHours = (timeLog: string) => {
 
   if (parsedTimeLogs.length) {
     parsedTimeLogs.forEach(([start, stop]) => {
-      const unixStart = dayjs.unix(start);
-      const unixStop = dayjs.unix(stop);
+      if (start && stop) {
+        const unixStart = dayjs.unix(start);
+        const unixStop = dayjs.unix(stop);
 
-      hoursSum += Number(
-        (unixStop.diff(unixStart, 'seconds') / 3600).toFixed(4)
-      );
+        hoursSum += Number(
+          (unixStop.diff(unixStart, 'seconds') / 3600).toFixed(4)
+        );
+      }
     });
   }
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for calculating hours, which need to be multiplied by the task rate to get the final amount of money when a task is running. If the task is running for the first time, the amount will be presented as 0.00. However, if it has run previously, the calculation will be made for all time logs before the last one, which is the currently running time log. Only "fully" populated time logs will be included in the calculation. Screenshot:

![Screenshot 2024-06-25 at 23 25 24](https://github.com/invoiceninja/ui/assets/51542191/ba1ffbf9-f08d-4cf5-8beb-44ef408b9bac)

Let me know your thoughts.