### PR TITLE
[Bugfix] Breadcrumbs Issue On Tax Rates and Task Statuses Pages | Production Issue

### DIFF
--- a/src/pages/settings/task-statuses/Create.tsx
+++ b/src/pages/settings/task-statuses/Create.tsx
@@ -20,7 +20,6 @@ import { useTitle } from '$app/common/hooks/useTitle';
 import { TaskStatus } from '$app/common/interfaces/task-status';
 import { ValidationBag } from '$app/common/interfaces/validation-bag';
 import { useBlankTaskStatusQuery } from '$app/common/queries/task-statuses';
-import { Container } from '$app/components/Container';
 import { ColorPicker } from '$app/components/forms/ColorPicker';
 import { Icon } from '$app/components/icons/Icon';
 import { Settings } from '$app/components/layouts/Settings';
@@ -114,8 +113,8 @@ export function Create() {
   ];
 
   return (
-    <Settings title={t('task_statuses')} breadcrumbs={[]}>
-      <Container className="space-y-6" breadcrumbs={pages}>
+    <Settings title={t('task_statuses')} breadcrumbs={pages}>
+      <div className="max-w-3xl">
         <Card
           title={documentTitle}
           withSaveButton
@@ -139,7 +138,7 @@ export function Create() {
             />
           </CardContainer>
         </Card>
-      </Container>
+      </div>
     </Settings>
   );
 }

--- a/src/pages/settings/task-statuses/Edit.tsx
+++ b/src/pages/settings/task-statuses/Edit.tsx
@@ -20,7 +20,6 @@ import { TaskStatus } from '$app/common/interfaces/task-status';
 import { ValidationBag } from '$app/common/interfaces/validation-bag';
 import { useTaskStatusQuery } from '$app/common/queries/task-statuses';
 import { Badge } from '$app/components/Badge';
-import { Container } from '$app/components/Container';
 import { ColorPicker } from '$app/components/forms/ColorPicker';
 import { Settings } from '$app/components/layouts/Settings';
 import { Spinner } from '$app/components/Spinner';
@@ -117,7 +116,7 @@ export function Edit() {
           />
         )
       }
-      breadcrumbs={[]}
+      breadcrumbs={pages}
     >
       {!taskStatus && (
         <div className="flex justify-center">
@@ -126,8 +125,7 @@ export function Edit() {
       )}
 
       {taskStatus && (
-        <Container className="space-y-6" breadcrumbs={pages}>
-
+        <div className="max-w-3xl">
           <Card
             title={documentTitle}
             withSaveButton
@@ -165,7 +163,7 @@ export function Edit() {
               />
             </CardContainer>
           </Card>
-        </Container>
+        </div>
       )}
     </Settings>
   );

--- a/src/pages/settings/tax-rates/Create.tsx
+++ b/src/pages/settings/tax-rates/Create.tsx
@@ -19,7 +19,6 @@ import { useTitle } from '$app/common/hooks/useTitle';
 import { TaxRate } from '$app/common/interfaces/tax-rate';
 import { ValidationBag } from '$app/common/interfaces/validation-bag';
 import { useBlankTaxRateQuery } from '$app/common/queries/tax-rates';
-import { Container } from '$app/components/Container';
 import { Icon } from '$app/components/icons/Icon';
 import { Settings } from '$app/components/layouts/Settings';
 import { FormEvent, useEffect, useState } from 'react';
@@ -103,8 +102,8 @@ export function Create() {
   }, [blankTaxRate]);
 
   return (
-    <Settings title={t('tax_rates')} breadcrumbs={[]}>
-      <Container className="space-y-6" breadcrumbs={pages}>
+    <Settings title={t('tax_rates')} breadcrumbs={pages}>
+      <div className="max-w-3xl">
         <Card
           title={documentTitle}
           withSaveButton
@@ -133,7 +132,7 @@ export function Create() {
             />
           </CardContainer>
         </Card>
-      </Container>
+      </div>
     </Settings>
   );
 }

--- a/src/pages/settings/tax-rates/Edit.tsx
+++ b/src/pages/settings/tax-rates/Edit.tsx
@@ -14,7 +14,6 @@ import { AxiosError } from 'axios';
 import { endpoint } from '$app/common/helpers';
 import { useTaxRateQuery } from '$app/common/queries/tax-rates';
 import { Badge } from '$app/components/Badge';
-import { Container } from '$app/components/Container';
 import { Settings } from '$app/components/layouts/Settings';
 import { Spinner } from '$app/components/Spinner';
 import { useFormik } from 'formik';
@@ -95,7 +94,7 @@ export function Edit() {
           />
         )
       }
-      breadcrumbs={[]}
+      breadcrumbs={pages}
     >
       {!data && (
         <div className="flex justify-center">
@@ -104,7 +103,7 @@ export function Edit() {
       )}
 
       {data && (
-        <Container className="space-y-6" breadcrumbs={pages}>
+        <div className="max-w-3xl">
           <Card
             withSaveButton
             onFormSubmit={formik.handleSubmit}
@@ -145,7 +144,7 @@ export function Edit() {
               />
             </CardContainer>
           </Card>
-        </Container>
+        </div>
       )}
     </Settings>
   );


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for incorrectly displayed breadcrumbs on the tax rates and task status pages. Screenshot of the bug:

![Screenshot 2024-08-05 at 19 43 01](https://github.com/user-attachments/assets/125ba235-b5cd-40f7-a4f5-517ec0284eee)

Let me know your thoughts.