### PR TITLE
[Bugfix] Displaying Activities On Invoice Edit Page

### DIFF
--- a/src/common/interfaces/invoice-activity.ts
+++ b/src/common/interfaces/invoice-activity.ts
@@ -8,6 +8,8 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
+import { ActivityRecordBase } from './activity-record';
+
 export interface InvoiceActivity {
   user: Client;
   invoice: Client;
@@ -20,6 +22,8 @@ export interface InvoiceActivity {
   created_at: number;
   ip: string;
   recurring_invoice?: Client;
+  payment?: Client;
+  payment_amount?: ActivityRecordBase;
 }
 
 export interface Client {

--- a/src/pages/invoices/common/components/InvoiceSlider.tsx
+++ b/src/pages/invoices/common/components/InvoiceSlider.tsx
@@ -119,6 +119,16 @@ export function useGenerateActivityElement() {
           {activity?.notes}
         </>
       ),
+
+      payment_amount: activity?.payment_amount?.label,
+
+      payment: (
+        <Link
+          to={route('/payments/:id/edit', { id: activity?.payment?.hashed_id })}
+        >
+          {activity?.payment?.label}
+        </Link>
+      ),
     };
 
     for (const [variable, value] of Object.entries(replacements)) {

--- a/src/pages/invoices/edit/components/Activities.tsx
+++ b/src/pages/invoices/edit/components/Activities.tsx
@@ -8,78 +8,19 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
-import { date, endpoint, trans } from '$app/common/helpers';
+import { date, endpoint } from '$app/common/helpers';
 import { request } from '$app/common/helpers/request';
-import { route } from '$app/common/helpers/route';
 import { GenericManyResponse } from '$app/common/interfaces/generic-many-response';
 import { InvoiceActivity } from '$app/common/interfaces/invoice-activity';
 import { NonClickableElement } from '$app/components/cards/NonClickableElement';
-import { Link } from '$app/components/forms';
 import { AxiosResponse } from 'axios';
 import { useTranslation } from 'react-i18next';
 import { useQuery } from 'react-query';
 import { useParams } from 'react-router-dom';
 import { useCurrentCompanyDateFormats } from '$app/common/hooks/useCurrentCompanyDateFormats';
 import { Card } from '$app/components/cards';
-import reactStringReplace from 'react-string-replace';
 import { Spinner } from '$app/components/Spinner';
-
-export function useGenerateActivityElement() {
-  const [t] = useTranslation();
-
-  return (activity: InvoiceActivity) => {
-    let text = trans(`activity_${activity.activity_type_id}`, {});
-
-    const replacements = {
-      client: (
-        <Link to={route('/clients/:id', { id: activity.client?.hashed_id })}>
-          {activity.client?.label}
-        </Link>
-      ),
-
-      user: activity.user?.label ?? t('system'),
-      invoice:
-        (
-          <Link
-            to={route('/invoices/:id/edit', {
-              id: activity.invoice?.hashed_id,
-            })}
-          >
-            {activity?.invoice?.label}
-          </Link>
-        ) ?? '',
-
-      recurring_invoice:
-        (
-          <Link
-            to={route('/recurring_invoices/:id/edit', {
-              id: activity?.recurring_invoice?.hashed_id,
-            })}
-          >
-            {activity?.recurring_invoice?.label}
-          </Link>
-        ) ?? '',
-
-      contact:
-        (
-          <Link
-            to={route('/clients/:id/edit', {
-              id: activity?.contact?.hashed_id,
-            })}
-          >
-            {activity?.contact?.label}
-          </Link>
-        ) ?? '',
-    };
-    for (const [variable, value] of Object.entries(replacements)) {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      text = reactStringReplace(text, `:${variable}`, () => value);
-    }
-
-    return text;
-  };
-}
+import { useGenerateActivityElement } from '../../common/components/InvoiceSlider';
 
 export default function Activities() {
   const [t] = useTranslation();


### PR DESCRIPTION
@beganovich @turbo124 The PR includes two fixes. First, we now use the same function for displaying activities on both the invoice edit page and the invoice slider. Second, I've added the resolution of two additional variables that we missed: `payment` and `payment_amount`. Screenshot:

<img width="725" alt="Screenshot 2024-08-07 at 11 42 34" src="https://github.com/user-attachments/assets/20097690-e08f-47d0-af76-5fdada3ee5ba">

Let me know your thoughts.