### PR TITLE
[Bugfix] Client Tax Exempt Overriding

### DIFF
--- a/src/pages/credits/create/Create.tsx
+++ b/src/pages/credits/create/Create.tsx
@@ -176,37 +176,39 @@ export default function Create() {
 
         handleChange('invitations', invitations);
 
-        if (
-          company &&
-          company.enabled_tax_rates > 0 &&
-          searchParams.get('action') !== 'clone'
-        ) {
-          const { name, rate } = settingResolver(client, '1');
+        if (!client.is_tax_exempt) {
+          if (
+            company &&
+            company.enabled_tax_rates > 0 &&
+            searchParams.get('action') !== 'clone'
+          ) {
+            const { name, rate } = settingResolver(client, '1');
 
-          handleChange('tax_name1', name);
-          handleChange('tax_rate1', rate);
-        }
+            handleChange('tax_name1', name);
+            handleChange('tax_rate1', rate);
+          }
 
-        if (
-          company &&
-          company.enabled_tax_rates > 1 &&
-          searchParams.get('action') !== 'clone'
-        ) {
-          const { name, rate } = settingResolver(client, '2');
+          if (
+            company &&
+            company.enabled_tax_rates > 1 &&
+            searchParams.get('action') !== 'clone'
+          ) {
+            const { name, rate } = settingResolver(client, '2');
 
-          handleChange('tax_name2', name);
-          handleChange('tax_rate2', rate);
-        }
+            handleChange('tax_name2', name);
+            handleChange('tax_rate2', rate);
+          }
 
-        if (
-          company &&
-          company.enabled_tax_rates > 2 &&
-          searchParams.get('action') !== 'clone'
-        ) {
-          const { name, rate } = settingResolver(client, '3');
+          if (
+            company &&
+            company.enabled_tax_rates > 2 &&
+            searchParams.get('action') !== 'clone'
+          ) {
+            const { name, rate } = settingResolver(client, '3');
 
-          handleChange('tax_name3', name);
-          handleChange('tax_rate3', rate);
+            handleChange('tax_name3', name);
+            handleChange('tax_rate3', rate);
+          }
         }
       });
   }, [credit?.client_id]);

--- a/src/pages/invoices/create/Create.tsx
+++ b/src/pages/invoices/create/Create.tsx
@@ -185,37 +185,39 @@ export default function Create() {
 
         handleChange('invitations', invitations);
 
-        if (
-          company &&
-          company.enabled_tax_rates > 0 &&
-          searchParams.get('action') !== 'clone'
-        ) {
-          const { name, rate } = settingResolver(client, '1');
+        if (!client.is_tax_exempt) {
+          if (
+            company &&
+            company.enabled_tax_rates > 0 &&
+            searchParams.get('action') !== 'clone'
+          ) {
+            const { name, rate } = settingResolver(client, '1');
 
-          handleChange('tax_name1', name);
-          handleChange('tax_rate1', rate);
-        }
+            handleChange('tax_name1', name);
+            handleChange('tax_rate1', rate);
+          }
 
-        if (
-          company &&
-          company.enabled_tax_rates > 1 &&
-          searchParams.get('action') !== 'clone'
-        ) {
-          const { name, rate } = settingResolver(client, '2');
+          if (
+            company &&
+            company.enabled_tax_rates > 1 &&
+            searchParams.get('action') !== 'clone'
+          ) {
+            const { name, rate } = settingResolver(client, '2');
 
-          handleChange('tax_name2', name);
-          handleChange('tax_rate2', rate);
-        }
+            handleChange('tax_name2', name);
+            handleChange('tax_rate2', rate);
+          }
 
-        if (
-          company &&
-          company.enabled_tax_rates > 2 &&
-          searchParams.get('action') !== 'clone'
-        ) {
-          const { name, rate } = settingResolver(client, '3');
+          if (
+            company &&
+            company.enabled_tax_rates > 2 &&
+            searchParams.get('action') !== 'clone'
+          ) {
+            const { name, rate } = settingResolver(client, '3');
 
-          handleChange('tax_name3', name);
-          handleChange('tax_rate3', rate);
+            handleChange('tax_name3', name);
+            handleChange('tax_rate3', rate);
+          }
         }
       });
   }, [invoice?.client_id]);

