### PR TITLE
[Cleanup] Adjusting "prose" Class For Dark Mode | Markdowns

### DIFF
--- a/src/pages/clients/common/hooks/useClientColumns.tsx
+++ b/src/pages/clients/common/hooks/useClientColumns.tsx
@@ -35,6 +35,7 @@ import {
   extractTextFromHTML,
   sanitizeHTML,
 } from '$app/common/helpers/html-string';
+import { useColorScheme } from '$app/common/colors';
 
 export const defaultColumns: string[] = [
   'name',
@@ -102,6 +103,7 @@ export function useClientColumns() {
 
   const disableNavigation = useDisableNavigation();
 
+  const colors = useColorScheme();
   const company = useCurrentCompany();
   const reactSettings = useReactSettings();
 
@@ -328,6 +330,9 @@ export function useClientColumns() {
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
                 }}
+                style={{
+                  color: colors.$3,
+                }}
               />
             </div>
           }
@@ -351,6 +356,9 @@ export function useClientColumns() {
                 className="prose prose-sm"
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
+                }}
+                style={{
+                  color: colors.$3,
                 }}
               />
             </div>

--- a/src/pages/clients/common/hooks/useClientColumns.tsx
+++ b/src/pages/clients/common/hooks/useClientColumns.tsx
@@ -35,7 +35,7 @@ import {
   extractTextFromHTML,
   sanitizeHTML,
 } from '$app/common/helpers/html-string';
