### PR TITLE
[Cleanup] Adjusting Queries Params

### DIFF
--- a/src/components/credit/CreditSelector.tsx
+++ b/src/components/credit/CreditSelector.tsx
@@ -34,7 +34,9 @@ export function CreditSelector(props: Props) {
       inputOptions={{
         value: props.value ?? null,
       }}
-      endpoint={endpoint('/api/v1/credits?include=client&status=active')}
+      endpoint={endpoint(
+        '/api/v1/credits?include=client&filter_deleted_clients=true&status=active'
+      )}
       onChange={(credit: Entry<Credit>) =>
         credit.resource && props.onChange(credit.resource)
       }

--- a/src/components/invoices/InvoiceSelector.tsx
+++ b/src/components/invoices/InvoiceSelector.tsx
@@ -34,7 +34,9 @@ export function InvoiceSelector(props: Props) {
       inputOptions={{
         value: props.value ?? null,
       }}
-      endpoint={endpoint('/api/v1/invoices?include=client&status=active')}
+      endpoint={endpoint(
+        '/api/v1/invoices?include=client&filter_deleted_clients=true&status=active'
+      )}
       onChange={(invoice: Entry<Invoice>) =>
         invoice.resource && props.onChange(invoice.resource)
       }

--- a/src/components/projects/ProjectSelector.tsx
+++ b/src/components/projects/ProjectSelector.tsx
@@ -38,7 +38,9 @@ export function ProjectSelector(props: GenericSelectorProps<Project>) {
           label: props.inputLabel?.toString(),
           value: props.value ?? null,
         }}
-        endpoint={endpoint('/api/v1/projects?status=active')}
+        endpoint={endpoint(
+          '/api/v1/projects?status=active&filter_deleted_clients=true'
+        )}
         entryOptions={{ id: 'id', label: 'name', value: 'id' }}
         onChange={(entry) =>
           entry.resource ? props.onChange(entry.resource) : null

--- a/src/components/quotes/QuoteSelector.tsx
+++ b/src/components/quotes/QuoteSelector.tsx
@@ -34,7 +34,9 @@ export function QuoteSelector(props: Props) {
       inputOptions={{
         value: props.value ?? null,
       }}
-      endpoint={endpoint('/api/v1/quotes?include=client&status=active')}
+      endpoint={endpoint(
+        '/api/v1/quotes?include=client&filter_deleted_clients=true&status=active'
+      )}
       onChange={(quote: Entry<Quote>) =>
         quote.resource && props.onChange(quote.resource)
       }

--- a/src/pages/credits/index/Credits.tsx
+++ b/src/pages/credits/index/Credits.tsx
@@ -60,7 +60,7 @@ export default function Credits() {
     >
       <DataTable
         resource="credit"
-        endpoint="/api/v1/credits?include=client&without_deleted_clients=true&sort=id|desc"
+        endpoint="/api/v1/credits?include=client&filter_deleted_clients=true&sort=id|desc"
         bulkRoute="/api/v1/credits/bulk"
         columns={columns}
         linkToCreate="/credits/create"

--- a/src/pages/dashboard/components/ExpiredQuotes.tsx
+++ b/src/pages/dashboard/components/ExpiredQuotes.tsx
@@ -82,7 +82,7 @@ export function ExpiredQuotes() {
           resource="quote"
           columns={columns}
           className="pr-4"
-          endpoint="/api/v1/quotes?include=client&client_status=expired&without_deleted_clients=true&per_page=50&page=1&sort=id|desc"
+          endpoint="/api/v1/quotes?include=client&client_status=expired&filter_deleted_clients=true&per_page=50&page=1&sort=id|desc"
           withoutActions
           withoutPagination
           withoutPadding

--- a/src/pages/dashboard/components/PastDueInvoices.tsx
+++ b/src/pages/dashboard/components/PastDueInvoices.tsx
@@ -88,7 +88,7 @@ export function PastDueInvoices() {
           resource="invoice"
           columns={columns}
           className="pr-4"
-          endpoint="/api/v1/invoices?include=client.group_settings&overdue=true&without_deleted_clients=true&per_page=50&page=1&sort=id|desc"
+          endpoint="/api/v1/invoices?include=client.group_settings&overdue=true&filter_deleted_clients=true&per_page=50&page=1&sort=id|desc"
           withoutActions
           withoutPagination
           withoutPadding

--- a/src/pages/dashboard/components/RecentPayments.tsx
+++ b/src/pages/dashboard/components/RecentPayments.tsx
@@ -101,7 +101,7 @@ export function RecentPayments() {
           resource="payment"
           columns={columns}
           className="pr-4"
-          endpoint="/api/v1/payments?include=client,invoices&sort=date|desc&per_page=50&page=1"
+          endpoint="/api/v1/payments?include=client,invoices&sort=date|desc&per_page=50&filter_deleted_clients=true&page=1"
           withoutActions
           withoutPagination
           withoutPadding

--- a/src/pages/dashboard/components/UpcomingInvoices.tsx
+++ b/src/pages/dashboard/components/UpcomingInvoices.tsx
@@ -91,7 +91,7 @@ export function UpcomingInvoices() {
           resource="invoice"
           columns={columns}
           className="pr-4"
-          endpoint="/api/v1/invoices?include=client.group_settings&upcoming=true&without_deleted_clients=true&per_page=50&page=1&sort=id|desc"
+          endpoint="/api/v1/invoices?include=client.group_settings&upcoming=true&filter_deleted_clients=true&per_page=50&page=1&sort=id|desc"
           withoutActions
           withoutPagination
           withoutPadding

--- a/src/pages/dashboard/components/UpcomingQuotes.tsx
+++ b/src/pages/dashboard/components/UpcomingQuotes.tsx
@@ -82,7 +82,7 @@ export function UpcomingQuotes() {
           resource="quote"
           columns={columns}
           className="pr-4"
-          endpoint="/api/v1/quotes?include=client&client_status=upcoming&without_deleted_clients=true&per_page=50&page=1&sort=id|desc"
+          endpoint="/api/v1/quotes?include=client&client_status=upcoming&filter_deleted_clients=true&per_page=50&page=1&sort=id|desc"
           withoutActions
           withoutPagination
           withoutPadding

--- a/src/pages/dashboard/components/UpcomingRecurringInvoices.tsx
+++ b/src/pages/dashboard/components/UpcomingRecurringInvoices.tsx
@@ -88,7 +88,7 @@ export function UpcomingRecurringInvoices() {
           resource="recurring_invoice"
           columns={columns}
           className="pr-4"
-          endpoint="/api/v1/recurring_invoices?include=client&client_status=active&without_deleted_clients=true&per_page=50&page=1&sort=next_send_date_client|asc"
+          endpoint="/api/v1/recurring_invoices?include=client&client_status=active&filter_deleted_clients=true&per_page=50&page=1&sort=next_send_date_client|asc"
           withoutActions
           withoutPagination
           withoutPadding

--- a/src/pages/expenses/common/components/AddToInvoiceAction.tsx
+++ b/src/pages/expenses/common/components/AddToInvoiceAction.tsx
@@ -121,13 +121,13 @@ export function AddToInvoiceAction(props: Props) {
         .fetchQuery(
           [
             '/api/v1/invoices',
-            `include=client&status_id=1,2,3&is_deleted=true&without_deleted_clients=true&client_id=${expense.client_id}`,
+            `include=client&status_id=1,2,3&is_deleted=true&filter_deleted_clients=true&client_id=${expense.client_id}`,
           ],
           () =>
             request(
               'GET',
               endpoint(
-                '/api/v1/invoices?include=client.group_settings&status_id=1,2,3&is_deleted=true&without_deleted_clients=true&client_id=:clientId',
+                '/api/v1/invoices?include=client.group_settings&status_id=1,2,3&is_deleted=true&filter_deleted_clients=true&client_id=:clientId',
                 { clientId: expense.client_id || '' }
               )
             ),

--- a/src/pages/invoices/common/queries.ts
+++ b/src/pages/invoices/common/queries.ts
@@ -30,7 +30,7 @@ export function useInvoicesQuery(params: InvoiceParams) {
       request(
         'GET',
         endpoint(
-          '/api/v1/invoices?client_status=:client_status&filter=:filter&client_id=:client_id&without_deleted_clients=:without_deleted_clients&per_page=:per_page&page=:page&include=:include',
+          '/api/v1/invoices?client_status=:client_status&filter=:filter&client_id=:client_id&filter_deleted_clients=:without_deleted_clients&per_page=:per_page&page=:page&include=:include',
           {
             per_page: params.perPage ?? '100',
             page: params.currentPage ?? '1',

--- a/src/pages/invoices/index/Invoices.tsx
+++ b/src/pages/invoices/index/Invoices.tsx
@@ -98,7 +98,7 @@ export default function Invoices() {
     >
       <DataTable
         resource="invoice"
-        endpoint="/api/v1/invoices?include=client.group_settings&without_deleted_clients=true&sort=id|desc"
+        endpoint="/api/v1/invoices?include=client.group_settings&filter_deleted_clients=true&sort=id|desc"
         columns={columns}
         footerColumns={footerColumns}
         bulkRoute="/api/v1/invoices/bulk"

--- a/src/pages/payments/index/Payments.tsx
+++ b/src/pages/payments/index/Payments.tsx
@@ -92,7 +92,7 @@ export default function Payments() {
       <DataTable
         resource="payment"
         columns={columns}
-        endpoint="/api/v1/payments?include=client,invoices&without_deleted_clients=true&sort=id|desc"
+        endpoint="/api/v1/payments?include=client,invoices&filter_deleted_clients=true&sort=id|desc"
         linkToCreate="/payments/create"
         bulkRoute="/api/v1/payments/bulk"
         linkToEdit="/payments/:id/edit"

--- a/src/pages/projects/common/hooks.tsx
+++ b/src/pages/projects/common/hooks.tsx
@@ -347,7 +347,7 @@ export function useActions() {
           request(
             'GET',
             endpoint(
-              '/api/v1/tasks?project_tasks=:projectId&per_page=100&status=active',
+              '/api/v1/tasks?project_tasks=:projectId&per_page=100&status=active&without_deleted_clients=true',
               {
                 projectId: project.id,
               }

--- a/src/pages/projects/common/hooks/useCombineProjectsTasks.ts
+++ b/src/pages/projects/common/hooks/useCombineProjectsTasks.ts
@@ -53,7 +53,7 @@ export function useCombineProjectsTasks() {
             request(
               'GET',
               endpoint(
-                '/api/v1/tasks?project_tasks=:projectId&per_page=100&status=active',
+                '/api/v1/tasks?project_tasks=:projectId&per_page=100&status=active&without_deleted_clients=true',
                 {
                   projectId,
                 }

--- a/src/pages/projects/index/Projects.tsx
+++ b/src/pages/projects/index/Projects.tsx
@@ -59,7 +59,7 @@ export default function Projects() {
     >
       <DataTable
         resource="project"
-        endpoint="/api/v1/projects?status=active&include=client&without_deleted_clients=true&sort=id|desc"
+        endpoint="/api/v1/projects?status=active&include=client&filter_deleted_clients=true&sort=id|desc"
         bulkRoute="/api/v1/projects/bulk"
         columns={columns}
         customActions={actions}

--- a/src/pages/projects/show/Show.tsx
+++ b/src/pages/projects/show/Show.tsx
@@ -242,7 +242,7 @@ export default function Show() {
             resource="task"
             columns={columns}
             customActions={taskActions}
-            endpoint={`/api/v1/tasks?include=status,client,project&sort=id|desc&project_tasks=${project.id}`}
+            endpoint={`/api/v1/tasks?include=status,client,project&sort=id|desc&project_tasks=${project.id}&without_deleted_clients=true`}
             bulkRoute="/api/v1/tasks/bulk"
             linkToCreate={`/tasks/create?project=${id}&rate=${project.task_rate}`}
             linkToEdit="/tasks/:id/edit"

--- a/src/pages/quotes/index/Quotes.tsx
+++ b/src/pages/quotes/index/Quotes.tsx
@@ -94,7 +94,7 @@ export default function Quotes() {
         resource="quote"
         columns={columns}
         footerColumns={footerColumns}
-        endpoint="/api/v1/quotes?include=client&without_deleted_clients=true&sort=id|desc"
+        endpoint="/api/v1/quotes?include=client&filter_deleted_clients=true&sort=id|desc"
         linkToEdit="/quotes/:id/edit"
         linkToCreate="/quotes/create"
         bulkRoute="/api/v1/quotes/bulk"

--- a/src/pages/recurring-expenses/index/RecurringExpenses.tsx
+++ b/src/pages/recurring-expenses/index/RecurringExpenses.tsx
@@ -50,7 +50,7 @@ export default function RecurringExpenses() {
     >
       <DataTable
         resource="recurring_expense"
-        endpoint="/api/v1/recurring_expenses?include=client,vendor&sort=id|desc"
+        endpoint="/api/v1/recurring_expenses?include=client,vendor&sort=id|desc&without_deleted_clients=true&without_deleted_vendors=true"
         columns={columns}
         bulkRoute="/api/v1/recurring_expenses/bulk"
         linkToCreate="/recurring_expenses/create"

--- a/src/pages/recurring-invoices/index/RecurringInvoices.tsx
+++ b/src/pages/recurring-invoices/index/RecurringInvoices.tsx
@@ -99,7 +99,7 @@ export default function RecurringInvoices() {
         resource="recurring_invoice"
         columns={columns}
         footerColumns={footerColumns}
-        endpoint="/api/v1/recurring_invoices?include=client&without_deleted_clients=true&sort=id|desc"
+        endpoint="/api/v1/recurring_invoices?include=client&filter_deleted_clients=true&sort=id|desc"
         linkToCreate="/recurring_invoices/create"
         linkToEdit="/recurring_invoices/:id/edit"
         bulkRoute="/api/v1/recurring_invoices/bulk"

--- a/src/pages/settings/schedules/common/components/EmailRecord.tsx
+++ b/src/pages/settings/schedules/common/components/EmailRecord.tsx
@@ -129,7 +129,9 @@ export function EmailRecord(props: Props) {
       {schedule.parameters.entity === 'credit' && (
         <Element leftSide={t('credit')}>
           <ComboboxAsync<Credit>
-            endpoint={endpoint('/api/v1/credits?include=client&status=active')}
+            endpoint={endpoint(
+              '/api/v1/credits?include=client&filter_deleted_clients=true&status=active'
+            )}
             onChange={(credit: Entry<Credit>) =>
               credit.resource &&
               handleChange(

--- a/src/pages/settings/schedules/common/components/EmailRecord.tsx
+++ b/src/pages/settings/schedules/common/components/EmailRecord.tsx
@@ -67,7 +67,7 @@ export function EmailRecord(props: Props) {
         <Element leftSide={t('invoice')}>
           <ComboboxAsync<Invoice>
             endpoint={endpoint(
-              '/api/v1/invoices?include=client.group_settings&status=active'
+              '/api/v1/invoices?include=client.group_settings&filter_deleted_clients=true&status=active'
             )}
             onChange={(invoice: Entry<Invoice>) =>
               invoice.resource &&
@@ -98,7 +98,9 @@ export function EmailRecord(props: Props) {
       {schedule.parameters.entity === 'quote' && (
         <Element leftSide={t('quote')}>
           <ComboboxAsync<Quote>
-            endpoint={endpoint('/api/v1/quotes?include=client&status=active')}
+            endpoint={endpoint(
+              '/api/v1/quotes?include=client&filter_deleted_clients=true&status=active'
+            )}
             onChange={(quote: Entry<Quote>) =>
               quote.resource &&
               handleChange(


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adjustments to query parameters. For the entities that must have a client during creation, we ensured that list queries have the `filter_deleted_clients` parameter set to true. For the entities where the client is optional, we ensured that the queries contain the `without_deleted_clients` parameter set to true. Let me know your thoughts.