### PR TITLE
[Cleanup] Displaying "Processing" Modal On self-update

### DIFF
--- a/src/components/AboutModal.tsx
+++ b/src/components/AboutModal.tsx
@@ -156,12 +156,8 @@ export function AboutModal(props: Props) {
 
   const handleUpdateApp = (password: string) => {
     if (!isFormBusy) {
-      const timeoutId = setTimeout(() => {
-        setIsUpgradeLoadingModalOpen(true);
-      }, 25000);
-
-      toast.processing();
       setIsFormBusy(true);
+      setIsUpgradeLoadingModalOpen(true);
 
       request(
         'POST',
@@ -177,8 +173,8 @@ export function AboutModal(props: Props) {
           }
         })
         .finally(() => {
-          clearTimeout(timeoutId);
           setIsFormBusy(false);
+          setIsUpgradeLoadingModalOpen(false);
         });
     }
   };
@@ -527,9 +523,12 @@ export function AboutModal(props: Props) {
       <Modal
         title={t('updating_app')}
         visible={isUpgradeLoadingModalOpen}
-        onClose={() => setIsUpgradeLoadingModalOpen(false)}
+        onClose={() => {}}
+        disableClosing
       >
-        {t('upgrade_in_progress')}
+        <span className="text-center py-3 font-medium">
+          {t('upgrade_in_progress')}
+        </span>
       </Modal>
 
       <PasswordConfirmation

--- a/src/components/AboutModal.tsx
+++ b/src/components/AboutModal.tsx
@@ -521,13 +521,13 @@ export function AboutModal(props: Props) {
       </Modal>
 
       <Modal
-        title={t('updating_app')}
+        title={t('self-update')}
         visible={isUpgradeLoadingModalOpen}
         onClose={() => {}}
         disableClosing
       >
         <span className="text-center py-3 font-medium">
-          {t('upgrade_in_progress')}
+          {t('in_progress')}
         </span>
       </Modal>
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes an adjustment to display a "processing" modal for the `/api/v1/self-update` endpoint when the endpoint is called. This modal will be closed on `ANY` kind of response. If this endpoint succeeds, we will `RELOAD` the whole page. On any error, we will display an error message in the toaster and close this "processing" modal. Screenshot:

<img width="1194" alt="Screenshot 2024-09-04 at 13 18 24" src="https://github.com/user-attachments/assets/81ee54e0-d91b-4821-b0da-c1294ac52dc4">

`Note`: We are missing both "updating_app" and "upgrade_in_progress" translation keywords from the files. If you agree, please add them there.

Let me know your thoughts.