### PR TITLE
Resolve warnings for `??` operator will always return left operand

### DIFF
--- a/src/common/hooks/useCompanyTimeZone.ts
+++ b/src/common/hooks/useCompanyTimeZone.ts
@@ -23,7 +23,7 @@ export function useCompanyTimeZone() {
   useEffect(() => {
     if (statics?.timezones) {
       const result = statics.timezones.find(
-        (format: any) => format.id === company?.settings?.timezone_id ?? '1'
+        (format: any) => format.id === (company?.settings?.timezone_id ?? '1')
       );
 
       if (result) {

--- a/src/common/hooks/useCurrentCompanyDateFormats.ts
+++ b/src/common/hooks/useCurrentCompanyDateFormats.ts
@@ -23,7 +23,7 @@ export function useCurrentCompanyDateFormats() {
   useEffect(() => {
     if (statics?.date_formats) {
       const result = statics.date_formats.find(
-        (format: any) => format.id === company?.settings?.date_format_id ?? '0'
+        (format: any) => format.id === (company?.settings?.date_format_id ?? '0')
       );
 
       if (result) {


### PR DESCRIPTION
Adds parens to ensure that the fallback value applies when intended and to resolve the warning.
```
2:48:56 PM [vite] warning: The "??" operator here will always return the left operand
24 |      if (statics?.timezones) {
25 |        const result = statics.timezones.find(
26 |          (format: any) => format.id === company?.settings?.timezone_id ?? '1'
   |                                                                        ^
27 |        );
28 |  

  Plugin: vite:esbuild
  File: ui/src/common/hooks/useCompanyTimeZone.ts
```