### PR TITLE
[Bugfix] Setting "product_key" Through Combo Input Value && Test Implementation

### DIFF
--- a/src/components/forms/Combobox.tsx
+++ b/src/components/forms/Combobox.tsx
@@ -327,9 +327,7 @@ export function Combobox<T = any>({
         >
           <input
             type="text"
-            onChange={(e) => {
-              handleInputChange(e.target.value);
-            }}
+            onChange={(e) => handleInputChange(e.target.value)}
             onKeyDown={handleKeyDown}
             onFocus={() => {
               setIsOpen(true);
@@ -350,6 +348,7 @@ export function Combobox<T = any>({
               borderColor: colors.$5,
               color: colors.$3,
             }}
+            data-cy="comboboxInput"
             tabIndex={-1}
           />
 

--- a/src/components/forms/Combobox.tsx
+++ b/src/components/forms/Combobox.tsx
@@ -64,6 +64,7 @@ export interface ComboboxStaticProps<T = any> {
   errorMessage?: string | string[];
   clearInputAfterSelection?: boolean;
   isDataLoading?: boolean;
+  onInputValueChange?: (value: string) => void;
 }
 
 export type Nullable<T> = T | null;
@@ -104,6 +105,7 @@ export function Combobox<T = any>({
   clearInputAfterSelection,
   onEmptyValues,
   onFocus,
+  onInputValueChange,
 }: ComboboxStaticProps<T>) {
   const [inputValue, setInputValue] = useState(
     String(inputOptions.value ?? '')
@@ -113,6 +115,7 @@ export function Combobox<T = any>({
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
 
   const comboboxRef = useRef<HTMLDivElement>(null);
+  const selectorRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   let filteredOptions =
@@ -277,6 +280,10 @@ export function Combobox<T = any>({
     onChange(option);
   });
 
+  useClickAway(selectorRef, () => {
+    onInputValueChange?.(inputValue);
+  });
+
   useDebounce(
     () => {
       if (inputValue === '' && filteredOptions.length > 0) {
@@ -320,7 +327,9 @@ export function Combobox<T = any>({
         >
           <input
             type="text"
-            onChange={(e) => handleInputChange(e.target.value)}
+            onChange={(e) => {
+              handleInputChange(e.target.value);
+            }}
             onKeyDown={handleKeyDown}
             onFocus={() => {
               setIsOpen(true);
@@ -783,6 +792,7 @@ export interface ComboboxAsyncProps<T> {
   disableWithQueryParameter?: boolean;
   errorMessage?: string | string[];
   clearInputAfterSelection?: boolean;
+  onInputValueChange?: (value: string) => void;
 }
 
 export function ComboboxAsync<T = any>({
@@ -803,6 +813,7 @@ export function ComboboxAsync<T = any>({
   disableWithQueryParameter,
   errorMessage,
   clearInputAfterSelection,
+  onInputValueChange,
 }: ComboboxAsyncProps<T>) {
   const [entries, setEntries] = useState<Entry<T>[]>([]);
   const [url, setUrl] = useState(endpoint);
@@ -968,6 +979,7 @@ export function ComboboxAsync<T = any>({
         clearInputAfterSelection={clearInputAfterSelection}
         isDataLoading={isLoading}
         onFocus={() => setEnableQuery(true)}
+        onInputValueChange={onInputValueChange}
       />
     );
   }
@@ -990,6 +1002,7 @@ export function ComboboxAsync<T = any>({
       errorMessage={errorMessage}
       clearInputAfterSelection={clearInputAfterSelection}
       isDataLoading={isLoading}
+      onInputValueChange={onInputValueChange}
     />
   );
 }

--- a/src/components/products/ProductSelector.tsx
+++ b/src/components/products/ProductSelector.tsx
@@ -29,6 +29,7 @@ interface Props {
   onInputFocus?: () => unknown;
   errorMessage?: string | string[];
   displayStockQuantity?: boolean;
+  onInputValueChange?: (value: string) => void;
 }
 
 export function ProductSelector(props: Props) {
@@ -83,6 +84,7 @@ export function ProductSelector(props: Props) {
           ),
         }}
         onChange={(product) => props.onChange && props.onChange(product)}
+        onInputValueChange={props.onInputValueChange}
         action={{
           label: t('new_product'),
           onClick: () => setIsModalOpen(true),

--- a/src/pages/invoices/common/hooks/useResolveInputField.tsx
+++ b/src/pages/invoices/common/hooks/useResolveInputField.tsx
@@ -331,6 +331,7 @@ export function useResolveInputField(props: Props) {
             product && onProductChange(index, product.product_key, product)
           }
           clearButton
+          onInputValueChange={(value) => onChange('product_key', value, index)}
           onClearButtonClick={() => handleProductChange(index, '', null)}
           displayStockQuantity={location.pathname.startsWith('/invoices')}
         />

--- a/tests/e2e/invoices.spec.ts
+++ b/tests/e2e/invoices.spec.ts
@@ -770,6 +770,8 @@ test('Enter Payment displayed with creation permissions', async ({ page }) => {
 test('Second and Third Custom email sending template is displayed', async ({
   page,
 }) => {
+  await page.waitForTimeout(15000);
+
   await login(page);
 
   await page
@@ -1036,6 +1038,101 @@ test('Prevent back button', async ({ page }) => {
     .click();
 
   await page.waitForURL('**/invoices/create');
+
+  await logout(page);
+});
+
+test('Products combobox various selections', async ({ page }) => {
+  await login(page);
+
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Invoices', exact: true })
+    .click();
+
+  await page
+    .getByRole('main')
+    .getByRole('link', { name: 'New Invoice' })
+    .click();
+
+  await page.waitForTimeout(1000);
+
+  await page.getByRole('option').first().click();
+
+  await page.getByRole('button', { name: 'Add Item' }).first().click();
+
+  await page.locator('[data-cy="comboboxInput"]').first().click();
+
+  await page.waitForTimeout(500);
+
+  await page.locator('[data-combobox-element-id="0"]').first().click();
+
+  await page.waitForTimeout(100);
+
+  expect(
+    (await page.locator('[id="notes"]').first().inputValue()) ===
+      'Et aliquid soluta.'
+  ).toBeTruthy();
+
+  await page.getByRole('button', { name: 'Add Item' }).first().click();
+
+  await page.locator('[data-cy="comboboxInput"]').nth(1).click();
+
+  await page.waitForTimeout(500);
+
+  await page.locator('[data-cy="comboboxInput"]').nth(1).fill('Qui');
+
+  await page.waitForTimeout(200);
+
+  await page.locator('[data-combobox-element-id="0"]').first().click();
+
+  await page.waitForTimeout(100);
+
+  expect(
+    (await page.locator('[id="notes"]').nth(1).inputValue()) ===
+      'Et aliquid soluta.'
+  ).toBeTruthy();
+
+  await page.getByRole('button', { name: 'Add Item' }).first().click();
+
+  await page.locator('[data-cy="comboboxInput"]').nth(2).click();
+
+  await page.waitForTimeout(500);
+
+  await page.keyboard.press('ArrowDown');
+
+  await page.waitForTimeout(50);
+
+  await page.keyboard.press('ArrowDown');
+
+  await page.keyboard.press('Enter');
+
+  await page.waitForTimeout(100);
+
+  expect(
+    (await page.locator('[id="notes"]').nth(2).inputValue()) ===
+      'Atque non quibusdam.'
+  ).toBeTruthy();
+
+  await page.getByRole('button', { name: 'Add Item' }).first().click();
+
+  await page.locator('[data-cy="comboboxInput"]').nth(3).click();
+
+  await page.waitForTimeout(500);
+
+  await page
+    .locator('[data-cy="comboboxInput"]')
+    .nth(3)
+    .fill('test product name');
+
+  await page.getByRole('button', { name: 'Save' }).click();
+
+  await expect(page.getByText('Successfully created invoice')).toBeVisible();
+
+  expect(
+    (await page.locator('[data-cy="comboboxInput"]').nth(3).inputValue()) ===
+      'test product name'
+  ).toBeTruthy();
 
   await logout(page);
 });

--- a/tests/e2e/invoices.spec.ts
+++ b/tests/e2e/invoices.spec.ts
@@ -770,8 +770,6 @@ test('Enter Payment displayed with creation permissions', async ({ page }) => {
 test('Second and Third Custom email sending template is displayed', async ({
   page,
 }) => {
-  await page.waitForTimeout(15000);
-
   await login(page);
 
   await page


### PR DESCRIPTION
@beganovich @turbo124 The PR reintroduces the functionality for entering the "product_key" property of a line item by simply typing text into the product selector input field. Once saved, the API will automatically create the product. I implemented a different approach because the previous one caused an issue. Additionally, I created a test that covers all scenarios (`manual selection`, `selection with keyword`, `selection with entered filtering keyword`, and `selection with entering a custom name for the product to allow API creation of the product`). Let me know your thoughts.