### PR TITLE
[Feature] New Purchase Order Event

### DIFF
--- a/src/pages/settings/integrations/api-webhooks/common/hooks/useEvents.ts
+++ b/src/pages/settings/integrations/api-webhooks/common/hooks/useEvents.ts
@@ -77,6 +77,7 @@ export function useEvents() {
   const EVENT_DELETE_PURCHASE_ORDER = '57';
   const EVENT_RESTORE_PURCHASE_ORDER = '58';
   const EVENT_ARCHIVE_PURCHASE_ORDER = '59';
+  const EVENT_ACCEPTED_PURCHASE_ORDER = '65';
 
   return [
     { event: EVENT_CREATE_CLIENT, label: t('create_client') },
@@ -158,6 +159,10 @@ export function useEvents() {
     {
       event: EVENT_ARCHIVE_PURCHASE_ORDER,
       label: t('archive_purchase_order'),
+    },
+    {
+      event: EVENT_ACCEPTED_PURCHASE_ORDER,
+      label: t('accept_purchase_order'),
     },
   ];
 }


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adding a new `ACCEPTED_PURCHASE_ORDER` event for webhooks.

`Note`:  We're missing the "accept_purchase_order" translation keyword from the files, so if you agree, please just add it to the files.

Let me know your thoughts.