### PR TITLE
[Feature] Implementing Add To Invoice | Expense Bulk Action

### DIFF
--- a/src/pages/expenses/common/components/AddToInvoiceAction.tsx
+++ b/src/pages/expenses/common/components/AddToInvoiceAction.tsx
@@ -33,9 +33,12 @@ import { styled } from 'styled-components';
 import { useColorScheme } from '$app/common/colors';
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
+import collect from 'collect.js';
+import { toast } from '$app/common/helpers/toast/toast';
 
 interface Props {
-  expense: Expense;
+  expenses: Expense[];
+  bulkAction?: boolean;
 }
 
 const Div = styled.div`
@@ -46,26 +49,35 @@ const Div = styled.div`
 
 export function AddToInvoiceAction(props: Props) {
   const [t] = useTranslation();
+
+  const { expenses, bulkAction } = props;
+
   const navigate = useNavigate();
   const formatMoney = useFormatMoney();
-
   const hasPermission = useHasPermission();
   const entityAssigned = useEntityAssigned();
-
-  const colors = useColorScheme();
-
-  const queryClient = useQueryClient();
-
   const { calculatedTaxRate } = useInvoiceExpense();
 
-  const { expense } = props;
+  const colors = useColorScheme();
+  const queryClient = useQueryClient();
 
   const setInvoice = useSetAtom(invoiceAtom);
 
   const [invoices, setInvoices] = useState<Invoice[]>([]);
-
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [visibleModal, setVisibleModal] = useState<boolean>(false);
+
+  const handleOpenModal = () => {
+    if (bulkAction) {
+      const clientIds = collect(expenses).pluck('client_id').unique().toArray();
+
+      if (clientIds.length > 1) {
+        return toast.error('multiple_client_error');
+      }
+    }
+
+    setVisibleModal(true);
+  };
 
   const handleAddToInvoice = (invoice: Invoice) => {
     setInvoice(
@@ -74,7 +86,7 @@ export function AddToInvoiceAction(props: Props) {
           ...invoice,
           line_items: [
             ...invoice.line_items,
-            {
+            ...expenses.map((expense) => ({
               ...blankLineItem(),
               type_id: InvoiceItemType.Product,
               cost: expense.amount,
@@ -101,7 +113,7 @@ export function AddToInvoiceAction(props: Props) {
                 expense.tax_amount3,
                 expense.tax_rate3
               ),
-            },
+            })),
           ],
         }
     );
@@ -121,14 +133,14 @@ export function AddToInvoiceAction(props: Props) {
         .fetchQuery(
           [
             '/api/v1/invoices',
-            `include=client&status_id=1,2,3&is_deleted=true&filter_deleted_clients=true&client_id=${expense.client_id}`,
+            `include=client&status_id=1,2,3&is_deleted=true&filter_deleted_clients=true&client_id=${expenses[0]?.client_id}`,
           ],
           () =>
             request(
               'GET',
               endpoint(
                 '/api/v1/invoices?include=client.group_settings&status_id=1,2,3&is_deleted=true&filter_deleted_clients=true&client_id=:clientId',
-                { clientId: expense.client_id || '' }
+                { clientId: expenses[0]?.client_id || '' }
               )
             ),
           { staleTime: Infinity }
@@ -192,7 +204,7 @@ export function AddToInvoiceAction(props: Props) {
       </Modal>
 
       <DropdownElement
-        onClick={() => setVisibleModal(true)}
+        onClick={handleOpenModal}
         icon={<Icon element={MdTextSnippet} />}
       >
         {t('action_add_to_invoice')}

--- a/src/pages/expenses/common/hooks.tsx
+++ b/src/pages/expenses/common/hooks.tsx
@@ -125,7 +125,7 @@ export function useActions() {
     (expense) =>
       expense.should_be_invoiced === true &&
       expense.invoice_id.length === 0 && (
-        <AddToInvoiceAction expense={expense} />
+        <AddToInvoiceAction expenses={[expense]} />
       ),
     (expense) =>
       hasPermission('create_expense') && (

--- a/src/pages/expenses/common/hooks/useCustomBulkActions.tsx
+++ b/src/pages/expenses/common/hooks/useCustomBulkActions.tsx
@@ -128,7 +128,7 @@ export const useCustomBulkActions = () => {
   };
 
   const handleDisplayAddToInvoice = (expenses: Expense[]) => {
-    return expenses.some(({ should_be_invoiced, invoice_id }) => {
+    return expenses.every(({ should_be_invoiced, invoice_id }) => {
       return should_be_invoiced && !invoice_id.length;
     });
   };

--- a/src/pages/expenses/common/hooks/useCustomBulkActions.tsx
+++ b/src/pages/expenses/common/hooks/useCustomBulkActions.tsx
@@ -25,6 +25,7 @@ import { Icon } from '$app/components/icons/Icon';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MdCategory, MdDownload } from 'react-icons/md';
+import { AddToInvoiceAction } from '../components/AddToInvoiceAction';
 
 interface Props {
   isVisible: boolean;
@@ -126,6 +127,12 @@ export const useCustomBulkActions = () => {
     return expenses.flatMap(({ documents }) => documents.map(({ id }) => id));
   };
 
+  const handleDisplayAddToInvoice = (expenses: Expense[]) => {
+    return expenses.some(({ should_be_invoiced, invoice_id }) => {
+      return should_be_invoiced && !invoice_id.length;
+    });
+  };
+
   const handleDownloadDocuments = (
     selectedExpenses: Expense[],
     setSelected: Dispatch<SetStateAction<string[]>>
@@ -151,6 +158,10 @@ export const useCustomBulkActions = () => {
         {t('documents')}
       </DropdownElement>
     ),
+    ({ selectedResources }) =>
+      handleDisplayAddToInvoice(selectedResources) && (
+        <AddToInvoiceAction expenses={selectedResources} bulkAction />
+      ),
     ({ selectedResources, setSelected }) => (
       <>
         {selectedResources ? (


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of the `add_to_invoice` bulk action. This action will be available in the dropdown after selecting expenses in the table if ALL of the selected expenses have the `should_be_invoiced` property set to true and if the `invoice_id` property is not populated yet. Additionally, if the expenses have the `client_id` populated, then the client_id needs to be the same for all of them, or it will be acceptable if none of them have the client_id property populated at all. Screenshot:

<img width="717" alt="Screenshot 2024-10-01 at 07 35 37" src="https://github.com/user-attachments/assets/757897ad-b6a7-46ee-b711-6dbed47ae016">

Let me know your thoughts.