### PR TITLE
[Bugfix] Wrapping Text On Client Show Page

### DIFF
--- a/src/pages/clients/show/components/Address.tsx
+++ b/src/pages/clients/show/components/Address.tsx
@@ -32,21 +32,24 @@ export function Address(props: Props) {
             title={t('address')}
             value={
               <>
-                <p>
+                <p className="break-all">
                   {client.address1.length > 0 && client.address1}
                   {client.address1.length > 0 && <br />}
                   {client.address2}
                 </p>
 
-                <p>
+                <p className="break-all">
                   {client.city.length > 0 && client.city} &nbsp;
                   {client.state} &nbsp;
                   {client.postal_code.length > 0 && client.postal_code}
                 </p>
 
-                <p>{resolveCountry(client.country_id)?.name}</p>
+                <p className="break-all">
+                  {resolveCountry(client.country_id)?.name}
+                </p>
               </>
             }
+            withoutTruncate
             className="h-full"
           />
         </div>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for the text wrapping issue on the "Address" card on the Client show page. Screenshot:

<img width="1055" alt="Screenshot 2024-09-06 at 10 57 12" src="https://github.com/user-attachments/assets/56ed4de3-bff8-438f-8241-8d543b7a5950">

Let me know your thoughts.

Closes #1905 