### PR TITLE
[Bugfix] Fixes For Calculation Y Axis Width

### DIFF
--- a/src/pages/dashboard/components/Chart.tsx
+++ b/src/pages/dashboard/components/Chart.tsx
@@ -135,7 +135,9 @@ export function Chart(props: Props) {
     const largestTick = chartData.reduce((maxTick, data) => {
       return properties.reduce((currentMax, property) => {
         const currentTickLength = formatMoney(
-          Number(data[property as keyof typeof data]) ?? 0,
+          typeof data[property as keyof typeof data] === 'number'
+            ? Number((data[property as keyof typeof data] as number) * 10)
+            : 0,
           company?.settings.country_id,
           currency
         ).toString().length;


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for the calculations of the y-axis width. We encountered a similar issue much earlier, which I addressed with a solution that covered many cases. However, I didn't account for this specific scenario. I've now added a quick improvement to fix the case that the client discovered. Here's a screenshot of the fixed case the user created:

![Screenshot 2024-09-08 at 22 58 16](https://github.com/user-attachments/assets/b94fc387-5b8f-42da-ba80-3cbb86ad599f)

Let me know your thoughts.

Closes #2032 