### PR TITLE
[Bugfix] Language-Searchable Selector Does Not Overflowing TinyMCE

### DIFF
--- a/src/components/SearchableSelect.tsx
+++ b/src/components/SearchableSelect.tsx
@@ -97,6 +97,7 @@ export function SearchableSelect({
       minWidth: '100%',
       backgroundColor: colors.$4,
       borderColor: colors.$4,
+      zIndex: 50,
     }),
     control: (base, { isDisabled }) => ({
       ...base,


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes to prevent the TinyMCE header from overflowing when the language selector is opened on the user details page. Let me know your thoughts.