### PR TITLE
[Bugfix] Reseting "Reset Counter Date"

### DIFF
--- a/src/pages/settings/generated-numbers/components/Settings.tsx
+++ b/src/pages/settings/generated-numbers/components/Settings.tsx
@@ -185,9 +185,16 @@ export function Settings() {
       >
         <SelectField
           value={companyChanges?.settings?.reset_counter_frequency_id || '0'}
-          onValueChange={(value) =>
-            handleChange('settings.reset_counter_frequency_id', parseInt(value))
-          }
+          onValueChange={(value) => {
+            handleChange(
+              'settings.reset_counter_frequency_id',
+              parseInt(value)
+            );
+
+            if (value === '0') {
+              handleChange('settings.reset_counter_date', '');
+            }
+          }}
           disabled={disableSettingsField('reset_counter_frequency_id')}
           errorMessage={errors?.errors['settings.reset_counter_frequency_id']}
         >


### PR DESCRIPTION
@beganovich @turbo124 The PR includes updated logic to set the `reset_counter_date` property to an empty string if `reset_counter_frequency_id` is set to `0 (Never)`. Let me know your thoughts.

Closes #1822 