### PR TITLE
[Bugfix] Displaying Validation Error Message | Payments | Refund

### DIFF
--- a/src/pages/payments/refund/Refund.tsx
+++ b/src/pages/payments/refund/Refund.tsx
@@ -235,39 +235,45 @@ export default function Refund() {
 
             if (invoiceItem)
               return (
-                <Element
-                  key={index}
-                  leftSide={`${t('invoice')}: ${invoiceItem?.number}`}
-                >
-                  <div className="flex items-center space-x-2">
-                    <InputField
-                      id={`invoices[${index}].amount`}
-                      type="number"
-                      value={(formik.values.invoices[index] as Invoice).amount}
-                      onChange={formik.handleChange}
-                      errorMessage={
-                        errors?.errors[`invoices.${[index]}.amount`]
-                      }
-                    />
+                <div key={index} className="flex flex-col">
+                  <Element leftSide={`${t('invoice')}: ${invoiceItem?.number}`}>
+                    <div className="flex items-center space-x-2">
+                      <InputField
+                        id={`invoices[${index}].amount`}
+                        type="number"
+                        value={
+                          (formik.values.invoices[index] as Invoice).amount
+                        }
+                        onChange={formik.handleChange}
+                      />
 
-                    <Button
-                      behavior="button"
-                      type="minimal"
-                      onClick={() => {
-                        formik.setFieldValue(
-                          'invoices',
-                          formik.values.invoices.filter(
-                            (invoice: any) =>
-                              invoice.invoice_id !=
-                              requestInvoiceItem.invoice_id
-                          )
-                        );
-                      }}
-                    >
-                      <X />
-                    </Button>
-                  </div>
-                </Element>
+                      <Button
+                        behavior="button"
+                        type="minimal"
+                        onClick={() => {
+                          formik.setFieldValue(
+                            'invoices',
+                            formik.values.invoices.filter(
+                              (invoice: any) =>
+                                invoice.invoice_id !=
+                                requestInvoiceItem.invoice_id
+                            )
+                          );
+                        }}
+                      >
+                        <X />
+                      </Button>
+                    </div>
+                  </Element>
+
+                  {errors?.errors[`invoices.${[index]}.amount`] && (
+                    <div className="px-6">
+                      <Alert className="mt-2 break-all" type="danger">
+                        {errors?.errors[`invoices.${[index]}.amount`]}
+                      </Alert>
+                    </div>
+                  )}
+                </div>
               );
           }
         )}

--- a/src/pages/payments/refund/Refund.tsx
+++ b/src/pages/payments/refund/Refund.tsx
@@ -266,10 +266,12 @@ export default function Refund() {
                     </div>
                   </Element>
 
-                  {errors?.errors[`invoices.${[index]}.amount`] && (
+                  {(errors?.errors[`invoices.${[index]}.invoice_id`] ||
+                    errors?.errors[`invoices.${[index]}.amount`]) && (
                     <div className="px-6">
                       <Alert className="mt-2 break-all" type="danger">
-                        {errors?.errors[`invoices.${[index]}.amount`]}
+                        {errors?.errors[`invoices.${[index]}.invoice_id`] ||
+                          errors?.errors[`invoices.${[index]}.amount`]}
                       </Alert>
                     </div>
                   )}

--- a/src/pages/payments/refund/Refund.tsx
+++ b/src/pages/payments/refund/Refund.tsx
@@ -246,7 +246,7 @@ export default function Refund() {
                       value={(formik.values.invoices[index] as Invoice).amount}
                       onChange={formik.handleChange}
                       errorMessage={
-                        errors?.errors[`invoices.${[index]}.invoice_id`]
+                        errors?.errors[`invoices.${[index]}.amount`]
                       }
                     />
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes implementation for displaying an `amount` prop message for payments on the refund page. The path I took to the error message is `errors.invoices[index].amount`. The message will look like this:

<img width="673" alt="Screenshot 2024-09-04 at 12 59 59" src="https://github.com/user-attachments/assets/4c2b7088-9c7d-411e-a439-60e28a30637f">

Let me know your thoughts.