### PR TITLE
[Cleanup] Adjusting The "per_page" Query Parameter On Expense Category Selector

### DIFF
--- a/src/components/expense-categories/ExpenseCategorySelector.tsx
+++ b/src/components/expense-categories/ExpenseCategorySelector.tsx
@@ -33,7 +33,7 @@ export function ExpenseCategorySelector(props: ExpenseCategorySelectorProps) {
   const hasPermission = useHasPermission();
 
   const perPageParameter =
-    import.meta.env.VITE_IS_TEST === 'true' ? '&per_page=1' : '';
+    import.meta.env.VITE_IS_TEST === 'true' ? '&per_page=1' : '&per_page=500';
 
   return (
     <>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes setting the "per_page" query parameter for the expense category selector to 500. Let me know your thoughts.

Closes #2005 