### PR TITLE
[Bugfix] About Modal App Version

### DIFF
--- a/src/components/AboutModal.tsx
+++ b/src/components/AboutModal.tsx
@@ -19,7 +19,6 @@ import {
   Youtube,
 } from 'react-feather';
 import { Modal } from './Modal';
-import { version } from '$app/common/helpers/version';
 import { useCurrentUser } from '$app/common/hooks/useCurrentUser';
 import { useTranslation } from 'react-i18next';
 import { Dispatch, SetStateAction, useState } from 'react';
@@ -205,7 +204,7 @@ export function AboutModal(props: Props) {
             <span>{user?.email}</span>
           </div>
 
-          <span className="mt-4">{version}</span>
+          <span className="mt-4">v{currentSystemInfo?.api_version}</span>
         </div>
 
         {isSelfHosted() && (


### PR DESCRIPTION
@beganovich @turbo124 The PR includes changing the value which indicates the app version. Instead of having the React build version, we replaced it with the `api_version` value. Screenshot:

<img width="353" alt="Screenshot 2024-08-22 at 10 19 25" src="https://github.com/user-attachments/assets/d11320a2-f7fb-41dc-b0d4-d12ae34a90c7">

Let me know your thoughts.

#1976 