### PR TITLE
[Bugfix] Avoiding NaN Values For Task Duration

### DIFF
--- a/src/pages/tasks/common/helpers/calculate-time.ts
+++ b/src/pages/tasks/common/helpers/calculate-time.ts
@@ -40,8 +40,14 @@ export function calculateHours(log: string, includeRunning = false) {
       continue;
     }
 
-    const finishTime = finish !== 0 ? finish : Math.floor(Date.now() / 1000);
-    const durationInSeconds = finishTime - start;
+    const finishTime =
+      finish !== 0
+        ? typeof finish === 'number'
+          ? finish
+          : 0
+        : Math.floor(Date.now() / 1000);
+    const durationInSeconds =
+      finishTime - (typeof start === 'number' ? start : 0);
 
     seconds += Math.max(durationInSeconds, 0);
   }


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adding additional checks to avoid NaN values for "Duration" in the tasks table. I was not able to recreate the case from the screenshot, but I've added the checks to eliminate any possibility of getting it. Screenshot:

![image-20240706-222343](https://github.com/user-attachments/assets/c03dbe58-b362-4970-a81a-1c98b7eba6f8)

Let me know your thoughts.