### PR TITLE
[Bugfix] Implementing 3 Missing Invalidations

### DIFF
--- a/src/common/queries/purchase-orders.ts
+++ b/src/common/queries/purchase-orders.ts
@@ -91,6 +91,10 @@ export function useBulk() {
 
       $refetch(['purchase_orders']);
 
+      if (action === 'expense') {
+        $refetch(['expenses']);
+      }
+
       invalidateQueryValue &&
         queryClient.invalidateQueries([invalidateQueryValue]);
     });

--- a/src/pages/quotes/common/hooks/useBulkAction.ts
+++ b/src/pages/quotes/common/hooks/useBulkAction.ts
@@ -63,7 +63,13 @@ export const useBulkAction = () => {
       invalidateQueryValue &&
         queryClient.invalidateQueries([invalidateQueryValue]);
 
+      if (action === 'convert_to_invoice') {
+        $refetch(['invoices']);
+      }
+
       if (action === 'convert_to_project') {
+        $refetch(['projects']);
+
         navigate(
           route('/projects/:id', { id: response.data.data[0].project_id })
         );


### PR DESCRIPTION
@beganovich @turbo124 The PR includes implementing 3 missing query invalidations. When converting to an Expense from Purchase Orders (invalidation of Expenses query), when converting to Project or Invoice from Quote (invalidation of Project and Expenses query). Let me know your thoughts.