### PR TITLE
[Bugfix] Label When Self-hosted Plan Is Paid

### DIFF
--- a/src/pages/settings/account-management/component/Plan.tsx
+++ b/src/pages/settings/account-management/component/Plan.tsx
@@ -41,7 +41,8 @@ export function Plan() {
         ) : (
           <span>
             {t(
-              account?.plan_expires !== ''
+              account?.plan_expires !== '' &&
+                !dayjs(account.plan_expires).isBefore(dayjs())
                 ? 'licensed'
                 : 'plan_free_self_hosted'
             )}

--- a/src/pages/settings/account-management/component/Plan.tsx
+++ b/src/pages/settings/account-management/component/Plan.tsx
@@ -39,7 +39,13 @@ export function Plan() {
             </span>
           </>
         ) : (
-          <span>{t('plan_free_self_hosted')}</span>
+          <span>
+            {t(
+              account?.plan_expires !== ''
+                ? 'licensed'
+                : 'plan_free_self_hosted'
+            )}
+          </span>
         )}
       </Element>
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adjusting the label on the `account_management` page for self-hosted users with a paid plan. The label will use the `"licensed"` translation keyword when `account.plan_expires` is not empty, or in other words, when `plan_expires` is populated.

`Note`: We are missing the "licensed" translation keyword from the files. If you agree with this addition, please add it to the files.

Let me know your thoughts.

Closes #1844 