### PR TITLE
[Feature] New Email Template | Payment Failed

### DIFF
--- a/src/pages/settings/templates-and-reminders/TemplatesAndReminders.tsx
+++ b/src/pages/settings/templates-and-reminders/TemplatesAndReminders.tsx
@@ -370,6 +370,8 @@ export function TemplatesAndReminders() {
                 </option>
               ))}
 
+            <option value="payment_failed">{t('payment_failed')}</option>
+
             <option value="custom1">{t('first_custom')}</option>
             <option value="custom2">{t('second_custom')}</option>
             <option value="custom3">{t('third_custom')}</option>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of a new email_template called "Payment Failed". 

`Note`: We're missing the "payment_failed" translation keyword in the files, so if you agree, please just add it there.

Let me know your thoughts.