--- a/src/pages/quotes/create/Create.tsx
+++ b/src/pages/quotes/create/Create.tsx
@@ -168,37 +168,39 @@ export default function Create() {
 
         handleChange('invitations', invitations);
 
-        if (
-          company &&
-          company.enabled_tax_rates > 0 &&
-          searchParams.get('action') !== 'clone'
-        ) {
-          const { name, rate } = settingResolver(client, '1');
+        if (!client.is_tax_exempt) {
+          if (
+            company &&
+            company.enabled_tax_rates > 0 &&
+            searchParams.get('action') !== 'clone'
+          ) {
+            const { name, rate } = settingResolver(client, '1');
 
-          handleChange('tax_name1', name);
-          handleChange('tax_rate1', rate);
-        }
+            handleChange('tax_name1', name);
+            handleChange('tax_rate1', rate);
+          }
 
-        if (
-          company &&
-          company.enabled_tax_rates > 1 &&
-          searchParams.get('action') !== 'clone'
-        ) {
-          const { name, rate } = settingResolver(client, '2');
+          if (
+            company &&
+            company.enabled_tax_rates > 1 &&
+            searchParams.get('action') !== 'clone'
+          ) {
+            const { name, rate } = settingResolver(client, '2');
 
-          handleChange('tax_name2', name);
-          handleChange('tax_rate2', rate);
-        }
+            handleChange('tax_name2', name);
+            handleChange('tax_rate2', rate);
+          }
 
-        if (
-          company &&
-          company.enabled_tax_rates > 2 &&
-          searchParams.get('action') !== 'clone'
-        ) {
-          const { name, rate } = settingResolver(client, '3');
+          if (
+            company &&
+            company.enabled_tax_rates > 2 &&
+            searchParams.get('action') !== 'clone'
+          ) {
+            const { name, rate } = settingResolver(client, '3');
 
-          handleChange('tax_name3', name);
-          handleChange('tax_rate3', rate);
+            handleChange('tax_name3', name);
+            handleChange('tax_rate3', rate);
+          }
         }
       });
   }, [quote?.client_id]);

--- a/src/pages/recurring-invoices/create/Create.tsx
+++ b/src/pages/recurring-invoices/create/Create.tsx
@@ -179,37 +179,39 @@ export default function Create() {
 
         handleChange('invitations', invitations);
 
-        if (
-          company &&
-          company.enabled_tax_rates > 0 &&
-          searchParams.get('action') !== 'clone'
-        ) {
-          const { name, rate } = settingResolver(client, '1');
+        if (!client.is_tax_exempt) {
+          if (
+            company &&
+            company.enabled_tax_rates > 0 &&
+            searchParams.get('action') !== 'clone'
+          ) {
+            const { name, rate } = settingResolver(client, '1');
 
-          handleChange('tax_name1', name);
-          handleChange('tax_rate1', rate);
-        }
+            handleChange('tax_name1', name);
+            handleChange('tax_rate1', rate);
+          }
 
-        if (
-          company &&
-          company.enabled_tax_rates > 1 &&
-          searchParams.get('action') !== 'clone'
-        ) {
-          const { name, rate } = settingResolver(client, '2');
+          if (
+            company &&
+            company.enabled_tax_rates > 1 &&
+            searchParams.get('action') !== 'clone'
+          ) {
+            const { name, rate } = settingResolver(client, '2');
 
-          handleChange('tax_name2', name);
-          handleChange('tax_rate2', rate);
-        }
+            handleChange('tax_name2', name);
+            handleChange('tax_rate2', rate);
+          }
 
-        if (
-          company &&
-          company.enabled_tax_rates > 2 &&
-          searchParams.get('action') !== 'clone'
-        ) {
-          const { name, rate } = settingResolver(client, '3');
+          if (
+            company &&
+            company.enabled_tax_rates > 2 &&
+            searchParams.get('action') !== 'clone'
+          ) {
+            const { name, rate } = settingResolver(client, '3');
 
-          handleChange('tax_name3', name);
-          handleChange('tax_rate3', rate);
+            handleChange('tax_name3', name);
+            handleChange('tax_rate3', rate);
+          }
         }
       });
   }, [recurringInvoice?.client_id]);


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adding additional logic to prevent applying default taxes from any level if the `is_tax_exempt` is set to TRUE. If this property is set to FALSE, then the taxes will be able to be applied. Let me know your thoughts.

Closes #2040 