-import { useColorScheme } from '$app/common/colors';
+import classNames from 'classnames';
 
 export const defaultColumns: string[] = [
   'name',
@@ -103,7 +103,6 @@ export function useClientColumns() {
 
   const disableNavigation = useDisableNavigation();
 
-  const colors = useColorScheme();
   const company = useCurrentCompany();
   const reactSettings = useReactSettings();
 
@@ -326,12 +325,11 @@ export function useClientColumns() {
           tooltipElement={
             <div className="w-full max-h-48 overflow-auto whitespace-normal break-all">
               <article
-                className="prose prose-sm"
+                className={classNames('prose prose-sm', {
+                  'prose-invert': reactSettings.dark_mode,
+                })}
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
-                }}
-                style={{
-                  color: colors.$3,
                 }}
               />
             </div>
@@ -353,12 +351,11 @@ export function useClientColumns() {
           tooltipElement={
             <div className="w-full max-h-48 overflow-auto whitespace-normal break-all">
               <article
-                className="prose prose-sm"
+                className={classNames('prose prose-sm', {
+                  'prose-invert': reactSettings.dark_mode,
+                })}
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
-                }}
-                style={{
-                  color: colors.$3,
                 }}
               />
             </div>

--- a/src/pages/clients/show/components/ClientPrivateNotes.tsx
+++ b/src/pages/clients/show/components/ClientPrivateNotes.tsx
@@ -8,6 +8,7 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
+import { useColorScheme } from '$app/common/colors';
 import { sanitizeHTML } from '$app/common/helpers/html-string';
 import { Client } from '$app/common/interfaces/client';
 import { InfoCard } from '$app/components/InfoCard';
@@ -22,6 +23,8 @@ export function ClientPrivateNotes(props: Props) {
 
   const { client } = props;
 
+  const colors = useColorScheme();
+
   return (
     <>
       {Boolean(client && client.private_notes) && (
@@ -34,6 +37,9 @@ export function ClientPrivateNotes(props: Props) {
                   className="prose prose-sm"
                   dangerouslySetInnerHTML={{
                     __html: sanitizeHTML(client.private_notes),
+                  }}
+                  style={{
+                    color: colors.$3,
                   }}
                 />
               </div>

--- a/src/pages/clients/show/components/ClientPrivateNotes.tsx
+++ b/src/pages/clients/show/components/ClientPrivateNotes.tsx
@@ -8,10 +8,11 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
-import { useColorScheme } from '$app/common/colors';
 import { sanitizeHTML } from '$app/common/helpers/html-string';
+import { useReactSettings } from '$app/common/hooks/useReactSettings';
 import { Client } from '$app/common/interfaces/client';
 import { InfoCard } from '$app/components/InfoCard';
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 
 interface Props {
@@ -23,7 +24,7 @@ export function ClientPrivateNotes(props: Props) {
 
   const { client } = props;
 
-  const colors = useColorScheme();
+  const reactSettings = useReactSettings({ overwrite: false });
 
   return (
     <>
@@ -34,12 +35,11 @@ export function ClientPrivateNotes(props: Props) {
             value={
               <div className="whitespace-normal max-h-56 overflow-y-auto">
                 <article
-                  className="prose prose-sm"
+                  className={classNames('prose prose-sm', {
+                    'prose-invert': reactSettings.dark_mode,
+                  })}
                   dangerouslySetInnerHTML={{
                     __html: sanitizeHTML(client.private_notes),
-                  }}
-                  style={{
-                    color: colors.$3,
                   }}
                 />
               </div>

--- a/src/pages/clients/show/components/ClientPrivateNotes.tsx
+++ b/src/pages/clients/show/components/ClientPrivateNotes.tsx
@@ -24,7 +24,7 @@ export function ClientPrivateNotes(props: Props) {
 
   const { client } = props;
 
-  const reactSettings = useReactSettings({ overwrite: false });
+  const reactSettings = useReactSettings();
 
   return (
     <>

--- a/src/pages/clients/show/components/ClientPublicNotes.tsx
+++ b/src/pages/clients/show/components/ClientPublicNotes.tsx
@@ -24,7 +24,7 @@ export function ClientPublicNotes(props: Props) {
 
   const { client } = props;
 
-  const reactSettings = useReactSettings({ overwrite: false });
+  const reactSettings = useReactSettings();
 
   return (
     <>

--- a/src/pages/clients/show/components/ClientPublicNotes.tsx
+++ b/src/pages/clients/show/components/ClientPublicNotes.tsx
@@ -8,6 +8,7 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
+import { useColorScheme } from '$app/common/colors';
 import { sanitizeHTML } from '$app/common/helpers/html-string';
 import { Client } from '$app/common/interfaces/client';
 import { InfoCard } from '$app/components/InfoCard';
@@ -22,6 +23,8 @@ export function ClientPublicNotes(props: Props) {
 
   const { client } = props;
 
+  const colors = useColorScheme();
+
   return (
     <>
       {Boolean(client && client.public_notes) && (
@@ -34,6 +37,9 @@ export function ClientPublicNotes(props: Props) {
                   className="prose prose-sm"
                   dangerouslySetInnerHTML={{
                     __html: sanitizeHTML(client.public_notes),
+                  }}
+                  style={{
+                    color: colors.$3,
                   }}
                 />
               </div>

--- a/src/pages/clients/show/components/ClientPublicNotes.tsx
+++ b/src/pages/clients/show/components/ClientPublicNotes.tsx
@@ -8,10 +8,11 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
-import { useColorScheme } from '$app/common/colors';
 import { sanitizeHTML } from '$app/common/helpers/html-string';
+import { useReactSettings } from '$app/common/hooks/useReactSettings';
 import { Client } from '$app/common/interfaces/client';
 import { InfoCard } from '$app/components/InfoCard';
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 
 interface Props {
@@ -23,7 +24,7 @@ export function ClientPublicNotes(props: Props) {
 
   const { client } = props;
 
-  const colors = useColorScheme();
+  const reactSettings = useReactSettings({ overwrite: false });
 
   return (
     <>
@@ -34,12 +35,11 @@ export function ClientPublicNotes(props: Props) {
             value={
               <div className="whitespace-normal max-h-56 overflow-y-auto">
                 <article
-                  className="prose prose-sm"
+                  className={classNames('prose prose-sm', {
+                    'prose-invert': reactSettings.dark_mode,
+                  })}
                   dangerouslySetInnerHTML={{
                     __html: sanitizeHTML(client.public_notes),
-                  }}
-                  style={{
-                    color: colors.$3,
                   }}
                 />
               </div>

--- a/src/pages/credits/common/hooks.tsx
+++ b/src/pages/credits/common/hooks.tsx
@@ -95,7 +95,7 @@ import {
   sanitizeHTML,
 } from '$app/common/helpers/html-string';
 import { useFormatNumber } from '$app/common/hooks/useFormatNumber';
-import { useColorScheme } from '$app/common/colors';
+import classNames from 'classnames';
 
 interface CreditUtilitiesProps {
   client?: Client;
@@ -599,8 +599,6 @@ export function useCreditColumns() {
   const { t } = useTranslation();
   const { dateFormat } = useCurrentCompanyDateFormats();
 
-  const colors = useColorScheme();
-
   const formatNumber = useFormatNumber();
   const disableNavigation = useDisableNavigation();
 
@@ -847,12 +845,11 @@ export function useCreditColumns() {
           tooltipElement={
             <div className="w-full max-h-48 overflow-auto whitespace-normal break-all">
               <article
-                className="prose prose-sm"
+                className={classNames('prose prose-sm', {
+                  'prose-invert': reactSettings.dark_mode,
+                })}
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
-                }}
-                style={{
-                  color: colors.$3,
                 }}
               />
             </div>
@@ -874,12 +871,11 @@ export function useCreditColumns() {
           tooltipElement={
             <div className="w-full max-h-48 overflow-auto whitespace-normal break-all">
               <article
-                className="prose prose-sm"
+                className={classNames('prose prose-sm', {
+                  'prose-invert': reactSettings.dark_mode,
+                })}
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
-                }}
-                style={{
-                  color: colors.$3,
                 }}
               />
             </div>

--- a/src/pages/credits/common/hooks.tsx
+++ b/src/pages/credits/common/hooks.tsx
@@ -95,6 +95,7 @@ import {
   sanitizeHTML,
 } from '$app/common/helpers/html-string';
 import { useFormatNumber } from '$app/common/hooks/useFormatNumber';
+import { useColorScheme } from '$app/common/colors';
 
 interface CreditUtilitiesProps {
   client?: Client;
@@ -598,6 +599,8 @@ export function useCreditColumns() {
   const { t } = useTranslation();
   const { dateFormat } = useCurrentCompanyDateFormats();
 
+  const colors = useColorScheme();
+
   const formatNumber = useFormatNumber();
   const disableNavigation = useDisableNavigation();
 
@@ -848,6 +851,9 @@ export function useCreditColumns() {
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
                 }}
+                style={{
+                  color: colors.$3,
+                }}
               />
             </div>
           }
@@ -871,6 +877,9 @@ export function useCreditColumns() {
                 className="prose prose-sm"
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
+                }}
+                style={{
+                  color: colors.$3,
                 }}
               />
             </div>

--- a/src/pages/expenses/common/hooks.tsx
+++ b/src/pages/expenses/common/hooks.tsx
@@ -59,7 +59,7 @@ import {
   sanitizeHTML,
 } from '$app/common/helpers/html-string';
 import { useFormatNumber } from '$app/common/hooks/useFormatNumber';
-import { useColorScheme } from '$app/common/colors';
+import classNames from 'classnames';
 
 export function useActions() {
   const [t] = useTranslation();
@@ -231,8 +231,6 @@ export function useExpenseColumns() {
   const { t } = useTranslation();
   const { dateFormat } = useCurrentCompanyDateFormats();
 
-  const colors = useColorScheme();
-
   const formatNumber = useFormatNumber();
   const hasPermission = useHasPermission();
   const disableNavigation = useDisableNavigation();
@@ -365,12 +363,11 @@ export function useExpenseColumns() {
           tooltipElement={
             <div className="w-full max-h-48 overflow-auto whitespace-normal break-all">
               <article
-                className="prose prose-sm"
+                className={classNames('prose prose-sm', {
+                  'prose-invert': reactSettings.dark_mode,
+                })}
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
-                }}
-                style={{
-                  color: colors.$3,
                 }}
               />
             </div>
@@ -477,12 +474,11 @@ export function useExpenseColumns() {
           tooltipElement={
             <div className="w-full max-h-48 overflow-auto whitespace-normal break-all">
               <article
-                className="prose prose-sm"
+                className={classNames('prose prose-sm', {
+                  'prose-invert': reactSettings.dark_mode,
+                })}
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
-                }}
-                style={{
-                  color: colors.$3,
                 }}
               />
             </div>

--- a/src/pages/expenses/common/hooks.tsx
+++ b/src/pages/expenses/common/hooks.tsx
@@ -59,6 +59,7 @@ import {
   sanitizeHTML,
 } from '$app/common/helpers/html-string';
 import { useFormatNumber } from '$app/common/hooks/useFormatNumber';
+import { useColorScheme } from '$app/common/colors';
 
 export function useActions() {
   const [t] = useTranslation();
@@ -230,6 +231,8 @@ export function useExpenseColumns() {
   const { t } = useTranslation();
   const { dateFormat } = useCurrentCompanyDateFormats();
 
+  const colors = useColorScheme();
+
   const formatNumber = useFormatNumber();
   const hasPermission = useHasPermission();
   const disableNavigation = useDisableNavigation();
@@ -366,6 +369,9 @@ export function useExpenseColumns() {
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
                 }}
+                style={{
+                  color: colors.$3,
+                }}
               />
             </div>
           }
@@ -474,6 +480,9 @@ export function useExpenseColumns() {
                 className="prose prose-sm"
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
+                }}
+                style={{
+                  color: colors.$3,
                 }}
               />
             </div>

--- a/src/pages/invoices/common/components/InvoiceSlider.tsx
+++ b/src/pages/invoices/common/components/InvoiceSlider.tsx
@@ -52,6 +52,7 @@ import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
 import { useDisableNavigation } from '$app/common/hooks/useDisableNavigation';
 import { DynamicLink } from '$app/components/DynamicLink';
 import { sanitizeHTML } from '$app/common/helpers/html-string';
+import { useColorScheme } from '$app/common/colors';
 
 export const invoiceSliderAtom = atom<Invoice | null>(null);
 export const invoiceSliderVisibilityAtom = atom(false);
@@ -119,6 +120,8 @@ export function InvoiceSlider() {
   const [isVisible, setIsSliderVisible] = useAtom(invoiceSliderVisibilityAtom);
   const [invoice, setInvoice] = useAtom(invoiceSliderAtom);
   const [t] = useTranslation();
+
+  const colors = useColorScheme();
 
   const hasPermission = useHasPermission();
   const entityAssigned = useEntityAssigned();
@@ -309,6 +312,9 @@ export function InvoiceSlider() {
                       __html: sanitizeHTML(
                         (resource?.reminder_schedule as string) ?? ''
                       ),
+                    }}
+                    style={{
+                      color: colors.$3,
                     }}
                   />
                 }

--- a/src/pages/invoices/common/components/InvoiceSlider.tsx
+++ b/src/pages/invoices/common/components/InvoiceSlider.tsx
@@ -52,7 +52,8 @@ import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
 import { useDisableNavigation } from '$app/common/hooks/useDisableNavigation';
 import { DynamicLink } from '$app/components/DynamicLink';
 import { sanitizeHTML } from '$app/common/helpers/html-string';
-import { useColorScheme } from '$app/common/colors';
+import classNames from 'classnames';
+import { useReactSettings } from '$app/common/hooks/useReactSettings';
 
 export const invoiceSliderAtom = atom<Invoice | null>(null);
 export const invoiceSliderVisibilityAtom = atom(false);
@@ -121,7 +122,7 @@ export function InvoiceSlider() {
   const [invoice, setInvoice] = useAtom(invoiceSliderAtom);
   const [t] = useTranslation();
 
-  const colors = useColorScheme();
+  const reactSettings = useReactSettings();
 
   const hasPermission = useHasPermission();
   const entityAssigned = useEntityAssigned();
@@ -307,14 +308,13 @@ export function InvoiceSlider() {
                 width="auto"
                 tooltipElement={
                   <article
-                    className="prose prose-sm"
+                    className={classNames('prose prose-sm', {
+                      'prose-invert': reactSettings.dark_mode,
+                    })}
                     dangerouslySetInnerHTML={{
                       __html: sanitizeHTML(
                         (resource?.reminder_schedule as string) ?? ''
                       ),
-                    }}
-                    style={{
-                      color: colors.$3,
                     }}
                   />
                 }

--- a/src/pages/invoices/common/hooks/useInvoiceColumns.tsx
+++ b/src/pages/invoices/common/hooks/useInvoiceColumns.tsx
@@ -32,7 +32,7 @@ import {
   sanitizeHTML,
 } from '$app/common/helpers/html-string';
 import { useFormatNumber } from '$app/common/hooks/useFormatNumber';
-import { useColorScheme } from '$app/common/colors';
+import classNames from 'classnames';
 
 export type DataTableColumnsExtended<TResource = any, TColumn = string> = {
   column: TColumn;
@@ -121,8 +121,6 @@ export function useInvoiceColumns(): DataTableColumns<Invoice> {
 
   const { t } = useTranslation();
   const { dateFormat } = useCurrentCompanyDateFormats();
-
-  const colors = useColorScheme();
 
   const formatNumber = useFormatNumber();
   const disableNavigation = useDisableNavigation();
@@ -392,12 +390,11 @@ export function useInvoiceColumns(): DataTableColumns<Invoice> {
           tooltipElement={
             <div className="w-full max-h-48 overflow-auto whitespace-normal break-all">
               <article
-                className="prose prose-sm"
+                className={classNames('prose prose-sm', {
+                  'prose-invert': reactSettings.dark_mode,
+                })}
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
-                }}
-                style={{
-                  color: colors.$3,
                 }}
               />
             </div>
@@ -419,12 +416,11 @@ export function useInvoiceColumns(): DataTableColumns<Invoice> {
           tooltipElement={
             <div className="w-full max-h-48 overflow-auto whitespace-normal break-all">
               <article
-                className="prose prose-sm"
+                className={classNames('prose prose-sm', {
+                  'prose-invert': reactSettings.dark_mode,
+                })}
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
-                }}
-                style={{
-                  color: colors.$3,
                 }}
               />
             </div>

--- a/src/pages/invoices/common/hooks/useInvoiceColumns.tsx
+++ b/src/pages/invoices/common/hooks/useInvoiceColumns.tsx
@@ -32,6 +32,7 @@ import {
   sanitizeHTML,
 } from '$app/common/helpers/html-string';
 import { useFormatNumber } from '$app/common/hooks/useFormatNumber';
+import { useColorScheme } from '$app/common/colors';
 
 export type DataTableColumnsExtended<TResource = any, TColumn = string> = {
   column: TColumn;
@@ -120,6 +121,8 @@ export function useInvoiceColumns(): DataTableColumns<Invoice> {
 
   const { t } = useTranslation();
   const { dateFormat } = useCurrentCompanyDateFormats();
+
+  const colors = useColorScheme();
 
   const formatNumber = useFormatNumber();
   const disableNavigation = useDisableNavigation();
@@ -393,6 +396,9 @@ export function useInvoiceColumns(): DataTableColumns<Invoice> {
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
                 }}
+                style={{
+                  color: colors.$3,
+                }}
               />
             </div>
           }
@@ -416,6 +422,9 @@ export function useInvoiceColumns(): DataTableColumns<Invoice> {
                 className="prose prose-sm"
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
+                }}
+                style={{
+                  color: colors.$3,
                 }}
               />
             </div>

--- a/src/pages/payments/common/hooks/usePaymentColumns.tsx
+++ b/src/pages/payments/common/hooks/usePaymentColumns.tsx
@@ -31,7 +31,7 @@ import {
   sanitizeHTML,
 } from '$app/common/helpers/html-string';
 import { useFormatNumber } from '$app/common/hooks/useFormatNumber';
-import { useColorScheme } from '$app/common/colors';
+import classNames from 'classnames';
 
 export const defaultColumns: string[] = [
   'status',
@@ -91,8 +91,6 @@ export function usePaymentColumns() {
 
   const paymentColumns = useAllPaymentColumns();
   type PaymentColumns = (typeof paymentColumns)[number];
-
-  const colors = useColorScheme();
 
   const formatMoney = useFormatMoney();
   const formatNumber = useFormatNumber();
@@ -303,12 +301,11 @@ export function usePaymentColumns() {
           tooltipElement={
             <div className="w-full max-h-48 overflow-auto whitespace-normal break-all">
               <article
-                className="prose prose-sm"
+                className={classNames('prose prose-sm', {
+                  'prose-invert': reactSettings.dark_mode,
+                })}
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
-                }}
-                style={{
-                  color: colors.$3,
                 }}
               />
             </div>

--- a/src/pages/payments/common/hooks/usePaymentColumns.tsx
+++ b/src/pages/payments/common/hooks/usePaymentColumns.tsx
@@ -31,6 +31,7 @@ import {
   sanitizeHTML,
 } from '$app/common/helpers/html-string';
 import { useFormatNumber } from '$app/common/hooks/useFormatNumber';
+import { useColorScheme } from '$app/common/colors';
 
 export const defaultColumns: string[] = [
   'status',
@@ -90,6 +91,8 @@ export function usePaymentColumns() {
 
   const paymentColumns = useAllPaymentColumns();
   type PaymentColumns = (typeof paymentColumns)[number];
+
+  const colors = useColorScheme();
 
   const formatMoney = useFormatMoney();
   const formatNumber = useFormatNumber();
@@ -303,6 +306,9 @@ export function usePaymentColumns() {
                 className="prose prose-sm"
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
+                }}
+                style={{
+                  color: colors.$3,
                 }}
               />
             </div>

--- a/src/pages/products/common/hooks.tsx
+++ b/src/pages/products/common/hooks.tsx
@@ -50,6 +50,7 @@ import {
   sanitizeHTML,
 } from '$app/common/helpers/html-string';
 import { useFormatNumber } from '$app/common/hooks/useFormatNumber';
+import { useColorScheme } from '$app/common/colors';
 
 export const defaultColumns: string[] = [
   'product_key',
@@ -102,6 +103,8 @@ export function useProductColumns() {
 
   const { dateFormat } = useCurrentCompanyDateFormats();
 
+  const colors = useColorScheme();
+
   const formatMoney = useFormatMoney();
   const formatNumber = useFormatNumber();
   const reactSettings = useReactSettings();
@@ -144,6 +147,9 @@ export function useProductColumns() {
                 className="prose prose-sm"
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
+                }}
+                style={{
+                  color: colors.$3,
                 }}
               />
             </div>

--- a/src/pages/products/common/hooks.tsx
+++ b/src/pages/products/common/hooks.tsx
@@ -50,7 +50,7 @@ import {
   sanitizeHTML,
 } from '$app/common/helpers/html-string';
 import { useFormatNumber } from '$app/common/hooks/useFormatNumber';
-import { useColorScheme } from '$app/common/colors';
+import classNames from 'classnames';
 
 export const defaultColumns: string[] = [
   'product_key',
@@ -103,8 +103,6 @@ export function useProductColumns() {
 
   const { dateFormat } = useCurrentCompanyDateFormats();
 
-  const colors = useColorScheme();
-
   const formatMoney = useFormatMoney();
   const formatNumber = useFormatNumber();
   const reactSettings = useReactSettings();
@@ -144,12 +142,11 @@ export function useProductColumns() {
           tooltipElement={
             <div className="w-full max-h-48 overflow-auto whitespace-normal break-all">
               <article
-                className="prose prose-sm"
+                className={classNames('prose prose-sm', {
+                  'prose-invert': reactSettings.dark_mode,
+                })}
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
-                }}
-                style={{
-                  color: colors.$3,
                 }}
               />
             </div>

--- a/src/pages/projects/common/hooks.tsx
+++ b/src/pages/projects/common/hooks.tsx
@@ -57,7 +57,7 @@ import {
   sanitizeHTML,
 } from '$app/common/helpers/html-string';
 import { useFormatNumber } from '$app/common/hooks/useFormatNumber';
-import { useColorScheme } from '$app/common/colors';
+import classNames from 'classnames';
 
 export const defaultColumns: string[] = [
   'name',
@@ -114,7 +114,6 @@ export function useProjectColumns() {
 
   const formatMoney = useFormatMoney();
 
-  const colors = useColorScheme();
   const reactSettings = useReactSettings();
 
   const projectColumns = useAllProjectColumns();
@@ -180,12 +179,11 @@ export function useProjectColumns() {
           tooltipElement={
             <div className="w-full max-h-48 overflow-auto whitespace-normal break-all">
               <article
-                className="prose prose-sm"
+                className={classNames('prose prose-sm', {
+                  'prose-invert': reactSettings.dark_mode,
+                })}
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
-                }}
-                style={{
-                  color: colors.$3,
                 }}
               />
             </div>
@@ -207,12 +205,11 @@ export function useProjectColumns() {
           tooltipElement={
             <div className="w-full max-h-48 overflow-auto whitespace-normal break-all">
               <article
-                className="prose prose-sm"
+                className={classNames('prose prose-sm', {
+                  'prose-invert': reactSettings.dark_mode,
+                })}
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
-                }}
-                style={{
-                  color: colors.$3,
                 }}
               />
             </div>

--- a/src/pages/projects/common/hooks.tsx
+++ b/src/pages/projects/common/hooks.tsx
@@ -57,6 +57,7 @@ import {
   sanitizeHTML,
 } from '$app/common/helpers/html-string';
 import { useFormatNumber } from '$app/common/hooks/useFormatNumber';
+import { useColorScheme } from '$app/common/colors';
 
 export const defaultColumns: string[] = [
   'name',
@@ -113,6 +114,7 @@ export function useProjectColumns() {
 
   const formatMoney = useFormatMoney();
 
+  const colors = useColorScheme();
   const reactSettings = useReactSettings();
 
   const projectColumns = useAllProjectColumns();
@@ -182,6 +184,9 @@ export function useProjectColumns() {
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
                 }}
+                style={{
+                  color: colors.$3,
+                }}
               />
             </div>
           }
@@ -205,6 +210,9 @@ export function useProjectColumns() {
                 className="prose prose-sm"
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
+                }}
+                style={{
+                  color: colors.$3,
                 }}
               />
             </div>

--- a/src/pages/projects/show/components/ProjectPrivateNotes.tsx
+++ b/src/pages/projects/show/components/ProjectPrivateNotes.tsx
@@ -8,6 +8,7 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
+import { useColorScheme } from '$app/common/colors';
 import { sanitizeHTML } from '$app/common/helpers/html-string';
 import { Project } from '$app/common/interfaces/project';
 import { InfoCard } from '$app/components/InfoCard';
@@ -22,6 +23,8 @@ export function ProjectPrivateNotes(props: Props) {
 
   const { project } = props;
 
+  const colors = useColorScheme();
+
   return (
     <>
       {Boolean(project && project.private_notes) && (
@@ -34,6 +37,9 @@ export function ProjectPrivateNotes(props: Props) {
                   className="prose prose-sm"
                   dangerouslySetInnerHTML={{
                     __html: sanitizeHTML(project.private_notes),
+                  }}
+                  style={{
+                    color: colors.$3,
                   }}
                 />
               </div>

--- a/src/pages/projects/show/components/ProjectPrivateNotes.tsx
+++ b/src/pages/projects/show/components/ProjectPrivateNotes.tsx
@@ -8,10 +8,11 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
-import { useColorScheme } from '$app/common/colors';
 import { sanitizeHTML } from '$app/common/helpers/html-string';
+import { useReactSettings } from '$app/common/hooks/useReactSettings';
 import { Project } from '$app/common/interfaces/project';
 import { InfoCard } from '$app/components/InfoCard';
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 
 interface Props {
@@ -23,7 +24,7 @@ export function ProjectPrivateNotes(props: Props) {
 
   const { project } = props;
 
-  const colors = useColorScheme();
+  const reactSettings = useReactSettings();
 
   return (
     <>
@@ -34,12 +35,11 @@ export function ProjectPrivateNotes(props: Props) {
             value={
               <div className="whitespace-normal max-h-56 overflow-y-auto">
                 <article
-                  className="prose prose-sm"
+                  className={classNames('prose prose-sm', {
+                    'prose-invert': reactSettings.dark_mode,
+                  })}
                   dangerouslySetInnerHTML={{
                     __html: sanitizeHTML(project.private_notes),
-                  }}
-                  style={{
-                    color: colors.$3,
                   }}
                 />
               </div>

--- a/src/pages/projects/show/components/ProjectPublicNotes.tsx
+++ b/src/pages/projects/show/components/ProjectPublicNotes.tsx
@@ -8,6 +8,7 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
+import { useColorScheme } from '$app/common/colors';
 import { sanitizeHTML } from '$app/common/helpers/html-string';
 import { Project } from '$app/common/interfaces/project';
 import { InfoCard } from '$app/components/InfoCard';
@@ -22,6 +23,8 @@ export function ProjectPublicNotes(props: Props) {
 
   const { project } = props;
 
+  const colors = useColorScheme();
+
   return (
     <>
       {Boolean(project && project.public_notes) && (
@@ -34,6 +37,9 @@ export function ProjectPublicNotes(props: Props) {
                   className="prose prose-sm"
                   dangerouslySetInnerHTML={{
                     __html: sanitizeHTML(project.public_notes),
+                  }}
+                  style={{
+                    color: colors.$3,
                   }}
                 />
               </div>

--- a/src/pages/projects/show/components/ProjectPublicNotes.tsx
+++ b/src/pages/projects/show/components/ProjectPublicNotes.tsx
@@ -8,10 +8,11 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
-import { useColorScheme } from '$app/common/colors';
 import { sanitizeHTML } from '$app/common/helpers/html-string';
+import { useReactSettings } from '$app/common/hooks/useReactSettings';
 import { Project } from '$app/common/interfaces/project';
 import { InfoCard } from '$app/components/InfoCard';
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 
 interface Props {
@@ -23,7 +24,7 @@ export function ProjectPublicNotes(props: Props) {
 
   const { project } = props;
 
-  const colors = useColorScheme();
+  const reactSettings = useReactSettings();
 
   return (
     <>
@@ -34,12 +35,11 @@ export function ProjectPublicNotes(props: Props) {
             value={
               <div className="whitespace-normal max-h-56 overflow-y-auto">
                 <article
-                  className="prose prose-sm"
+                  className={classNames('prose prose-sm', {
+                    'prose-invert': reactSettings.dark_mode,
+                  })}
                   dangerouslySetInnerHTML={{
                     __html: sanitizeHTML(project.public_notes),
-                  }}
-                  style={{
-                    color: colors.$3,
                   }}
                 />
               </div>

--- a/src/pages/quotes/common/components/QuoteSlider.tsx
+++ b/src/pages/quotes/common/components/QuoteSlider.tsx
@@ -53,6 +53,7 @@ import { QuoteActivity } from '$app/common/interfaces/quote-activity';
 import { useInvoiceQuery } from '$app/common/queries/invoices';
 import { InvoiceStatus } from '$app/pages/invoices/common/components/InvoiceStatus';
 import { sanitizeHTML } from '$app/common/helpers/html-string';
+import { useColorScheme } from '$app/common/colors';
 
 export const quoteSliderAtom = atom<Quote | null>(null);
 export const quoteSliderVisibilityAtom = atom(false);
@@ -112,6 +113,8 @@ export function QuoteSlider() {
     showEditAction: true,
   });
   const { dateFormat } = useCurrentCompanyDateFormats();
+
+  const colors = useColorScheme();
 
   const formatMoney = useFormatMoney();
   const hasPermission = useHasPermission();
@@ -283,6 +286,9 @@ export function QuoteSlider() {
                       __html: sanitizeHTML(
                         (resource?.reminder_schedule as string) ?? ''
                       ),
+                    }}
+                    style={{
+                      color: colors.$3,
                     }}
                   />
                 }

--- a/src/pages/quotes/common/components/QuoteSlider.tsx
+++ b/src/pages/quotes/common/components/QuoteSlider.tsx
@@ -53,7 +53,8 @@ import { QuoteActivity } from '$app/common/interfaces/quote-activity';
 import { useInvoiceQuery } from '$app/common/queries/invoices';
 import { InvoiceStatus } from '$app/pages/invoices/common/components/InvoiceStatus';
 import { sanitizeHTML } from '$app/common/helpers/html-string';
-import { useColorScheme } from '$app/common/colors';
+import classNames from 'classnames';
+import { useReactSettings } from '$app/common/hooks/useReactSettings';
 
 export const quoteSliderAtom = atom<Quote | null>(null);
 export const quoteSliderVisibilityAtom = atom(false);
@@ -114,7 +115,7 @@ export function QuoteSlider() {
   });
   const { dateFormat } = useCurrentCompanyDateFormats();
 
-  const colors = useColorScheme();
+  const reactSettings = useReactSettings();
 
   const formatMoney = useFormatMoney();
   const hasPermission = useHasPermission();
@@ -281,14 +282,13 @@ export function QuoteSlider() {
                 width="auto"
                 tooltipElement={
                   <article
-                    className="prose prose-sm"
+                    className={classNames('prose prose-sm', {
+                      'prose-invert': reactSettings.dark_mode,
+                    })}
                     dangerouslySetInnerHTML={{
                       __html: sanitizeHTML(
                         (resource?.reminder_schedule as string) ?? ''
                       ),
-                    }}
-                    style={{
-                      color: colors.$3,
                     }}
                   />
                 }

--- a/src/pages/quotes/common/hooks.tsx
+++ b/src/pages/quotes/common/hooks.tsx
@@ -100,6 +100,7 @@ import {
   sanitizeHTML,
 } from '$app/common/helpers/html-string';
 import { useFormatNumber } from '$app/common/hooks/useFormatNumber';
+import { useColorScheme } from '$app/common/colors';
 
 export type ChangeHandler = <T extends keyof Quote>(
   property: T,
@@ -615,6 +616,7 @@ export function useQuoteColumns() {
   const quoteColumns = useAllQuoteColumns();
   type QuoteColumns = (typeof quoteColumns)[number];
 
+  const colors = useColorScheme();
   const accentColor = useAccentColor();
   const navigate = useNavigate();
 
@@ -900,6 +902,9 @@ export function useQuoteColumns() {
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
                 }}
+                style={{
+                  color: colors.$3,
+                }}
               />
             </div>
           }
@@ -923,6 +928,9 @@ export function useQuoteColumns() {
                 className="prose prose-sm"
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
+                }}
+                style={{
+                  color: colors.$3,
                 }}
               />
             </div>

--- a/src/pages/quotes/common/hooks.tsx
+++ b/src/pages/quotes/common/hooks.tsx
@@ -100,7 +100,7 @@ import {
   sanitizeHTML,
 } from '$app/common/helpers/html-string';
 import { useFormatNumber } from '$app/common/hooks/useFormatNumber';
-import { useColorScheme } from '$app/common/colors';
+import classNames from 'classnames';
 
 export type ChangeHandler = <T extends keyof Quote>(
   property: T,
@@ -616,7 +616,6 @@ export function useQuoteColumns() {
   const quoteColumns = useAllQuoteColumns();
   type QuoteColumns = (typeof quoteColumns)[number];
 
-  const colors = useColorScheme();
   const accentColor = useAccentColor();
   const navigate = useNavigate();
 
@@ -898,12 +897,11 @@ export function useQuoteColumns() {
           tooltipElement={
             <div className="w-full max-h-48 overflow-auto whitespace-normal break-all">
               <article
-                className="prose prose-sm"
+                className={classNames('prose prose-sm', {
+                  'prose-invert': reactSettings.dark_mode,
+                })}
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
-                }}
-                style={{
-                  color: colors.$3,
                 }}
               />
             </div>
@@ -925,12 +923,11 @@ export function useQuoteColumns() {
           tooltipElement={
             <div className="w-full max-h-48 overflow-auto whitespace-normal break-all">
               <article
-                className="prose prose-sm"
+                className={classNames('prose prose-sm', {
+                  'prose-invert': reactSettings.dark_mode,
+                })}
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
-                }}
-                style={{
-                  color: colors.$3,
                 }}
               />
             </div>

--- a/src/pages/recurring-expenses/common/hooks.tsx
+++ b/src/pages/recurring-expenses/common/hooks.tsx
@@ -61,7 +61,7 @@ import {
   sanitizeHTML,
 } from '$app/common/helpers/html-string';
 import { useFormatNumber } from '$app/common/hooks/useFormatNumber';
-import { useColorScheme } from '$app/common/colors';
+import classNames from 'classnames';
 
 export const defaultColumns: string[] = [
   'status',
@@ -134,8 +134,6 @@ export function useRecurringExpenseColumns() {
   const disableNavigation = useDisableNavigation();
 
   const { dateFormat } = useCurrentCompanyDateFormats();
-
-  const colors = useColorScheme();
 
   const formatMoney = useFormatMoney();
   const formatNumber = useFormatNumber();
@@ -241,12 +239,11 @@ export function useRecurringExpenseColumns() {
           tooltipElement={
             <div className="w-full max-h-48 overflow-auto whitespace-normal break-all">
               <article
-                className="prose prose-sm"
+                className={classNames('prose prose-sm', {
+                  'prose-invert': reactSettings.dark_mode,
+                })}
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
-                }}
-                style={{
-                  color: colors.$3,
                 }}
               />
             </div>
@@ -355,12 +352,11 @@ export function useRecurringExpenseColumns() {
           tooltipElement={
             <div className="w-full max-h-48 overflow-auto whitespace-normal break-all">
               <article
-                className="prose prose-sm"
+                className={classNames('prose prose-sm', {
+                  'prose-invert': reactSettings.dark_mode,
+                })}
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
-                }}
-                style={{
-                  color: colors.$3,
                 }}
               />
             </div>

--- a/src/pages/recurring-expenses/common/hooks.tsx
+++ b/src/pages/recurring-expenses/common/hooks.tsx
@@ -61,6 +61,7 @@ import {
   sanitizeHTML,
 } from '$app/common/helpers/html-string';
 import { useFormatNumber } from '$app/common/hooks/useFormatNumber';
+import { useColorScheme } from '$app/common/colors';
 
 export const defaultColumns: string[] = [
   'status',
@@ -133,6 +134,8 @@ export function useRecurringExpenseColumns() {
   const disableNavigation = useDisableNavigation();
 
   const { dateFormat } = useCurrentCompanyDateFormats();
+
+  const colors = useColorScheme();
 
   const formatMoney = useFormatMoney();
   const formatNumber = useFormatNumber();
@@ -241,6 +244,9 @@ export function useRecurringExpenseColumns() {
                 className="prose prose-sm"
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
+                }}
+                style={{
+                  color: colors.$3,
                 }}
               />
             </div>
@@ -352,6 +358,9 @@ export function useRecurringExpenseColumns() {
                 className="prose prose-sm"
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
+                }}
+                style={{
+                  color: colors.$3,
                 }}
               />
             </div>

--- a/src/pages/recurring-invoices/common/hooks.tsx
+++ b/src/pages/recurring-invoices/common/hooks.tsx
@@ -79,6 +79,7 @@ import {
   sanitizeHTML,
 } from '$app/common/helpers/html-string';
 import { useFormatNumber } from '$app/common/hooks/useFormatNumber';
+import { useColorScheme } from '$app/common/colors';
 
 interface RecurringInvoiceUtilitiesProps {
   client?: Client;
@@ -524,6 +525,8 @@ export function useRecurringInvoiceColumns() {
   const recurringInvoiceColumns = useAllRecurringInvoiceColumns();
   type RecurringInvoiceColumns = (typeof recurringInvoiceColumns)[number];
 
+  const colors = useColorScheme();
+
   const formatMoney = useFormatMoney();
   const reactSettings = useReactSettings();
   const formatCustomFieldValue = useFormatCustomFieldValue();
@@ -714,6 +717,9 @@ export function useRecurringInvoiceColumns() {
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
                 }}
+                style={{
+                  color: colors.$3,
+                }}
               />
             </div>
           }
@@ -737,6 +743,9 @@ export function useRecurringInvoiceColumns() {
                 className="prose prose-sm"
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
+                }}
+                style={{
+                  color: colors.$3,
                 }}
               />
             </div>

--- a/src/pages/recurring-invoices/common/hooks.tsx
+++ b/src/pages/recurring-invoices/common/hooks.tsx
@@ -79,7 +79,7 @@ import {
   sanitizeHTML,
 } from '$app/common/helpers/html-string';
 import { useFormatNumber } from '$app/common/hooks/useFormatNumber';
-import { useColorScheme } from '$app/common/colors';
+import classNames from 'classnames';
 
 interface RecurringInvoiceUtilitiesProps {
   client?: Client;
@@ -525,8 +525,6 @@ export function useRecurringInvoiceColumns() {
   const recurringInvoiceColumns = useAllRecurringInvoiceColumns();
   type RecurringInvoiceColumns = (typeof recurringInvoiceColumns)[number];
 
-  const colors = useColorScheme();
-
   const formatMoney = useFormatMoney();
   const reactSettings = useReactSettings();
   const formatCustomFieldValue = useFormatCustomFieldValue();
@@ -713,12 +711,11 @@ export function useRecurringInvoiceColumns() {
           tooltipElement={
             <div className="w-full max-h-48 overflow-auto whitespace-normal break-all">
               <article
-                className="prose prose-sm"
+                className={classNames('prose prose-sm', {
+                  'prose-invert': reactSettings.dark_mode,
+                })}
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
-                }}
-                style={{
-                  color: colors.$3,
                 }}
               />
             </div>
@@ -740,12 +737,11 @@ export function useRecurringInvoiceColumns() {
           tooltipElement={
             <div className="w-full max-h-48 overflow-auto whitespace-normal break-all">
               <article
-                className="prose prose-sm"
+                className={classNames('prose prose-sm', {
+                  'prose-invert': reactSettings.dark_mode,
+                })}
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
-                }}
-                style={{
-                  color: colors.$3,
                 }}
               />
             </div>

--- a/src/pages/tasks/common/hooks.tsx
+++ b/src/pages/tasks/common/hooks.tsx
@@ -77,7 +77,7 @@ import {
   extractTextFromHTML,
   sanitizeHTML,
 } from '$app/common/helpers/html-string';
-import { useColorScheme } from '$app/common/colors';
+import classNames from 'classnames';
 
 export const defaultColumns: string[] = [
   'status',
@@ -136,7 +136,6 @@ export function useTaskColumns() {
   const disableNavigation = useDisableNavigation();
   const formatCustomFieldValue = useFormatCustomFieldValue();
 
-  const colors = useColorScheme();
   const company = useCurrentCompany();
   const reactSettings = useReactSettings();
 
@@ -247,12 +246,11 @@ export function useTaskColumns() {
           tooltipElement={
             <div className="w-full max-h-48 overflow-auto whitespace-normal break-all">
               <article
-                className="prose prose-sm"
+                className={classNames('prose prose-sm', {
+                  'prose-invert': reactSettings.dark_mode,
+                })}
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
-                }}
-                style={{
-                  color: colors.$3,
                 }}
               />
             </div>

--- a/src/pages/tasks/common/hooks.tsx
+++ b/src/pages/tasks/common/hooks.tsx
@@ -77,6 +77,7 @@ import {
   extractTextFromHTML,
   sanitizeHTML,
 } from '$app/common/helpers/html-string';
+import { useColorScheme } from '$app/common/colors';
 
 export const defaultColumns: string[] = [
   'status',
@@ -135,10 +136,12 @@ export function useTaskColumns() {
   const disableNavigation = useDisableNavigation();
   const formatCustomFieldValue = useFormatCustomFieldValue();
 
+  const colors = useColorScheme();
   const company = useCurrentCompany();
-  const formatMoney = useFormatMoney();
   const reactSettings = useReactSettings();
+
   const navigate = useNavigate();
+  const formatMoney = useFormatMoney();
 
   const taskColumns = useAllTaskColumns();
   type TaskColumns = (typeof taskColumns)[number];
@@ -247,6 +250,9 @@ export function useTaskColumns() {
                 className="prose prose-sm"
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
+                }}
+                style={{
+                  color: colors.$3,
                 }}
               />
             </div>

--- a/src/pages/transactions/common/hooks/useTransactionColumns.tsx
+++ b/src/pages/transactions/common/hooks/useTransactionColumns.tsx
@@ -29,10 +29,12 @@ import {
   extractTextFromHTML,
   sanitizeHTML,
 } from '$app/common/helpers/html-string';
+import { useColorScheme } from '$app/common/colors';
 
 export function useTransactionColumns() {
   const { t } = useTranslation();
 
+  const colors = useColorScheme();
   const company = useCurrentCompany();
   const { dateFormat } = useCurrentCompanyDateFormats();
 
@@ -108,6 +110,9 @@ export function useTransactionColumns() {
                 className="prose prose-sm"
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(cleanDescriptionText(value as string)),
+                }}
+                style={{
+                  color: colors.$3,
                 }}
               />
             </div>

--- a/src/pages/transactions/common/hooks/useTransactionColumns.tsx
+++ b/src/pages/transactions/common/hooks/useTransactionColumns.tsx
@@ -29,13 +29,14 @@ import {
   extractTextFromHTML,
   sanitizeHTML,
 } from '$app/common/helpers/html-string';
-import { useColorScheme } from '$app/common/colors';
+import classNames from 'classnames';
+import { useReactSettings } from '$app/common/hooks/useReactSettings';
 
 export function useTransactionColumns() {
   const { t } = useTranslation();
 
-  const colors = useColorScheme();
   const company = useCurrentCompany();
+  const reactSettings = useReactSettings();
   const { dateFormat } = useCurrentCompanyDateFormats();
 
   const formatMoney = useFormatMoney();
@@ -107,12 +108,11 @@ export function useTransactionColumns() {
           tooltipElement={
             <div className="w-full max-h-48 overflow-auto whitespace-normal break-all">
               <article
-                className="prose prose-sm"
+                className={classNames('prose prose-sm', {
+                  'prose-invert': reactSettings.dark_mode,
+                })}
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(cleanDescriptionText(value as string)),
-                }}
-                style={{
-                  color: colors.$3,
                 }}
               />
             </div>

--- a/src/pages/vendors/common/hooks.tsx
+++ b/src/pages/vendors/common/hooks.tsx
@@ -29,7 +29,7 @@ import {
   extractTextFromHTML,
   sanitizeHTML,
 } from '$app/common/helpers/html-string';
-import { useColorScheme } from '$app/common/colors';
+import classNames from 'classnames';
 
 export const defaultColumns: string[] = [
   'number',
@@ -85,7 +85,6 @@ export function useVendorColumns() {
 
   const disableNavigation = useDisableNavigation();
 
-  const colors = useColorScheme();
   const reactSettings = useReactSettings();
 
   const resolveCountry = useResolveCountry();
@@ -259,12 +258,11 @@ export function useVendorColumns() {
           tooltipElement={
             <div className="w-full max-h-48 overflow-auto whitespace-normal break-all">
               <article
-                className="prose prose-sm"
+                className={classNames('prose prose-sm', {
+                  'prose-invert': reactSettings.dark_mode,
+                })}
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
-                }}
-                style={{
-                  color: colors.$3,
                 }}
               />
             </div>

--- a/src/pages/vendors/common/hooks.tsx
+++ b/src/pages/vendors/common/hooks.tsx
@@ -29,6 +29,7 @@ import {
   extractTextFromHTML,
   sanitizeHTML,
 } from '$app/common/helpers/html-string';
+import { useColorScheme } from '$app/common/colors';
 
 export const defaultColumns: string[] = [
   'number',
@@ -84,7 +85,9 @@ export function useVendorColumns() {
 
   const disableNavigation = useDisableNavigation();
 
+  const colors = useColorScheme();
   const reactSettings = useReactSettings();
+
   const resolveCountry = useResolveCountry();
   const resolveCurrency = useResolveCurrency();
   const formatCustomFieldValue = useFormatCustomFieldValue();
@@ -259,6 +262,9 @@ export function useVendorColumns() {
                 className="prose prose-sm"
                 dangerouslySetInnerHTML={{
                   __html: sanitizeHTML(value as string),
+                }}
+                style={{
+                  color: colors.$3,
                 }}
               />
             </div>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adjustments to the "prose" class across the app for dark mode, addressing issues with colors. Screenshot:

<img width="782" alt="Screenshot 2024-07-23 at 11 19 27" src="https://github.com/user-attachments/assets/ff1bc4f0-b9d2-4fcd-bc1c-0e395835fb2d">

Let me know your thoughts.