### PR TITLE
[Bugfix] Invoicing Expense | Query Invalidation

### DIFF
--- a/src/pages/invoices/create/hooks/useHandleCreate.ts
+++ b/src/pages/invoices/create/hooks/useHandleCreate.ts
@@ -64,7 +64,11 @@ export function useHandleCreate(params: Params) {
 
         toast.success('created_invoice');
 
-        $refetch(['products', 'tasks', 'expenses']);
+        $refetch(['products', 'tasks']);
+
+        if (searchParams.get('action') === 'invoice_expense') {
+          $refetch(['expenses']);
+        }
 
         navigate(
           route('/invoices/:id/edit?table=:table', {

--- a/src/pages/invoices/create/hooks/useHandleCreate.ts
+++ b/src/pages/invoices/create/hooks/useHandleCreate.ts
@@ -64,7 +64,7 @@ export function useHandleCreate(params: Params) {
 
         toast.success('created_invoice');
 
-        $refetch(['products', 'tasks']);
+        $refetch(['products', 'tasks', 'expenses']);
 
         navigate(
           route('/invoices/:id/edit?table=:table', {


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for query invalidation when saving the invoice. We did not have correctly invalidated the /expenses route, so the table was not updating. I have added query invalidation for expenses once the invoice is saved. Let me know your thoughts.