### PR TITLE
[Cleanup] Replacing "Quick" Actions Section

### DIFF
--- a/src/pages/invoices/Invoice.tsx
+++ b/src/pages/invoices/Invoice.tsx
@@ -123,7 +123,6 @@ export default function Invoice() {
                 cypressRef="invoiceActionDropdown"
               />
             ),
-            topRight: <CommonActions invoice={invoice} />,
           })}
       >
         {invoice?.id === id ? (
@@ -138,7 +137,16 @@ export default function Invoice() {
             )}
 
             <div className="space-y-4">
-              <Tabs tabs={tabs} />
+              <Tabs
+                tabs={tabs}
+                rightSide={
+                  invoice && (
+                    <div className="flex items-center">
+                      <CommonActions invoice={invoice} />
+                    </div>
+                  )
+                }
+              />
 
               <Outlet
                 context={{

--- a/src/pages/invoices/edit/components/CommonActions.tsx
+++ b/src/pages/invoices/edit/components/CommonActions.tsx
@@ -16,11 +16,15 @@ import { MdSettings } from 'react-icons/md';
 import { useActions } from './Actions';
 import { ResourceAction } from '$app/components/DataTable';
 import { useCurrentUser } from '$app/common/hooks/useCurrentUser';
+import { useTranslation } from 'react-i18next';
+import { Tooltip } from '$app/components/Tooltip';
 
 interface Props {
   invoice: Invoice;
 }
 export function CommonActions(props: Props) {
+  const [t] = useTranslation();
+
   const user = useCurrentUser();
   const actions = useActions({ dropdown: false });
 
@@ -65,14 +69,21 @@ export function CommonActions(props: Props) {
           <div key={index}>{action(invoice)}</div>
         ))}
 
-        <div>
-          <Icon
-            className="cursor-pointer"
-            element={MdSettings}
-            size={25}
-            onClick={() => setIsPreferenceModalOpen(true)}
-          />
-        </div>
+        <Tooltip
+          width="auto"
+          message={t('quick_actions') as string}
+          placement="bottom"
+          withoutArrow
+        >
+          <div>
+            <Icon
+              className="cursor-pointer"
+              element={MdSettings}
+              size={25}
+              onClick={() => setIsPreferenceModalOpen(true)}
+            />
+          </div>
+        </Tooltip>
       </div>
 
       <CommonActionsPreferenceModal


### PR DESCRIPTION
@beganovich @turbo124 The PR includes replacement of the "quick actions" section for the invoice edit page. Screenshot:

<img width="554" alt="Screenshot 2024-09-27 at 20 36 39" src="https://github.com/user-attachments/assets/70e2da97-e126-46dc-9659-5e5d18d54e5b">

`Note`: We missed the "quick_actions" translation keyword in the files, so if you agree, please add it to the files.

Let me know your thoughts.