### PR TITLE
[Cleanup] Changing Select Fields | Clients && Products

### DIFF
--- a/src/components/forms/SelectField.tsx
+++ b/src/components/forms/SelectField.tsx
@@ -26,6 +26,7 @@ export interface SelectProps extends CommonProps {
   errorMessage?: string | string[];
   blankOptionValue?: string | number;
   customSelector?: boolean;
+  dismissable?: boolean;
 }
 
 export function SelectField(props: SelectProps) {
@@ -42,6 +43,7 @@ export function SelectField(props: SelectProps) {
     className,
     disabled,
     cypressRef,
+    dismissable = true,
   } = props;
 
   const blankEntry: ReactNode = (
@@ -156,7 +158,7 @@ export function SelectField(props: SelectProps) {
           // @ts-ignore
           styles={customStyles}
           isSearchable={false}
-          isClearable
+          isClearable={dismissable}
           data-cy={cypressRef}
         />
       )}

--- a/src/pages/clients/edit/components/AdditionalInfo.tsx
+++ b/src/pages/clients/edit/components/AdditionalInfo.tsx
@@ -146,6 +146,7 @@ export function AdditionalInfo({ client, errors, setClient }: Props) {
                   handleSettingsChange('payment_terms', value)
                 }
                 withBlank
+                customSelector
               >
                 {paymentTermsResponse.data.data.map(
                   (paymentTerm: PaymentTerm, index: number) => (
@@ -168,6 +169,7 @@ export function AdditionalInfo({ client, errors, setClient }: Props) {
                 }
                 errorMessage={errors?.errors['settings.valid_until']}
                 withBlank
+                customSelector
               >
                 {paymentTermsResponse.data.data.map(
                   (paymentTerm: PaymentTerm, index: number) => (
@@ -211,6 +213,7 @@ export function AdditionalInfo({ client, errors, setClient }: Props) {
               }
               withBlank
               errorMessage={errors?.errors['settings.send_reminders']}
+              customSelector
             >
               <option value="enabled">{t('enabled')}</option>
               <option value="disabled">{t('disabled')}</option>
@@ -243,6 +246,7 @@ export function AdditionalInfo({ client, errors, setClient }: Props) {
                 onValueChange={(value) => handleChange('size_id', value)}
                 errorMessage={errors?.errors.size_id}
                 withBlank
+                customSelector
               >
                 {statics?.sizes.map(
                   (size: { id: string; name: string }, index: number) => (
@@ -263,6 +267,7 @@ export function AdditionalInfo({ client, errors, setClient }: Props) {
                 errorMessage={errors?.errors.industry_id}
                 onValueChange={(value) => handleChange('industry_id', value)}
                 withBlank
+                customSelector
               >
                 {statics?.industries.map(
                   (size: { id: string; name: string }, index: number) => (

--- a/src/pages/clients/edit/components/AdditionalInfo.tsx
+++ b/src/pages/clients/edit/components/AdditionalInfo.tsx
@@ -202,9 +202,6 @@ export function AdditionalInfo({ client, errors, setClient }: Props) {
                   ? 'disabled'
                   : ''
               }
-              className={
-                'appearance-none block px-3 py-1.5 text-base font-normal  text-gray-700 bg-white bg-clip-padding bg-no-repeat border border-solid border-gray-300 rounded transition ease-in-out m-0 focus:text-gray-700 focus:bg-white focus:border-blue-600 focus:outline-none'
-              }
               onValueChange={(value) =>
                 handleSettingsChange(
                   'send_reminders',

--- a/src/pages/clients/edit/components/Details.tsx
+++ b/src/pages/clients/edit/components/Details.tsx
@@ -16,7 +16,7 @@ import { useUsersQuery } from '$app/common/queries/users';
 import { useTranslation } from 'react-i18next';
 import { Client } from '$app/common/interfaces/client';
 import { set } from 'lodash';
-import { ChangeEvent, Dispatch, SetStateAction } from 'react';
+import { Dispatch, SetStateAction } from 'react';
 import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { CustomField } from '$app/components/CustomField';
 import { ValidationBag } from '$app/common/interfaces/validation-bag';
@@ -35,13 +35,10 @@ export function Details(props: Props) {
   const { data: users } = useUsersQuery();
   const { data: groupSettings } = useGroupSettingsQuery();
 
-  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+  const handleChange = (property: keyof Client, value: string | number) => {
     props.setErrors(undefined);
 
-    props.setClient(
-      (client) =>
-        client && set({ ...client }, event.target.id, event.target.value)
-    );
+    props.setClient((client) => client && set({ ...client }, property, value));
   };
 
   const handleCustomFieldChange = (
@@ -63,18 +60,16 @@ export function Details(props: Props) {
 
       <Element leftSide={t('name')}>
         <InputField
-          id="name"
           value={props.client?.name || ''}
-          onChange={handleChange}
+          onValueChange={(value) => handleChange('name', value)}
           errorMessage={props.errors?.errors.name}
         />
       </Element>
 
       <Element leftSide={t('number')}>
         <InputField
-          id="number"
           value={props.client?.number || ''}
-          onChange={handleChange}
+          onValueChange={(value) => handleChange('number', value)}
           errorMessage={props.errors?.errors.number}
         />
       </Element>
@@ -82,13 +77,12 @@ export function Details(props: Props) {
       {groupSettings && (
         <Element leftSide={t('group')}>
           <SelectField
-            id="group_settings_id"
             value={props.client?.group_settings_id}
-            onChange={handleChange}
+            onValueChange={(value) => handleChange('group_settings_id', value)}
             errorMessage={props.errors?.errors.group_settings_id}
+            withBlank
             customSelector
           >
-            <option value=""></option>
             {groupSettings.map((group, index: number) => (
               <option value={group.id} key={index}>
                 {group.name}
@@ -101,13 +95,12 @@ export function Details(props: Props) {
       {users && (
         <Element leftSide={t('user')}>
           <SelectField
-            id="assigned_user_id"
-            onChange={handleChange}
-            defaultValue={props.client?.assigned_user_id}
+            value={props.client?.assigned_user_id}
+            onValueChange={(value) => handleChange('assigned_user_id', value)}
             errorMessage={props.errors?.errors.assigned_user_id}
+            withBlank
             customSelector
           >
-            <option value=""></option>
             {users.data.data.map((user: User, index: number) => (
               <option value={user.id} key={index}>
                 {user.first_name} {user.last_name}
@@ -119,52 +112,46 @@ export function Details(props: Props) {
 
       <Element leftSide={t('id_number')}>
         <InputField
-          id="id_number"
           value={props.client?.id_number || ''}
-          onChange={handleChange}
+          onValueChange={(value) => handleChange('id_number', value)}
           errorMessage={props.errors?.errors.id_number}
         />
       </Element>
 
       <Element leftSide={t('vat_number')}>
         <InputField
-          id="vat_number"
           value={props.client?.vat_number || ''}
-          onChange={handleChange}
+          onValueChange={(value) => handleChange('vat_number', value)}
           errorMessage={props.errors?.errors.vat_number}
         />
       </Element>
 
       <Element leftSide={t('website')}>
         <InputField
-          id="website"
           value={props.client?.website || ''}
-          onChange={handleChange}
+          onValueChange={(value) => handleChange('website', value)}
           errorMessage={props.errors?.errors.website}
         />
       </Element>
 
       <Element leftSide={t('phone')}>
         <InputField
-          id="phone"
           value={props.client?.phone || ''}
-          onChange={handleChange}
+          onValueChange={(value) => handleChange('phone', value)}
           errorMessage={props.errors?.errors.phone}
         />
       </Element>
 
       <Element leftSide={t('routing_id')}>
         <InputField
-          id="routing_id"
           value={props.client?.routing_id || ''}
-          onChange={handleChange}
+          onValueChange={(value) => handleChange('routing_id', value)}
           errorMessage={props.errors?.errors.routing_id}
         />
       </Element>
 
       <Element leftSide={t('valid_vat_number')}>
         <Toggle
-          id="has_valid_vat_number"
           checked={Boolean(props.client?.has_valid_vat_number)}
           onValueChange={(value) =>
             handleCustomFieldChange('has_valid_vat_number', value)
@@ -174,7 +161,6 @@ export function Details(props: Props) {
 
       <Element leftSide={t('tax_exempt')}>
         <Toggle
-          id="is_tax_exempt"
           checked={Boolean(props.client?.is_tax_exempt)}
           onValueChange={(value) =>
             handleCustomFieldChange('is_tax_exempt', value)
@@ -184,9 +170,8 @@ export function Details(props: Props) {
 
       <Element leftSide={t('classification')}>
         <SelectField
-          id="classification"
-          defaultValue={props.client?.classification ?? ''}
-          onChange={handleChange}
+          value={props.client?.classification ?? ''}
+          onValueChange={(value) => handleChange('classification', value)}
           withBlank
           customSelector
         >

--- a/src/pages/clients/edit/components/Details.tsx
+++ b/src/pages/clients/edit/components/Details.tsx
@@ -86,6 +86,7 @@ export function Details(props: Props) {
             value={props.client?.group_settings_id}
             onChange={handleChange}
             errorMessage={props.errors?.errors.group_settings_id}
+            customSelector
           >
             <option value=""></option>
             {groupSettings.map((group, index: number) => (
@@ -104,6 +105,7 @@ export function Details(props: Props) {
             onChange={handleChange}
             defaultValue={props.client?.assigned_user_id}
             errorMessage={props.errors?.errors.assigned_user_id}
+            customSelector
           >
             <option value=""></option>
             {users.data.data.map((user: User, index: number) => (
@@ -186,6 +188,7 @@ export function Details(props: Props) {
           defaultValue={props.client?.classification ?? ''}
           onChange={handleChange}
           withBlank
+          customSelector
         >
           <option value="individual">{t('individual')}</option>
           <option value="business">{t('business')}</option>

--- a/src/pages/products/common/components/ProductForm.tsx
+++ b/src/pages/products/common/components/ProductForm.tsx
@@ -9,7 +9,7 @@
  */
 
 import { useTranslation } from 'react-i18next';
-import { InputField } from '$app/components/forms';
+import { InputField, SelectField } from '$app/components/forms';
 import { Element } from '$app/components/cards';
 import { CustomField } from '$app/components/CustomField';
 import { TaxRateSelector } from '$app/components/tax-rates/TaxRateSelector';
@@ -18,10 +18,10 @@ import { Product } from '$app/common/interfaces/product';
 import { ValidationBag } from '$app/common/interfaces/validation-bag';
 import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { EntityStatus } from '$app/components/EntityStatus';
-import { TaxCategorySelector } from '$app/components/tax-rates/TaxCategorySelector';
 import { Alert } from '$app/components/Alert';
 import { useSearchParams } from 'react-router-dom';
 import { NumberInputField } from '$app/components/forms/NumberInputField';
+import { useTaxCategories } from '$app/components/tax-rates/TaxCategorySelector';
 
 interface Props {
   type?: 'create' | 'edit';
@@ -38,6 +38,7 @@ export function ProductForm(props: Props) {
   const [, setSearchParams] = useSearchParams();
 
   const company = useCurrentCompany();
+  const taxCategories = useTaxCategories();
 
   const { errors, handleChange, type, product } = props;
 
@@ -108,10 +109,18 @@ export function ProductForm(props: Props) {
       </Element>
 
       <Element leftSide={t('tax_category')}>
-        <TaxCategorySelector
+        <SelectField
           value={product.tax_id}
-          onChange={(taxCategory) => handleChange('tax_id', taxCategory.value)}
-        />
+          onValueChange={(value) => handleChange('tax_id', value)}
+          customSelector
+          dismissable={false}
+        >
+          {taxCategories.map((taxCategory, index) => (
+            <option key={index} value={taxCategory.value as string}>
+              {taxCategory.label}
+            </option>
+          ))}
+        </SelectField>
 
         {errors?.errors.tax_id ? (
           <Alert className="mt-2" type="danger">


### PR DESCRIPTION
@beganovich @turbo124 The PR includes transforming simple HTML select fields into newly created selectors that we already use in some places in the app. These also match the style of searchable selectors that we have applied for some properties. As we discussed on Slack, the implementation will be done entity by entity, or I may include two entities in one PR. However, the PRs will not be crowded for sure, to facilitate testing and reviewing. Screenshot:

![Screenshot 2024-10-03 at 00 38 14](https://github.com/user-attachments/assets/165deb58-1f49-421e-bc04-af2a3defe279)

Let me know your thoughts.