### PR TITLE
[Bugfix] Invoicing Project Does Not Apply Project Id To An Invoice

### DIFF
--- a/src/pages/projects/common/hooks.tsx
+++ b/src/pages/projects/common/hooks.tsx
@@ -370,7 +370,7 @@ export function useActions() {
           return toast.error('no_assigned_tasks');
         }
 
-        invoiceProject(unInvoicedTasks, project.client_id);
+        invoiceProject(unInvoicedTasks, project.client_id, project.id);
       });
   };
 
@@ -461,7 +461,10 @@ export const useCustomBulkActions = () => {
 
   const documentsBulk = useDocumentsBulk();
 
-  const handleInvoiceProjects = (tasks: Task[] | null) => {
+  const handleInvoiceProjects = (
+    tasks: Task[] | null,
+    projectsIds: string[]
+  ) => {
     if (tasks && !tasks.length) {
       return toast.error('no_assigned_tasks');
     }
@@ -470,7 +473,13 @@ export const useCustomBulkActions = () => {
       return toast.error('multiple_client_error');
     }
 
-    invoiceProject(tasks, tasks[0].client_id);
+    const projectsIdsLength = projectsIds.length;
+
+    invoiceProject(
+      tasks,
+      tasks[0].client_id,
+      projectsIds[projectsIdsLength - 1]
+    );
   };
 
   const shouldDownloadDocuments = (projects: Project[]) => {
@@ -503,7 +512,8 @@ export const useCustomBulkActions = () => {
         <DropdownElement
           onClick={async () => {
             handleInvoiceProjects(
-              await combineProjectsTasks(selectedIds, selectedResources)
+              await combineProjectsTasks(selectedIds, selectedResources),
+              selectedIds
             );
 
             setSelected([]);

--- a/src/pages/projects/common/hooks/useInvoiceProject.tsx
+++ b/src/pages/projects/common/hooks/useInvoiceProject.tsx
@@ -61,7 +61,7 @@ export function useInvoiceProject() {
 
   const setInvoice = useSetAtom(invoiceAtom);
 
-  return (tasks: Task[], clientId: string) => {
+  return (tasks: Task[], clientId: string, projectId: string) => {
     if (data) {
       const invoice: Invoice = { ...data };
 
@@ -86,6 +86,7 @@ export function useInvoiceProject() {
         return toast.error('multiple_client_error');
       }
 
+      invoice.project_id = projectId;
       invoice.client_id = clientId;
       invoice.line_items = [];
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for not applying project_id to the invoice object when invoicing a project. This should be fixed now, and project_id should be correctly applied to the invoice object. Let me know your thoughts.