### PR TITLE
[Cleanup] Generating Additional Columns As Link To Edit Page When Optional Columns Missing

### DIFF
--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -157,7 +157,7 @@ interface Props<T> extends CommonProps {
   enableFormattingEditPageLinkColumn?: boolean;
   formatEditPageLinkColumn?: (value: ReactNode, resource: T) => ReactElement;
   editPageLinkColumnOptions?: string[];
-  editPageLinkColumn?: string;
+  editPageLinkColumns?: string[];
 }
 
 export type ResourceAction<T> = (resource: T) => ReactElement;
@@ -201,7 +201,7 @@ export function DataTable<T extends object>(props: Props<T>) {
     showRestoreBulk,
     formatEditPageLinkColumn,
     editPageLinkColumnOptions = [],
-    editPageLinkColumn,
+    editPageLinkColumns = [],
   } = props;
 
   const firstEditPageLinkColumnOption = useRef<string>('');
@@ -474,8 +474,7 @@ export function DataTable<T extends object>(props: Props<T>) {
 
   useEffect(() => {
     if (
-      editPageLinkColumn &&
-      props.columns.some((column) => column.id === editPageLinkColumn)
+      props.columns.some((column) => editPageLinkColumns.includes(column.id))
     ) {
       firstEditPageLinkColumnOption.current = '';
     }
@@ -493,12 +492,12 @@ export function DataTable<T extends object>(props: Props<T>) {
         )
       : (resource[column.id as keyof T] as T);
 
-    if (!editPageLinkColumn) {
+    if (!editPageLinkColumns.length) {
       return currentValue;
     }
 
-    const isEditPageColumnAvailable = props.columns.some(
-      (col) => col.id === editPageLinkColumn
+    const isEditPageColumnAvailable = props.columns.some((col) =>
+      editPageLinkColumns.includes(col.id)
     );
 
     if (

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -70,6 +70,7 @@ export interface DateRangeColumn {
 export type DataTableColumn<T = any> = {
   id: string;
   label: string;
+  column?: string;
   format?: (field: string | number, resource: T) => unknown;
 };
 
@@ -474,7 +475,9 @@ export function DataTable<T extends object>(props: Props<T>) {
 
   useEffect(() => {
     if (
-      props.columns.some((column) => editPageLinkColumns.includes(column.id))
+      props.columns.some(
+        (column) => column.column && editPageLinkColumns.includes(column.column)
+      )
     ) {
       firstEditPageLinkColumnOption.current = '';
     }
@@ -496,8 +499,8 @@ export function DataTable<T extends object>(props: Props<T>) {
       return currentValue;
     }
 
-    const isEditPageColumnAvailable = props.columns.some((col) =>
-      editPageLinkColumns.includes(col.id)
+    const isEditPageColumnAvailable = props.columns.some(
+      (col) => col.column && editPageLinkColumns.includes(col.column)
     );
 
     if (

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 /**
  * Invoice Ninja (https://invoiceninja.com).
  *
@@ -152,6 +153,9 @@ interface Props<T> extends CommonProps {
   withoutPerPageAsPreference?: boolean;
   withoutSortQueryParameter?: boolean;
   showRestoreBulk?: (selectedResources: T[]) => boolean;
+  enableFormattingEditPageLinkColumn?: boolean;
+  formatEditPageLinkColumn?: (value: ReactNode, resource: T) => ReactElement;
+  editPageLinkColumnOptions?: string[];
 }
 
 export type ResourceAction<T> = (resource: T) => ReactElement;
@@ -193,6 +197,9 @@ export function DataTable<T extends object>(props: Props<T>) {
     withoutPerPageAsPreference = false,
     withoutSortQueryParameter = false,
     showRestoreBulk,
+    enableFormattingEditPageLinkColumn,
+    formatEditPageLinkColumn,
+    editPageLinkColumnOptions = [],
   } = props;
 
   const companyUpdateTimeOut = useRef<NodeJS.Timeout | undefined>(undefined);
@@ -742,7 +749,15 @@ export function DataTable<T extends object>(props: Props<T>) {
                           }
                         }}
                       >
-                        {column.format
+                        {formatEditPageLinkColumn &&
+                        editPageLinkColumnOptions.includes(column.id)
+                          ? formatEditPageLinkColumn(
+                              column.format
+                                ? column.format(resource[column.id], resource)
+                                : resource[column.id],
+                              resource as T
+                            )
+                          : column.format
                           ? column.format(resource[column.id], resource)
                           : resource[column.id]}
                       </Td>

--- a/src/pages/clients/show/pages/Expenses.tsx
+++ b/src/pages/clients/show/pages/Expenses.tsx
@@ -11,7 +11,11 @@
 import { permission } from '$app/common/guards/guards/permission';
 import { route } from '$app/common/helpers/route';
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
+import { useDisableNavigation } from '$app/common/hooks/useDisableNavigation';
+import { Expense } from '$app/common/interfaces/expense';
 import { DataTable } from '$app/components/DataTable';
+import { DynamicLink } from '$app/components/DynamicLink';
+import { getEditPageLinkColumnOptions } from '$app/pages/expenses/common/helpers/columns';
 import {
   useActions,
   useExpenseColumns,
@@ -23,12 +27,14 @@ export default function Expenses() {
   const { id } = useParams();
 
   const hasPermission = useHasPermission();
+  const disableNavigation = useDisableNavigation();
 
-  const columns = useExpenseColumns();
-
-  const filters = useExpenseFilters();
+  const { mainEditPageLinkColumns, editPageLinkColumnOptions } =
+    getEditPageLinkColumnOptions();
 
   const actions = useActions();
+  const filters = useExpenseFilters();
+  const columns = useExpenseColumns();
 
   return (
     <DataTable
@@ -50,6 +56,16 @@ export default function Expenses() {
       excludeColumns={['client_id']}
       linkToCreateGuards={[permission('create_expense')]}
       hideEditableOptions={!hasPermission('edit_expense')}
+      formatEditPageLinkColumn={(value, expense: Expense) => (
+        <DynamicLink
+          to={route('/expenses/:id/edit', { id: expense.id })}
+          renderSpan={disableNavigation('expense', expense)}
+        >
+          {value}
+        </DynamicLink>
+      )}
+      editPageLinkColumns={mainEditPageLinkColumns}
+      editPageLinkColumnOptions={editPageLinkColumnOptions}
     />
   );
 }

--- a/src/pages/clients/show/pages/RecurringExpenses.tsx
+++ b/src/pages/clients/show/pages/RecurringExpenses.tsx
@@ -11,7 +11,11 @@
 import { permission } from '$app/common/guards/guards/permission';
 import { route } from '$app/common/helpers/route';
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
+import { useDisableNavigation } from '$app/common/hooks/useDisableNavigation';
+import { RecurringExpense } from '$app/common/interfaces/recurring-expense';
 import { DataTable } from '$app/components/DataTable';
+import { DynamicLink } from '$app/components/DynamicLink';
+import { getEditPageLinkColumnOptions } from '$app/pages/recurring-expenses/common/helpers/columns';
 import {
   useActions,
   useRecurringExpenseColumns,
@@ -22,10 +26,12 @@ export default function RecurringExpenses() {
   const { id } = useParams();
 
   const hasPermission = useHasPermission();
-
-  const columns = useRecurringExpenseColumns();
+  const disableNavigation = useDisableNavigation();
 
   const actions = useActions();
+  const columns = useRecurringExpenseColumns();
+  const { mainEditPageLinkColumns, editPageLinkColumnOptions } =
+    getEditPageLinkColumnOptions();
 
   return (
     <DataTable
@@ -43,6 +49,18 @@ export default function RecurringExpenses() {
       excludeColumns={['client_id']}
       linkToCreateGuards={[permission('create_recurring_expense')]}
       hideEditableOptions={!hasPermission('edit_recurring_expense')}
+      formatEditPageLinkColumn={(value, recurringExpense: RecurringExpense) => (
+        <DynamicLink
+          to={route('/recurring_expenses/:id/edit', {
+            id: recurringExpense.id,
+          })}
+          renderSpan={disableNavigation('recurring_expense', recurringExpense)}
+        >
+          {value}
+        </DynamicLink>
+      )}
+      editPageLinkColumns={mainEditPageLinkColumns}
+      editPageLinkColumnOptions={editPageLinkColumnOptions}
     />
   );
 }

--- a/src/pages/clients/show/pages/Tasks.tsx
+++ b/src/pages/clients/show/pages/Tasks.tsx
@@ -39,7 +39,7 @@ export default function Tasks() {
   const filters = useTaskFilters();
   const columns = useTaskColumns();
   const customBulkActions = useCustomBulkActions();
-  const { mainEditPageLinkColumn, editPageLinkColumnOptions } =
+  const { mainEditPageLinkColumns, editPageLinkColumnOptions } =
     getEditPageLinkColumnOptions();
 
   return (
@@ -75,7 +75,7 @@ export default function Tasks() {
           {value}
         </DynamicLink>
       )}
-      editPageLinkColumn={mainEditPageLinkColumn}
+      editPageLinkColumns={mainEditPageLinkColumns}
       editPageLinkColumnOptions={editPageLinkColumnOptions}
     />
   );

--- a/src/pages/clients/show/pages/Tasks.tsx
+++ b/src/pages/clients/show/pages/Tasks.tsx
@@ -11,9 +11,12 @@
 import { permission } from '$app/common/guards/guards/permission';
 import { route } from '$app/common/helpers/route';
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
+import { useDisableNavigation } from '$app/common/hooks/useDisableNavigation';
 import { Task } from '$app/common/interfaces/task';
 import { useClientQuery } from '$app/common/queries/clients';
 import { DataTable } from '$app/components/DataTable';
+import { DynamicLink } from '$app/components/DynamicLink';
+import { getEditPageLinkColumnOptions } from '$app/pages/tasks/common/helpers/columns';
 import {
   useActions,
   useCustomBulkActions,
@@ -27,18 +30,17 @@ export default function Tasks() {
   const { id } = useParams();
 
   const hasPermission = useHasPermission();
+  const showEditOption = useShowEditOption();
+  const disableNavigation = useDisableNavigation();
 
   const { data: client } = useClientQuery({ id, enabled: true });
 
-  const columns = useTaskColumns();
-
-  const filters = useTaskFilters();
-
   const actions = useActions();
-
+  const filters = useTaskFilters();
+  const columns = useTaskColumns();
   const customBulkActions = useCustomBulkActions();
-
-  const showEditOption = useShowEditOption();
+  const { mainEditPageLinkColumn, editPageLinkColumnOptions } =
+    getEditPageLinkColumnOptions();
 
   return (
     <DataTable
@@ -65,6 +67,16 @@ export default function Tasks() {
       showEdit={(task: Task) => showEditOption(task)}
       linkToCreateGuards={[permission('create_task')]}
       hideEditableOptions={!hasPermission('edit_task')}
+      formatEditPageLinkColumn={(value, task) => (
+        <DynamicLink
+          to={route('/tasks/:id/edit', { id: task.id })}
+          renderSpan={disableNavigation('task', task)}
+        >
+          {value}
+        </DynamicLink>
+      )}
+      editPageLinkColumn={mainEditPageLinkColumn}
+      editPageLinkColumnOptions={editPageLinkColumnOptions}
     />
   );
 }

--- a/src/pages/expenses/common/helpers/columns.ts
+++ b/src/pages/expenses/common/helpers/columns.ts
@@ -10,15 +10,12 @@
 
 export function getEditPageLinkColumnOptions() {
   return {
-    mainEditPageLinkColumns: ['number'],
+    mainEditPageLinkColumns: ['number', 'status_id'],
     editPageLinkColumnOptions: [
-      'description',
-      'number',
-      'time_log',
-      'entity_state',
-      'calculated_rate',
-      'is_running',
-      'rate',
+      'date',
+      'amount',
+      'public_notes',
+      'exchange_rate',
     ],
   };
 }

--- a/src/pages/expenses/common/helpers/columns.ts
+++ b/src/pages/expenses/common/helpers/columns.ts
@@ -10,7 +10,7 @@
 
 export function getEditPageLinkColumnOptions() {
   return {
-    mainEditPageLinkColumns: ['number', 'status_id'],
+    mainEditPageLinkColumns: ['number', 'status'],
     editPageLinkColumnOptions: [
       'date',
       'amount',

--- a/src/pages/expenses/index/Expenses.tsx
+++ b/src/pages/expenses/index/Expenses.tsx
@@ -26,6 +26,10 @@ import { useCustomBulkActions } from '../common/hooks/useCustomBulkActions';
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 import { Guard } from '$app/common/guards/Guard';
 import { or } from '$app/common/guards/guards/or';
+import { DynamicLink } from '$app/components/DynamicLink';
+import { route } from '$app/common/helpers/route';
+import { useDisableNavigation } from '$app/common/hooks/useDisableNavigation';
+import { getEditPageLinkColumnOptions } from '../common/helpers/columns';
 
 export default function Expenses() {
   useTitle('expenses');
@@ -35,22 +39,18 @@ export default function Expenses() {
 
   const pages = [{ name: t('expenses'), href: '/expenses' }];
 
-  const columns = useExpenseColumns();
+  const disableNavigation = useDisableNavigation();
 
   const actions = useActions();
-
   const filters = useExpenseFilters();
-
+  const columns = useExpenseColumns();
   const expenseColumns = useAllExpenseColumns();
-
   const customBulkActions = useCustomBulkActions();
+  const { mainEditPageLinkColumns, editPageLinkColumnOptions } =
+    getEditPageLinkColumnOptions();
 
   return (
-    <Default
-      title={t('expenses')}
-      breadcrumbs={pages}
-      docsLink="en/expenses"
-    >
+    <Default title={t('expenses')} breadcrumbs={pages} docsLink="en/expenses">
       <DataTable
         resource="expense"
         endpoint="/api/v1/expenses?include=client,vendor,category&without_deleted_clients=true&without_deleted_vendors=true&sort=id|desc"
@@ -81,6 +81,16 @@ export default function Expenses() {
         }
         linkToCreateGuards={[permission('create_expense')]}
         hideEditableOptions={!hasPermission('edit_expense')}
+        formatEditPageLinkColumn={(value, expense) => (
+          <DynamicLink
+            to={route('/expenses/:id/edit', { id: expense.id })}
+            renderSpan={disableNavigation('expense', expense)}
+          >
+            {value}
+          </DynamicLink>
+        )}
+        editPageLinkColumns={mainEditPageLinkColumns}
+        editPageLinkColumnOptions={editPageLinkColumnOptions}
       />
     </Default>
   );

--- a/src/pages/projects/show/Show.tsx
+++ b/src/pages/projects/show/Show.tsx
@@ -58,6 +58,9 @@ import { useFormatNumber } from '$app/common/hooks/useFormatNumber';
 import { ClientActionButtons } from '$app/pages/invoices/common/components/ClientActionButtons';
 import { ProjectPrivateNotes } from './components/ProjectPrivateNotes';
 import { ProjectPublicNotes } from './components/ProjectPublicNotes';
+import { DynamicLink } from '$app/components/DynamicLink';
+import { useDisableNavigation } from '$app/common/hooks/useDisableNavigation';
+import { getEditPageLinkColumnOptions } from '$app/pages/tasks/common/helpers/columns';
 
 dayjs.extend(duration);
 
@@ -93,18 +96,19 @@ export default function Show() {
     staleTime: Infinity,
   });
 
-  const projectActions = useProjectsActions();
-  const taskActions = useTasksActions();
-  const columns = useTaskColumns();
-  const formatMoney = useFormatMoney();
-
-  const filters = useTaskFilters();
-  const taskColumns = useAllTaskColumns();
-
-  const customBulkActions = useCustomBulkActions();
-
-  const showEditOption = useShowEditOption();
   const colors = useColorScheme();
+  const filters = useTaskFilters();
+  const columns = useTaskColumns();
+  const taskActions = useTasksActions();
+  const taskColumns = useAllTaskColumns();
+  const projectActions = useProjectsActions();
+  const customBulkActions = useCustomBulkActions();
+  const { mainEditPageLinkColumn, editPageLinkColumnOptions } =
+    getEditPageLinkColumnOptions();
+
+  const formatMoney = useFormatMoney();
+  const showEditOption = useShowEditOption();
+  const disableNavigation = useDisableNavigation();
 
   const {
     changeTemplateVisible,
@@ -251,6 +255,16 @@ export default function Show() {
             }
             linkToCreateGuards={[permission('create_task')]}
             hideEditableOptions={!hasPermission('edit_task')}
+            formatEditPageLinkColumn={(value, task) => (
+              <DynamicLink
+                to={route('/tasks/:id/edit', { id: task.id })}
+                renderSpan={disableNavigation('task', task)}
+              >
+                {value}
+              </DynamicLink>
+            )}
+            editPageLinkColumn={mainEditPageLinkColumn}
+            editPageLinkColumnOptions={editPageLinkColumnOptions}
           />
         </div>
       )}

--- a/src/pages/projects/show/Show.tsx
+++ b/src/pages/projects/show/Show.tsx
@@ -103,7 +103,7 @@ export default function Show() {
   const taskColumns = useAllTaskColumns();
   const projectActions = useProjectsActions();
   const customBulkActions = useCustomBulkActions();
-  const { mainEditPageLinkColumn, editPageLinkColumnOptions } =
+  const { mainEditPageLinkColumns, editPageLinkColumnOptions } =
     getEditPageLinkColumnOptions();
 
   const formatMoney = useFormatMoney();
@@ -263,7 +263,7 @@ export default function Show() {
                 {value}
               </DynamicLink>
             )}
-            editPageLinkColumn={mainEditPageLinkColumn}
+            editPageLinkColumns={mainEditPageLinkColumns}
             editPageLinkColumnOptions={editPageLinkColumnOptions}
           />
         </div>

--- a/src/pages/recurring-expenses/common/helpers/columns.tsx
+++ b/src/pages/recurring-expenses/common/helpers/columns.tsx
@@ -10,15 +10,16 @@
 
 export function getEditPageLinkColumnOptions() {
   return {
-    mainEditPageLinkColumns: ['number'],
+    mainEditPageLinkColumns: ['number', 'status_id'],
     editPageLinkColumnOptions: [
-      'description',
-      'number',
-      'time_log',
-      'entity_state',
-      'calculated_rate',
-      'is_running',
-      'rate',
+      'date',
+      'amount',
+      'public_notes',
+      'exchange_rate',
+      'payment_date',
+      'private_notes',
+      'should_be_invoiced',
+      'next_send_date',
     ],
   };
 }

--- a/src/pages/recurring-expenses/common/helpers/columns.tsx
+++ b/src/pages/recurring-expenses/common/helpers/columns.tsx
@@ -10,7 +10,7 @@
 
 export function getEditPageLinkColumnOptions() {
   return {
-    mainEditPageLinkColumns: ['number', 'status_id'],
+    mainEditPageLinkColumns: ['number', 'status'],
     editPageLinkColumnOptions: [
       'date',
       'amount',

--- a/src/pages/recurring-expenses/index/RecurringExpenses.tsx
+++ b/src/pages/recurring-expenses/index/RecurringExpenses.tsx
@@ -21,6 +21,10 @@ import {
 import { permission } from '$app/common/guards/guards/permission';
 import { useCustomBulkActions } from '../common/hooks/useCustomBulkActions';
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
+import { DynamicLink } from '$app/components/DynamicLink';
+import { route } from '$app/common/helpers/route';
+import { useDisableNavigation } from '$app/common/hooks/useDisableNavigation';
+import { getEditPageLinkColumnOptions } from '../common/helpers/columns';
 
 export default function RecurringExpenses() {
   useTitle('recurring_expenses');
@@ -28,18 +32,18 @@ export default function RecurringExpenses() {
   const [t] = useTranslation();
 
   const hasPermission = useHasPermission();
+  const disableNavigation = useDisableNavigation();
 
   const pages = [
     { name: t('recurring_expenses'), href: '/recurring_expenses' },
   ];
 
-  const columns = useRecurringExpenseColumns();
-
   const actions = useActions();
-
-  const recurringExpenseColumns = useAllRecurringExpenseColumns();
-
+  const columns = useRecurringExpenseColumns();
   const customBulkActions = useCustomBulkActions();
+  const recurringExpenseColumns = useAllRecurringExpenseColumns();
+  const { mainEditPageLinkColumns, editPageLinkColumnOptions } =
+    getEditPageLinkColumnOptions();
 
   return (
     <Default
@@ -66,6 +70,21 @@ export default function RecurringExpenses() {
         }
         linkToCreateGuards={[permission('create_recurring_expense')]}
         hideEditableOptions={!hasPermission('edit_recurring_expense')}
+        formatEditPageLinkColumn={(value, recurringExpense) => (
+          <DynamicLink
+            to={route('/recurring_expenses/:id/edit', {
+              id: recurringExpense.id,
+            })}
+            renderSpan={disableNavigation(
+              'recurring_expense',
+              recurringExpense
+            )}
+          >
+            {value}
+          </DynamicLink>
+        )}
+        editPageLinkColumns={mainEditPageLinkColumns}
+        editPageLinkColumnOptions={editPageLinkColumnOptions}
       />
     </Default>
   );

--- a/src/pages/tasks/common/helpers/columns.ts
+++ b/src/pages/tasks/common/helpers/columns.ts
@@ -1,0 +1,24 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+export function getEditPageLinkColumnOptions() {
+  return {
+    mainEditPageLinkColumn: 'number',
+    editPageLinkColumnOptions: [
+      'description',
+      'number',
+      'time_log',
+      'entity_state',
+      'calculated_rate',
+      'is_running',
+      'rate',
+    ],
+  };
+}

--- a/src/pages/tasks/index/Tasks.tsx
+++ b/src/pages/tasks/index/Tasks.tsx
@@ -36,7 +36,7 @@ import {
   taskSliderAtom,
   taskSliderVisibilityAtom,
 } from '../common/components/TaskSlider';
-import { ReactElement, useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useAtom } from 'jotai';
 import { useTaskQuery } from '$app/common/queries/tasks';
 import { useDisableNavigation } from '$app/common/hooks/useDisableNavigation';
@@ -47,6 +47,7 @@ import {
 import { ExtensionBanner } from '../common/components/ExtensionBanner';
 import { DynamicLink } from '$app/components/DynamicLink';
 import { route } from '$app/common/helpers/route';
+import { getEditPageLinkColumnOptions } from '../common/helpers/columns';
 
 export default function Tasks() {
   const { documentTitle } = useTitle('tasks');
@@ -58,13 +59,13 @@ export default function Tasks() {
 
   const pages = [{ name: t('tasks'), href: '/tasks' }];
 
-  const isFormattingEditPageLinkColumnEnabled = useRef<boolean>(false);
-
   const actions = useActions();
   const filters = useTaskFilters();
   const columns = useTaskColumns();
   const taskColumns = useAllTaskColumns();
   const customBulkActions = useCustomBulkActions();
+  const { mainEditPageLinkColumn, editPageLinkColumnOptions } =
+    getEditPageLinkColumnOptions();
 
   const [sliderTaskId, setSliderTaskId] = useState<string>('');
   const [taskSlider, setTaskSlider] = useAtom(taskSliderAtom);
@@ -89,14 +90,6 @@ export default function Tasks() {
     setChangeTemplateVisible,
     changeTemplateResources,
   } = useChangeTemplate();
-
-  useEffect(() => {
-    if (columns.some((column) => column.id === 'number')) {
-      isFormattingEditPageLinkColumnEnabled.current = false;
-    } else {
-      isFormattingEditPageLinkColumnEnabled.current = true;
-    }
-  }, [columns]);
 
   return (
     <Default
@@ -147,33 +140,16 @@ export default function Tasks() {
           setSliderTaskId(quote.id);
           setTaskSliderVisibility(true);
         }}
-        formatEditPageLinkColumn={(value, task) => {
-          const lastValue = isFormattingEditPageLinkColumnEnabled.current;
-
-          if (value) {
-            isFormattingEditPageLinkColumnEnabled.current = false;
-          }
-
-          return value && lastValue ? (
-            <DynamicLink
-              to={route('/tasks/:id/edit', { id: task.id })}
-              renderSpan={disableNavigation('task', task)}
-            >
-              {value}
-            </DynamicLink>
-          ) : (
-            (value as unknown as ReactElement)
-          );
-        }}
-        editPageLinkColumnOptions={[
-          'description',
-          'number',
-          'time_log',
-          'entity_state',
-          'calculated_rate',
-          'is_running',
-          'rate',
-        ]}
+        formatEditPageLinkColumn={(value, task) => (
+          <DynamicLink
+            to={route('/tasks/:id/edit', { id: task.id })}
+            renderSpan={disableNavigation('task', task)}
+          >
+            {value}
+          </DynamicLink>
+        )}
+        editPageLinkColumn={mainEditPageLinkColumn}
+        editPageLinkColumnOptions={editPageLinkColumnOptions}
       />
 
       {!disableNavigation('task', taskSlider) && <TaskSlider />}

--- a/src/pages/tasks/index/Tasks.tsx
+++ b/src/pages/tasks/index/Tasks.tsx
@@ -64,7 +64,7 @@ export default function Tasks() {
   const columns = useTaskColumns();
   const taskColumns = useAllTaskColumns();
   const customBulkActions = useCustomBulkActions();
-  const { mainEditPageLinkColumn, editPageLinkColumnOptions } =
+  const { mainEditPageLinkColumns, editPageLinkColumnOptions } =
     getEditPageLinkColumnOptions();
 
   const [sliderTaskId, setSliderTaskId] = useState<string>('');
@@ -148,7 +148,7 @@ export default function Tasks() {
             {value}
           </DynamicLink>
         )}
-        editPageLinkColumn={mainEditPageLinkColumn}
+        editPageLinkColumns={mainEditPageLinkColumns}
         editPageLinkColumnOptions={editPageLinkColumnOptions}
       />
 

--- a/src/pages/vendors/show/pages/Expenses.tsx
+++ b/src/pages/vendors/show/pages/Expenses.tsx
@@ -11,7 +11,11 @@
 import { permission } from '$app/common/guards/guards/permission';
 import { route } from '$app/common/helpers/route';
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
+import { useDisableNavigation } from '$app/common/hooks/useDisableNavigation';
+import { Expense } from '$app/common/interfaces/expense';
 import { DataTable } from '$app/components/DataTable';
+import { DynamicLink } from '$app/components/DynamicLink';
+import { getEditPageLinkColumnOptions } from '$app/pages/expenses/common/helpers/columns';
 import {
   useActions,
   useExpenseColumns,
@@ -23,12 +27,13 @@ export default function Expenses() {
   const { id } = useParams();
 
   const hasPermission = useHasPermission();
-
-  const columns = useExpenseColumns();
-
-  const filters = useExpenseFilters();
+  const disableNavigation = useDisableNavigation();
 
   const actions = useActions();
+  const filters = useExpenseFilters();
+  const columns = useExpenseColumns();
+  const { mainEditPageLinkColumns, editPageLinkColumnOptions } =
+    getEditPageLinkColumnOptions();
 
   return (
     <DataTable
@@ -50,6 +55,16 @@ export default function Expenses() {
       excludeColumns={['vendor_id']}
       linkToCreateGuards={[permission('create_expense')]}
       hideEditableOptions={!hasPermission('edit_expense')}
+      formatEditPageLinkColumn={(value, expense: Expense) => (
+        <DynamicLink
+          to={route('/expenses/:id/edit', { id: expense.id })}
+          renderSpan={disableNavigation('expense', expense)}
+        >
+          {value}
+        </DynamicLink>
+      )}
+      editPageLinkColumns={mainEditPageLinkColumns}
+      editPageLinkColumnOptions={editPageLinkColumnOptions}
     />
   );
 }

--- a/src/pages/vendors/show/pages/RecurringExpenses.tsx
+++ b/src/pages/vendors/show/pages/RecurringExpenses.tsx
@@ -11,7 +11,11 @@
 import { permission } from '$app/common/guards/guards/permission';
 import { route } from '$app/common/helpers/route';
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
+import { useDisableNavigation } from '$app/common/hooks/useDisableNavigation';
+import { RecurringExpense } from '$app/common/interfaces/recurring-expense';
 import { DataTable } from '$app/components/DataTable';
+import { DynamicLink } from '$app/components/DynamicLink';
+import { getEditPageLinkColumnOptions } from '$app/pages/recurring-expenses/common/helpers/columns';
 import {
   useActions,
   useRecurringExpenseColumns,
@@ -22,10 +26,12 @@ export default function RecurringExpenses() {
   const { id } = useParams();
 
   const hasPermission = useHasPermission();
-
-  const columns = useRecurringExpenseColumns();
+  const disableNavigation = useDisableNavigation();
 
   const actions = useActions();
+  const columns = useRecurringExpenseColumns();
+  const { mainEditPageLinkColumns, editPageLinkColumnOptions } =
+    getEditPageLinkColumnOptions();
 
   return (
     <DataTable
@@ -43,6 +49,18 @@ export default function RecurringExpenses() {
       excludeColumns={['vendor_id']}
       linkToCreateGuards={[permission('create_recurring_expense')]}
       hideEditableOptions={!hasPermission('edit_recurring_expense')}
+      formatEditPageLinkColumn={(value, recurringExpense: RecurringExpense) => (
+        <DynamicLink
+          to={route('/recurring_expenses/:id/edit', {
+            id: recurringExpense.id,
+          })}
+          renderSpan={disableNavigation('recurring_expense', recurringExpense)}
+        >
+          {value}
+        </DynamicLink>
+      )}
+      editPageLinkColumns={mainEditPageLinkColumns}
+      editPageLinkColumnOptions={editPageLinkColumnOptions}
     />
   );
 }


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of logic that makes additional columns as links to an edit page if the main one is not selected in the columns picker. This is implemented for tasks, expenses, and recurring expenses. Let me know your thoughts.

Closes #1967 