### PR TITLE
[Bugfix] Creating Invoices and Purchase Orders From Products

### DIFF
--- a/src/pages/products/common/hooks/useInvoiceProducts.ts
+++ b/src/pages/products/common/hooks/useInvoiceProducts.ts
@@ -9,6 +9,7 @@
  */
 
 import { blankLineItem } from '$app/common/constants/blank-line-item';
+import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { InvoiceItemType } from '$app/common/interfaces/invoice-item';
 import { Product } from '$app/common/interfaces/product';
 import { useBlankInvoiceQuery } from '$app/common/queries/invoices';
@@ -19,6 +20,8 @@ import { useNavigate } from 'react-router-dom';
 export const useInvoiceProducts = () => {
   const navigate = useNavigate();
 
+  const company = useCurrentCompany();
+
   const { data: blankInvoice } = useBlankInvoiceQuery();
 
   const setInvoice = useSetAtom(invoiceAtom);
@@ -28,18 +31,24 @@ export const useInvoiceProducts = () => {
       const lineItems = products.map((product) => ({
         ...blankLineItem(),
         type_id: InvoiceItemType.Product,
-        cost: product.price,
-        quantity: product.quantity,
-        line_total: Number((product.price * product.quantity).toFixed(2)),
         product_key: product.product_key,
-        notes: product.notes,
-        tax_name1: product.tax_name1,
-        tax_rate1: product.tax_rate1,
-        tax_name2: product.tax_name2,
-        tax_rate2: product.tax_rate2,
-        tax_name3: product.tax_name3,
-        tax_rate3: product.tax_rate3,
-        tax_id: '',
+        quantity: company?.fill_products ? product.quantity : 1,
+        ...(company?.fill_products && {
+          line_total: Number((product.price * product.quantity).toFixed(2)),
+          cost: product.price,
+          notes: product.notes,
+          tax_name1: product.tax_name1,
+          tax_rate1: product.tax_rate1,
+          tax_name2: product.tax_name2,
+          tax_rate2: product.tax_rate2,
+          tax_name3: product.tax_name3,
+          tax_rate3: product.tax_rate3,
+          tax_id: '',
+          custom_value1: product.custom_value1,
+          custom_value2: product.custom_value2,
+          custom_value3: product.custom_value3,
+          custom_value4: product.custom_value4,
+        }),
       }));
 
       setInvoice({ ...blankInvoice, line_items: lineItems });

--- a/src/pages/products/common/hooks/usePurchaseOrderProducts.ts
+++ b/src/pages/products/common/hooks/usePurchaseOrderProducts.ts
@@ -9,6 +9,7 @@
  */
 
 import { blankLineItem } from '$app/common/constants/blank-line-item';
+import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { InvoiceItemType } from '$app/common/interfaces/invoice-item';
 import { Product } from '$app/common/interfaces/product';
 import { useBlankPurchaseOrderQuery } from '$app/common/queries/purchase-orders';
@@ -19,6 +20,8 @@ import { useNavigate } from 'react-router-dom';
 export const usePurchaseOrderProducts = () => {
   const navigate = useNavigate();
 
+  const company = useCurrentCompany();
+
   const { data: blankPurchaseOrder } = useBlankPurchaseOrderQuery();
 
   const setPurchaseOrder = useSetAtom(purchaseOrderAtom);
@@ -28,18 +31,24 @@ export const usePurchaseOrderProducts = () => {
       const lineItems = products.map((product) => ({
         ...blankLineItem(),
         type_id: InvoiceItemType.Product,
-        cost: product.price,
-        quantity: product.quantity,
-        line_total: Number((product.price * product.quantity).toFixed(2)),
-        product_key: product.id,
-        notes: product.notes,
-        tax_name1: product.tax_name1,
-        tax_rate1: product.tax_rate1,
-        tax_name2: product.tax_name2,
-        tax_rate2: product.tax_rate2,
-        tax_name3: product.tax_name3,
-        tax_rate3: product.tax_rate3,
-        tax_id: '',
+        product_key: product.product_key,
+        quantity: company?.fill_products ? product.quantity : 1,
+        ...(company?.fill_products && {
+          line_total: Number((product.price * product.quantity).toFixed(2)),
+          cost: product.price,
+          notes: product.notes,
+          tax_name1: product.tax_name1,
+          tax_rate1: product.tax_rate1,
+          tax_name2: product.tax_name2,
+          tax_rate2: product.tax_rate2,
+          tax_name3: product.tax_name3,
+          tax_rate3: product.tax_rate3,
+          tax_id: '',
+          custom_value1: product.custom_value1,
+          custom_value2: product.custom_value2,
+          custom_value3: product.custom_value3,
+          custom_value4: product.custom_value4,
+        }),
       }));
 
       setPurchaseOrder({ ...blankPurchaseOrder, line_items: lineItems });


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for two bugs related to creating invoices and purchase orders from Products. The first bug was that custom field values were not applied when created from a product. The second bug involved values other than `product_key` needing to be applied only if the `fill_products` company settings prop is turned on (Flutter app behavior), if not, only `product_key` should be applied. Both of these fixes have been made for both invoices and purchase orders. Let me know your thoughts.

Closes #1870 