### PR TITLE
[Bugfix] Matching Currency Format Symbol With Selected Currency

### DIFF
--- a/src/common/hooks/money/useFormatMoney.ts
+++ b/src/common/hooks/money/useFormatMoney.ts
@@ -22,7 +22,8 @@ export function useFormatMoney() {
     value: string | number,
     countryId: string | undefined,
     currencyId: string | undefined,
-    fractionDigits?: number
+    fractionDigits?: number,
+    showCurrencyCode?: boolean
   ) => {
     const currentCountryId = countryId || company?.settings.country_id;
     const currentCurrencyId =
@@ -39,7 +40,8 @@ export function useFormatMoney() {
         currency,
         country,
         {
-          showCurrencyCode: company.settings.show_currency_code,
+          showCurrencyCode:
+            showCurrencyCode ?? company.settings.show_currency_code,
         }
       );
     }

--- a/src/pages/settings/localization/components/Settings.tsx
+++ b/src/pages/settings/localization/components/Settings.tsx
@@ -25,7 +25,7 @@ import { useDispatch } from 'react-redux';
 import { Card, Element } from '../../../../components/cards';
 import { Radio, SelectField } from '../../../../components/forms';
 import Toggle from '../../../../components/forms/Toggle';
-import { useAtom, useAtomValue } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import { hasLanguageChanged } from '../common/atoms';
 import { companySettingsErrorsAtom } from '../../common/atoms';
 import { useCurrentSettingsLevel } from '$app/common/hooks/useCurrentSettingsLevel';
@@ -35,32 +35,47 @@ import { SettingsLabel } from '$app/components/SettingsLabel';
 import { CurrencySelector } from '$app/components/CurrencySelector';
 import { LanguageSelector } from '$app/components/LanguageSelector';
 import { SearchableSelect } from '$app/components/SearchableSelect';
+import { useFormatMoney } from '$app/common/hooks/money/useFormatMoney';
 
 export function Settings() {
   const [t] = useTranslation();
+
   const { data: statics } = useStaticsQuery();
 
-  const disableSettingsField = useDisableSettingsField();
-
+  const company = useInjectCompanyChanges();
   const { isCompanySettingsActive } = useCurrentSettingsLevel();
 
   const dispatch = useDispatch();
-  const company = useInjectCompanyChanges();
-
-  const errors = useAtomValue(companySettingsErrorsAtom);
-
+  const formatMoney = useFormatMoney();
   const handleChange = useHandleCurrentCompanyChange();
+  const disableSettingsField = useDisableSettingsField();
   const handlePropertyChange = useHandleCurrentCompanyChangeProperty();
 
-  const [, setHasLanguageIdChanged] = useAtom(hasLanguageChanged);
+  const errors = useAtomValue(companySettingsErrorsAtom);
+  const setHasLanguageIdChanged = useSetAtom(hasLanguageChanged);
 
   const currencyFormats = [
     {
       id: 'symbol',
-      title: `${t('currency_symbol')}: $1,000.00`,
+      title: `${t('currency_symbol')}: ${formatMoney(
+        1000,
+        company?.settings.country_id,
+        company?.settings.currency_id,
+        2
+      )}`,
       value: 'false',
     },
-    { id: 'code', title: `${t('currency_code')}: 1,000.00 USD`, value: 'true' },
+    {
+      id: 'code',
+      title: `${t('currency_code')}: ${formatMoney(
+        1000,
+        company?.settings.country_id,
+        company?.settings.currency_id,
+        2,
+        true
+      )}`,
+      value: 'true',
+    },
   ];
 
   return (


### PR DESCRIPTION
@beganovich @turbo124 The PR includes improving currency format preview by using the currently selected currency. Earlier, USD was the only one used. Screenshot:

![Screenshot 2024-08-21 at 20 33 33](https://github.com/user-attachments/assets/ad7c5d9e-7c71-42c0-bca3-3412cb3f75d0)

Let me know your thoughts.

Closes #1947 