### PR TITLE
[Cleanup] Implementing Searchable Select Field | Webhooks

### DIFF
--- a/src/pages/settings/integrations/api-webhooks/Create.tsx
+++ b/src/pages/settings/integrations/api-webhooks/Create.tsx
@@ -31,6 +31,7 @@ import { useNavigate } from 'react-router-dom';
 import { useHandleChange } from './common/hooks';
 import { $refetch } from '$app/common/hooks/useRefetch';
 import { useEvents } from './common/hooks/useEvents';
+import { SearchableSelect } from '$app/components/SearchableSelect';
 
 export function Create() {
   const [t] = useTranslation();
@@ -128,7 +129,7 @@ export function Create() {
         </Element>
 
         <Element leftSide={t('event_type')}>
-          <SelectField
+          <SearchableSelect
             value={apiWebHook?.event_id}
             onValueChange={(value) => handleChange('event_id', value)}
             errorMessage={errors?.errors.event_id}
@@ -138,7 +139,7 @@ export function Create() {
                 {event.label}
               </option>
             ))}
-          </SelectField>
+          </SearchableSelect>
         </Element>
 
         <Element leftSide={t('method')}>

--- a/src/pages/settings/integrations/api-webhooks/Edit.tsx
+++ b/src/pages/settings/integrations/api-webhooks/Edit.tsx
@@ -32,6 +32,7 @@ import { useHandleChange } from './common/hooks';
 import { useActions } from './common/useActions';
 import { $refetch } from '$app/common/hooks/useRefetch';
 import { useEvents } from './common/hooks/useEvents';
+import { SearchableSelect } from '$app/components/SearchableSelect';
 
 export function Edit() {
   const [t] = useTranslation();
@@ -137,7 +138,7 @@ export function Edit() {
         </Element>
 
         <Element leftSide={t('event_type')}>
-          <SelectField
+          <SearchableSelect
             value={apiWebHook?.event_id}
             onValueChange={(value) => handleChange('event_id', value)}
             errorMessage={errors?.errors.event_id}
@@ -147,7 +148,7 @@ export function Edit() {
                 {event.label}
               </option>
             ))}
-          </SelectField>
+          </SearchableSelect>
         </Element>
 
         <Element leftSide={t('method')}>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes replacing the standard select field with a searchable select field for the event_type field in webhooks. Screenshot:

<img width="897" alt="Screenshot 2024-08-23 at 11 57 40" src="https://github.com/user-attachments/assets/aea3ecb6-5bf7-4353-ac0f-c0d1d8ca8df6">

Let me know your thoughts.