### PR TITLE
[Bugfix] Disabling Navigation For Activities

### DIFF
--- a/src/pages/invoices/common/components/InvoiceSlider.tsx
+++ b/src/pages/invoices/common/components/InvoiceSlider.tsx
@@ -434,6 +434,7 @@ export function InvoiceSlider() {
               <ClickableElement
                 key={activity.id}
                 to={`/activities/${activity.id}`}
+                disableNavigation={Boolean(!activity.history.id)}
               >
                 <div className="flex flex-col">
                   <div className="flex space-x-1">

--- a/src/pages/invoices/edit/components/History.tsx
+++ b/src/pages/invoices/edit/components/History.tsx
@@ -70,7 +70,11 @@ export default function History() {
 
       {resource?.activities &&
         resource.activities.map((activity) => (
-          <ClickableElement key={activity.id} to={`/activities/${activity.id}`}>
+          <ClickableElement
+            key={activity.id}
+            to={`/activities/${activity.id}`}
+            disableNavigation={Boolean(!activity.history.id)}
+          >
             <div className="flex flex-col">
               <div className="flex space-x-1">
                 <span>

--- a/src/pages/quotes/common/components/QuoteSlider.tsx
+++ b/src/pages/quotes/common/components/QuoteSlider.tsx
@@ -377,6 +377,7 @@ export function QuoteSlider() {
               <ClickableElement
                 key={activity.id}
                 to={`/activities/${activity.id}`}
+                disableNavigation={Boolean(!activity.history.id)}
               >
                 <div className="flex flex-col">
                   <div className="flex space-x-1">

--- a/src/pages/recurring-invoices/common/components/RecurringInvoiceSlider.tsx
+++ b/src/pages/recurring-invoices/common/components/RecurringInvoiceSlider.tsx
@@ -290,6 +290,7 @@ export const RecurringInvoiceSlider = () => {
               <ClickableElement
                 key={activity.id}
                 to={route('/activities/:id', { id: activity.id })}
+                disableNavigation={Boolean(!activity.history.id)}
               >
                 <div className="flex flex-col">
                   <div className="flex space-x-1">


### PR DESCRIPTION
@beganovich @turbo124 The PR includes a fix for activities with no history. Previously, when navigating to the preview page of an activity with no history, the API returned a 404 error and the user was redirected to the 404 page. I resolved this by disabling navigation if the history object does not have a populated `id` property (the activity element will not be clickable). Let me know your thoughts.