### PR TITLE
[Bugfix] Removing "New User" Option From Email Settings Selector

### DIFF
--- a/src/components/users/UserSelector.tsx
+++ b/src/components/users/UserSelector.tsx
@@ -21,6 +21,7 @@ import { usePreventNavigation } from '$app/common/hooks/usePreventNavigation';
 interface UserSelectorProps extends GenericSelectorProps<User> {
   endpoint?: string;
   staleTime?: number;
+  withoutAction?: boolean;
 }
 
 export function UserSelector(props: UserSelectorProps) {
@@ -55,7 +56,7 @@ export function UserSelector(props: UserSelectorProps) {
           preventNavigation({
             fn: () => navigate('/settings/users'),
           }),
-        visible: isAdmin || isOwner,
+        visible: (isAdmin || isOwner) && !props.withoutAction,
       }}
       onChange={(entry) =>
         entry.resource ? props.onChange(entry.resource) : null

--- a/src/pages/settings/email-settings/EmailSettings.tsx
+++ b/src/pages/settings/email-settings/EmailSettings.tsx
@@ -247,7 +247,9 @@ export function EmailSettings() {
               leftSide={
                 <PropertyCheckbox
                   propertyKey="merge_e_invoice_to_pdf"
-                  labelElement={<SettingsLabel label={t('merge_e_invoice_to_pdf')} />}
+                  labelElement={
+                    <SettingsLabel label={t('merge_e_invoice_to_pdf')} />
+                  }
                 />
               }
             >
@@ -425,6 +427,7 @@ export function EmailSettings() {
                   handleChange('settings.gmail_sending_user_id', '0')
                 }
                 readonly={disableSettingsField('gmail_sending_user_id')}
+                withoutAction
                 errorMessage={errors?.errors['settings.gmail_sending_user_id']}
               />
             </Element>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the removal of the "New User" option from the User selector on the Email Settings page. Screenshot:

![Screenshot 2024-07-26 at 16 14 31](https://github.com/user-attachments/assets/afdda50b-06de-420a-b689-0cbfa65ddf5d)

Let me know your thoughts.

Closes #1857 