### PR TITLE
[Cleanup] Adjusting "Sort" Query Parameter | Dashboard Tables

### DIFF
--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -150,6 +150,7 @@ interface Props<T> extends CommonProps {
   disableQuery?: boolean;
   footerColumns?: FooterColumns;
   withoutPerPageAsPreference?: boolean;
+  withoutSortQueryParameter?: boolean;
 }
 
 export type ResourceAction<T> = (resource: T) => ReactElement;
@@ -189,6 +190,7 @@ export function DataTable<T extends object>(props: Props<T>) {
     footerColumns = [],
     bottomActionsKeys = [],
     withoutPerPageAsPreference = false,
+    withoutSortQueryParameter = false,
   } = props;
 
   const companyUpdateTimeOut = useRef<NodeJS.Timeout | undefined>(undefined);
@@ -271,7 +273,13 @@ export function DataTable<T extends object>(props: Props<T>) {
 
     handleChangingCustomFilters();
 
-    apiEndpoint.searchParams.set('sort', sort);
+    if (
+      !withoutSortQueryParameter ||
+      (withoutSortQueryParameter && sort !== 'id|asc')
+    ) {
+      apiEndpoint.searchParams.set('sort', sort);
+    }
+
     apiEndpoint.searchParams.set('status', status as unknown as string);
 
     if (dateRangeColumns.length && dateRangeQueryParameter) {

--- a/src/pages/dashboard/components/PastDueInvoices.tsx
+++ b/src/pages/dashboard/components/PastDueInvoices.tsx
@@ -88,7 +88,7 @@ export function PastDueInvoices() {
           resource="invoice"
           columns={columns}
           className="pr-4"
-          endpoint="/api/v1/invoices?include=client.group_settings&overdue=true&without_deleted_clients=true&per_page=50&page=1&sort=id|desc"
+          endpoint="/api/v1/invoices?include=client.group_settings&overdue=true&without_deleted_clients=true&per_page=50&page=1&sort=due_date|asc"
           withoutActions
           withoutPagination
           withoutPadding
@@ -108,6 +108,7 @@ export function PastDueInvoices() {
           style={{
             height: '19.9rem',
           }}
+          withoutSortQueryParameter
         />
       </div>
     </Card>

--- a/src/pages/dashboard/components/UpcomingInvoices.tsx
+++ b/src/pages/dashboard/components/UpcomingInvoices.tsx
@@ -91,7 +91,7 @@ export function UpcomingInvoices() {
           resource="invoice"
           columns={columns}
           className="pr-4"
-          endpoint="/api/v1/invoices?include=client.group_settings&upcoming=true&without_deleted_clients=true&per_page=50&page=1&sort=id|desc"
+          endpoint="/api/v1/invoices?include=client.group_settings&upcoming=true&without_deleted_clients=true&per_page=50&page=1"
           withoutActions
           withoutPagination
           withoutPadding
@@ -111,6 +111,7 @@ export function UpcomingInvoices() {
           style={{
             height: '19.9rem',
           }}
+          withoutSortQueryParameter
         />
       </div>
     </Card>

--- a/src/pages/dashboard/components/UpcomingQuotes.tsx
+++ b/src/pages/dashboard/components/UpcomingQuotes.tsx
@@ -82,7 +82,7 @@ export function UpcomingQuotes() {
           resource="quote"
           columns={columns}
           className="pr-4"
-          endpoint="/api/v1/quotes?include=client&client_status=upcoming&without_deleted_clients=true&per_page=50&page=1&sort=id|desc"
+          endpoint="/api/v1/quotes?include=client&client_status=upcoming&without_deleted_clients=true&per_page=50&page=1"
           withoutActions
           withoutPagination
           withoutPadding
@@ -102,6 +102,7 @@ export function UpcomingQuotes() {
           style={{
             height: '19.9rem',
           }}
+          withoutSortQueryParameter
         />
       </div>
     </Card>

--- a/src/pages/dashboard/components/UpcomingRecurringInvoices.tsx
+++ b/src/pages/dashboard/components/UpcomingRecurringInvoices.tsx
@@ -88,7 +88,7 @@ export function UpcomingRecurringInvoices() {
           resource="recurring_invoice"
           columns={columns}
           className="pr-4"
-          endpoint="/api/v1/recurring_invoices?include=client&client_status=active&without_deleted_clients=true&per_page=50&page=1"
+          endpoint="/api/v1/recurring_invoices?include=client&client_status=active&without_deleted_clients=true&per_page=50&page=1&sort=next_send_date_client|asc"
           withoutActions
           withoutPagination
           withoutPadding
@@ -108,7 +108,6 @@ export function UpcomingRecurringInvoices() {
           style={{
             height: '19.9rem',
           }}
-          withoutSortQueryParameter
         />
       </div>
     </Card>

--- a/src/pages/dashboard/components/UpcomingRecurringInvoices.tsx
+++ b/src/pages/dashboard/components/UpcomingRecurringInvoices.tsx
@@ -88,7 +88,7 @@ export function UpcomingRecurringInvoices() {
           resource="recurring_invoice"
           columns={columns}
           className="pr-4"
-          endpoint="/api/v1/recurring_invoices?include=client&client_status=active&without_deleted_clients=true&per_page=50&page=1&sort=next_send_date_client|asc"
+          endpoint="/api/v1/recurring_invoices?include=client&client_status=active&without_deleted_clients=true&per_page=50&page=1"
           withoutActions
           withoutPagination
           withoutPadding
@@ -108,6 +108,7 @@ export function UpcomingRecurringInvoices() {
           style={{
             height: '19.9rem',
           }}
+          withoutSortQueryParameter
         />
       </div>
     </Card>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adjustments for query parameters for dashboard tables. For tables with the `overdue` filter applied, the sort parameter will be set to `"due_date|asc"`. However, for tables with the `upcoming` filter applied, the sort parameter has been `REMOVED` by default. Let me know your thoughts.