### PR TITLE
[Feature] Implementing Task Assigned Toggle | Notifications | User Details

### DIFF
--- a/src/pages/settings/user/components/Notifications.tsx
+++ b/src/pages/settings/user/components/Notifications.tsx
@@ -149,8 +149,8 @@ export function Notifications() {
 
       <Element
         className="mb-4"
-        leftSide={t('task_assigned')}
-        leftSideHelp={t('task_assigned_help')}
+        leftSide={t('task_assigned_notification')}
+        leftSideHelp={t('task_assigned_notification_help')}
       >
         <Toggle
           checked={Boolean(

--- a/src/pages/settings/user/components/Notifications.tsx
+++ b/src/pages/settings/user/components/Notifications.tsx
@@ -92,6 +92,32 @@ export function Notifications() {
     dispatch(injectInChangesWithData(user));
   };
 
+  const handleTaskAssignedNotificationChange = (value: boolean) => {
+    const emailNotifications = userChanges?.company_user?.notifications?.email;
+
+    let updatedNotifications: string[] = [...emailNotifications];
+
+    if (!value) {
+      updatedNotifications = updatedNotifications.filter(
+        (notificationKey) => notificationKey !== 'task_assigned'
+      );
+    } else {
+      const isAlreadyAdded = updatedNotifications.find(
+        (notificationKey) => notificationKey === 'task_assigned'
+      );
+
+      if (!isAlreadyAdded) {
+        updatedNotifications = [...updatedNotifications, 'task_assigned'];
+      }
+    }
+
+    const user = cloneDeep(userChanges);
+
+    set(user, 'company_user.notifications.email', updatedNotifications);
+
+    dispatch(injectInChangesWithData(user));
+  };
+
   useEffect(() => {
     const emailNotifications = userChanges?.company_user?.notifications?.email;
 
@@ -110,7 +136,6 @@ export function Notifications() {
   return (
     <Card title={t('notifications')}>
       <Element
-        className="mb-4"
         leftSide={t('login_notification')}
         leftSideHelp={t('login_notification_help')}
       >
@@ -119,6 +144,21 @@ export function Notifications() {
           onChange={(value) =>
             handleChange('user_logged_in_notification', value)
           }
+        />
+      </Element>
+
+      <Element
+        className="mb-4"
+        leftSide={t('task_assigned')}
+        leftSideHelp={t('task_assigned_help')}
+      >
+        <Toggle
+          checked={Boolean(
+            userChanges?.company_user?.notifications?.email?.find(
+              (key: string) => key === 'task_assigned'
+            )
+          )}
+          onChange={(value) => handleTaskAssignedNotificationChange(value)}
         />
       </Element>
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of the `task_assigned` toggle on the "Notification" tab for the "User Details" page. If the toggle is turned on, task_assigned will be added to the notification property array of strings. If it is turned off, the notification will be removed from the array. Screenshot:

![Screenshot 2024-06-27 at 15 11 59](https://github.com/invoiceninja/ui/assets/51542191/06a6b436-919f-41a7-83c4-76bdc309c27d)

`Note`: We are missing the `task_assigned` and `task_assigned_help` translation keywords from the files. If you agree, please add them.

Let me know your thoughts.