### PR TITLE
[Cleanup] Project Query On Tasks

### DIFF
--- a/src/common/queries/clients.ts
+++ b/src/common/queries/clients.ts
@@ -124,6 +124,10 @@ export function useBulk() {
         queryClient.invalidateQueries([invalidateQueryValue]);
 
       $refetch(['clients']);
+
+      if (action === 'delete') {
+        $refetch(['projects']);
+      }
     });
   };
 }

--- a/src/components/projects/ProjectSelector.tsx
+++ b/src/components/projects/ProjectSelector.tsx
@@ -19,11 +19,17 @@ import { endpoint } from '$app/common/helpers';
 import { Alert } from '../Alert';
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 
-export function ProjectSelector(props: GenericSelectorProps<Project>) {
+interface Props extends GenericSelectorProps<Project> {
+  clientId?: string;
+}
+
+export function ProjectSelector(props: Props) {
   const [t] = useTranslation();
   const hasPermission = useHasPermission();
 
-  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+
+  const clientIdParam = props.clientId ? `&client_id=${props.clientId}` : '';
 
   return (
     <>
@@ -39,7 +45,7 @@ export function ProjectSelector(props: GenericSelectorProps<Project>) {
           value: props.value ?? null,
         }}
         endpoint={endpoint(
-          '/api/v1/projects?status=active&filter_deleted_clients=true'
+          `/api/v1/projects?status=active&filter_deleted_clients=true${clientIdParam}`
         )}
         entryOptions={{ id: 'id', label: 'name', value: 'id' }}
         onChange={(entry) =>

--- a/src/pages/tasks/common/components/TaskDetails.tsx
+++ b/src/pages/tasks/common/components/TaskDetails.tsx
@@ -170,6 +170,7 @@ export function TaskDetails(props: Props) {
                   handleChange('rate', project.task_rate);
                 }}
                 value={task.project_id}
+                clientId={task.client_id}
                 clearButton={Boolean(task.project_id)}
                 onClearButtonClick={() => handleChange('project_id', '')}
                 errorMessage={errors?.errors.project_id}


### PR DESCRIPTION
@beganovich @turbo124 The PR includes polishing the project query and filtering it by `client_id` if a client has been selected, so the user gets only projects from the selected client, along with adding query invalidation when clients are deleted. Let me know your thoughts.

Closes #2060 