### PR TITLE
[Bugfix] Calculating Line Item Totals And Totals In General | Purchase Orders Edit Page

### DIFF
--- a/src/pages/purchase-orders/PurchaseOrder.tsx
+++ b/src/pages/purchase-orders/PurchaseOrder.tsx
@@ -32,6 +32,8 @@ import {
 } from '$app/pages/settings/invoice-design/pages/custom-designs/components/ChangeTemplate';
 import { Tabs } from '$app/components/Tabs';
 import { useTabs } from './edit/hooks/useTabs';
+import { InvoiceSum } from '$app/common/helpers/invoices/invoice-sum';
+import { InvoiceSumInclusive } from '$app/common/helpers/invoices/invoice-sum-inclusive';
 
 export default function PurchaseOrder() {
   const { documentTitle } = useTitle('edit_purchase_order');
@@ -52,6 +54,9 @@ export default function PurchaseOrder() {
   ];
 
   const [errors, setErrors] = useState<ValidationBag>();
+  const [invoiceSum, setInvoiceSum] = useState<
+    InvoiceSum | InvoiceSumInclusive
+  >();
   const [isDefaultTerms, setIsDefaultTerms] = useState<boolean>(false);
   const [isDefaultFooter, setIsDefaultFooter] = useState<boolean>(false);
   const [purchaseOrder, setPurchaseOrder] = useState<PurchaseOrderType>();
@@ -112,6 +117,8 @@ export default function PurchaseOrder() {
               setIsDefaultTerms,
               isDefaultFooter,
               setIsDefaultFooter,
+              invoiceSum,
+              setInvoiceSum,
             }}
           />
         </div>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixing a bug where line totals and totals in general were not recalculated when values such as unit_cost or quantity were changed on the purchase order edit page specifically. Let me know your thoughts.