### PR TITLE
[Bugfix] Changing "product_key" After Entering Text In Product Selector

### DIFF
--- a/src/components/forms/Combobox.tsx
+++ b/src/components/forms/Combobox.tsx
@@ -64,6 +64,7 @@ export interface ComboboxStaticProps<T = any> {
   errorMessage?: string | string[];
   clearInputAfterSelection?: boolean;
   isDataLoading?: boolean;
+  onInputValueChange?: (value: string) => void;
 }
 
 export type Nullable<T> = T | null;
@@ -104,6 +105,7 @@ export function Combobox<T = any>({
   clearInputAfterSelection,
   onEmptyValues,
   onFocus,
+  onInputValueChange,
 }: ComboboxStaticProps<T>) {
   const [inputValue, setInputValue] = useState(
     String(inputOptions.value ?? '')
@@ -329,6 +331,7 @@ export function Combobox<T = any>({
                 onFocus();
               }
             }}
+            onBlur={() => onInputValueChange?.(inputValue ?? '')}
             placeholder={inputOptions.placeholder}
             disabled={readonly}
             defaultValue={
@@ -783,6 +786,7 @@ export interface ComboboxAsyncProps<T> {
   disableWithQueryParameter?: boolean;
   errorMessage?: string | string[];
   clearInputAfterSelection?: boolean;
+  onInputValueChange?: (value: string) => void;
 }
 
 export function ComboboxAsync<T = any>({
@@ -803,6 +807,7 @@ export function ComboboxAsync<T = any>({
   disableWithQueryParameter,
   errorMessage,
   clearInputAfterSelection,
+  onInputValueChange,
 }: ComboboxAsyncProps<T>) {
   const [entries, setEntries] = useState<Entry<T>[]>([]);
   const [url, setUrl] = useState(endpoint);
@@ -968,6 +973,7 @@ export function ComboboxAsync<T = any>({
         clearInputAfterSelection={clearInputAfterSelection}
         isDataLoading={isLoading}
         onFocus={() => setEnableQuery(true)}
+        onInputValueChange={onInputValueChange}
       />
     );
   }
@@ -990,6 +996,7 @@ export function ComboboxAsync<T = any>({
       errorMessage={errorMessage}
       clearInputAfterSelection={clearInputAfterSelection}
       isDataLoading={isLoading}
+      onInputValueChange={onInputValueChange}
     />
   );
 }

--- a/src/components/products/ProductSelector.tsx
+++ b/src/components/products/ProductSelector.tsx
@@ -29,6 +29,7 @@ interface Props {
   onInputFocus?: () => unknown;
   errorMessage?: string | string[];
   displayStockQuantity?: boolean;
+  onInputValueChange?: (inputValue: string) => void;
 }
 
 export function ProductSelector(props: Props) {
@@ -89,6 +90,7 @@ export function ProductSelector(props: Props) {
           visible: hasPermission('create_product'),
         }}
         onDismiss={props.onClearButtonClick}
+        onInputValueChange={props.onInputValueChange}
         sortBy="product_key|asc"
         nullable
         key="product_selector"

--- a/src/pages/invoices/common/hooks/useResolveInputField.tsx
+++ b/src/pages/invoices/common/hooks/useResolveInputField.tsx
@@ -333,6 +333,7 @@ export function useResolveInputField(props: Props) {
           clearButton
           onClearButtonClick={() => handleProductChange(index, '', null)}
           displayStockQuantity={location.pathname.startsWith('/invoices')}
+          onInputValueChange={(value) => onChange(property, value, index)}
         />
       );
     }


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for the 'product_key' property value not changing after modifying text in the product selector. Now, the value of the 'product_key' prop will change on the `onBlur` event after entering new text. Let me know your thoughts.

Closes #1938 