### PR TITLE
[Cleanup] Displaying "Restore" Action For Payments

### DIFF
--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -151,6 +151,7 @@ interface Props<T> extends CommonProps {
   footerColumns?: FooterColumns;
   withoutPerPageAsPreference?: boolean;
   withoutSortQueryParameter?: boolean;
+  showRestoreBulk?: (selectedResources: T[]) => boolean;
 }
 
 export type ResourceAction<T> = (resource: T) => ReactElement;
@@ -191,6 +192,7 @@ export function DataTable<T extends object>(props: Props<T>) {
     bottomActionsKeys = [],
     withoutPerPageAsPreference = false,
     withoutSortQueryParameter = false,
+    showRestoreBulk,
   } = props;
 
   const companyUpdateTimeOut = useRef<NodeJS.Timeout | undefined>(undefined);
@@ -549,7 +551,9 @@ export function DataTable<T extends object>(props: Props<T>) {
                     {t('delete')}
                   </DropdownElement>
 
-                  {showRestoreBulkAction() && (
+                  {(showRestoreBulk
+                    ? showRestoreBulk(selectedResources)
+                    : showRestoreBulkAction()) && (
                     <DropdownElement
                       onClick={() => {
                         if (onBulkActionCall) {

--- a/src/pages/clients/show/pages/Payments.tsx
+++ b/src/pages/clients/show/pages/Payments.tsx
@@ -16,6 +16,8 @@ import { usePaymentColumns } from '$app/pages/payments/common/hooks/usePaymentCo
 import { useActions } from '$app/pages/payments/common/hooks/useActions';
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 import { permission } from '$app/common/guards/guards/permission';
+import { getEntityState } from '$app/common/helpers';
+import { EntityState } from '$app/common/enums/entity-state';
 
 export default function Payments() {
   const { id } = useParams();
@@ -43,6 +45,11 @@ export default function Payments() {
       showRestore={(resource: Payment) => !resource.is_deleted}
       linkToCreateGuards={[permission('create_payment')]}
       hideEditableOptions={!hasPermission('edit_payment')}
+      showRestoreBulk={(selectedPayments) =>
+        selectedPayments.every(
+          (payment) => getEntityState(payment) === EntityState.Archived
+        )
+      }
     />
   );
 }

--- a/src/pages/payments/index/Payments.tsx
+++ b/src/pages/payments/index/Payments.tsx
@@ -38,6 +38,8 @@ import {
   ChangeTemplateModal,
   useChangeTemplate,
 } from '$app/pages/settings/invoice-design/pages/custom-designs/components/ChangeTemplate';
+import { EntityState } from '$app/common/enums/entity-state';
+import { getEntityState } from '$app/common/helpers';
 
 export default function Payments() {
   useTitle('payments');
@@ -115,6 +117,11 @@ export default function Payments() {
         }}
         linkToCreateGuards={[permission('create_payment')]}
         hideEditableOptions={!hasPermission('edit_payment')}
+        showRestoreBulk={(selectedPayments) =>
+          selectedPayments.every(
+            (payment) => getEntityState(payment) === EntityState.Archived
+          )
+        }
       />
 
       {!disableNavigation('payment', paymentSlider) && <PaymentSlider />}


### PR DESCRIPTION
@beganovich @turbo124 The PR includes applying the condition for displaying the "Restore" bulk action on payments only if the payment has a status of "archived", in any other case, it should not be displayed. Screenshot:

![Screenshot 2024-07-15 at 13 18 14](https://github.com/user-attachments/assets/27bf129b-4790-41fc-9baf-2a27ffc0e6d5)

Let me know your thoughts.