### PR TITLE
[Cleanup] Adding Tooltip For Ordering Gateways

### DIFF
--- a/src/components/tables/Th.tsx
+++ b/src/components/tables/Th.tsx
@@ -24,6 +24,7 @@ interface Props extends CommonProps {
   isCurrentlyUsed?: boolean;
   childrenClassName?: string;
   textColor?: string;
+  disableUppercase?: boolean;
 }
 
 const defaultProps: Props = {
@@ -58,9 +59,10 @@ export function Th(props: Props) {
       }}
       onClick={handleClick}
       className={classNames(
-        `px-2 lg:px-2.5 xl:px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wider whitespace-nowrap ${props.className}`,
+        `px-2 lg:px-2.5 xl:px-4 py-2.5 text-left text-xs font-medium tracking-wider whitespace-nowrap ${props.className}`,
         {
           'cursor-pointer': props.onColumnClick,
+          uppercase: !props.disableUppercase,
         }
       )}
     >

--- a/src/pages/settings/gateways/common/components/GatewaysTable.tsx
+++ b/src/pages/settings/gateways/common/components/GatewaysTable.tsx
@@ -47,6 +47,7 @@ import { Settings } from '$app/common/interfaces/company.interface';
 import { useHandleCurrentCompanyChangeProperty } from '$app/pages/settings/common/hooks/useHandleCurrentCompanyChange';
 import { useCurrentSettingsLevel } from '$app/common/hooks/useCurrentSettingsLevel';
 import { useSelectorCustomStyles } from '$app/pages/reports/common/hooks/useSelectorCustomStyles';
+import { BsQuestionCircle } from 'react-icons/bs';
 
 interface Params {
   includeRemoveAction: boolean;
@@ -277,7 +278,15 @@ export function GatewaysTable(params: Params) {
           <Th>{t('status')}</Th>
           <Th>{t('label')}</Th>
           <Th>{t('test_mode')}</Th>
-          <Th></Th>
+          <Th disableUppercase>
+            <Tooltip
+              placement="top"
+              message={t('sort_gateways') as string}
+              width="auto"
+            >
+              <Icon element={BsQuestionCircle} color="white" size={20} />
+            </Tooltip>
+          </Th>
         </Thead>
 
         <DragDropContext onDragEnd={onDragEnd}>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adding a tooltip as a helper for ordering gateways on the gateways table. Screenshot:

![Screenshot 2024-07-22 at 21 56 24](https://github.com/user-attachments/assets/9af147d6-f37c-4ba0-ab32-e138683a12ca)

`Note`: I used the 'sort_gateways' translation keyword, which we missed from the files. If you would agree, please just add it.

Let me know your thoughts.