### PR TITLE
[Cleanup] Nordigen Reconnecting One Time Token Generation

### DIFF
--- a/src/common/interfaces/bank-accounts.ts
+++ b/src/common/interfaces/bank-accounts.ts
@@ -28,4 +28,5 @@ export interface BankAccount {
   provider_name: string;
   updated_at: number;
   integration_type: string;
+  nordigen_institution_id: string;
 }

--- a/src/pages/settings/bank-accounts/common/hooks/useBankAccountColumns.tsx
+++ b/src/pages/settings/bank-accounts/common/hooks/useBankAccountColumns.tsx
@@ -32,10 +32,11 @@ export const useBankAccountColumns = () => {
   const formatMoney = useFormatMoney();
   const resolveCurrency = useResolveCurrency({ resolveBy: 'code' });
 
-  const handleConnectNordigen = () => {
+  const handleConnectNordigen = (institutionId: string) => {
     request('POST', endpoint('/api/v1/one_time_token'), {
       context: 'nordigen',
       platform: 'react',
+      institution_id: institutionId,
     }).then((tokenResponse) => {
       window.open(
         endpoint('/nordigen/connect/:hash', {
@@ -66,11 +67,15 @@ export const useBankAccountColumns = () => {
                 width="auto"
                 placement="top"
               >
-                <MdWarning
-                  color="red"
-                  size={22}
-                  onClick={handleConnectNordigen}
-                />
+                <div
+                  className="cursor-pointer"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    handleConnectNordigen(bankAccount.nordigen_institution_id);
+                  }}
+                >
+                  <MdWarning color="red" size={22} />
+                </div>
               </Tooltip>
             )}
         </div>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adding an additional prop (`institution_id`) to the payload while generating the `one_time_token` for the `Nordigen` reconnection when the upstream is `DISABLED`. Screenshot:

![Screenshot 2024-07-11 at 17 16 17](https://github.com/invoiceninja/ui/assets/51542191/49ce62b0-054b-40a8-9e44-459097e05874)

Let me know your thoughts.