### PR TITLE
[Cleanup] Adjusting Number Input Component To Accept Unlimited Number Of Decimal Places

### DIFF
--- a/src/components/ConvertCurrency.tsx
+++ b/src/components/ConvertCurrency.tsx
@@ -51,12 +51,14 @@ export function ConvertCurrency(props: Props) {
           onValueChange={(value) =>
             props.onExchangeRateChange(parseFloat(value))
           }
+          disablePrecision
         />
       </Element>
 
       <Element leftSide={t('converted_amount')}>
         <NumberInputField
           value={props.amount * parseFloat(props.exchangeRate)}
+          disablePrecision
         />
       </Element>
     </>

--- a/src/components/forms/NumberInputField.tsx
+++ b/src/components/forms/NumberInputField.tsx
@@ -33,6 +33,7 @@ interface Props extends CommonProps {
   required?: boolean;
   withoutLabelWrapping?: boolean;
   placeholder?: string | null;
+  disablePrecision?: boolean;
 }
 
 export function NumberInputField(props: Props) {
@@ -49,7 +50,25 @@ export function NumberInputField(props: Props) {
       : undefined
   );
 
-  const getNumberPrecision = () => {
+  const getDecimalSeparator = () => {
+    return company?.use_comma_as_decimal_place ? ',' : '.';
+  };
+
+  const getNumberPrecision = (enteredValue?: string) => {
+    if (props.disablePrecision && enteredValue) {
+      const currentDecimalSeparator = getDecimalSeparator();
+
+      if (enteredValue.includes(currentDecimalSeparator)) {
+        return enteredValue.split(currentDecimalSeparator)?.[1]?.length || 2;
+      }
+
+      return undefined;
+    }
+
+    if (props.disablePrecision) {
+      return undefined;
+    }
+
     if (typeof props.precision === 'number') {
       return props.precision;
     }
@@ -63,10 +82,6 @@ export function NumberInputField(props: Props) {
     }
 
     return 2;
-  };
-
-  const getDecimalSeparator = () => {
-    return company?.use_comma_as_decimal_place ? ',' : '.';
   };
 
   const getThousandSeparator = () => {
@@ -143,7 +158,7 @@ export function NumberInputField(props: Props) {
                     separator: getThousandSeparator(),
                     decimal: getDecimalSeparator(),
                     symbol: '',
-                    precision: getNumberPrecision(),
+                    precision: getNumberPrecision(event.target.value),
                   }).value
                 : undefined;
 
@@ -159,7 +174,7 @@ export function NumberInputField(props: Props) {
                         separator: getThousandSeparator(),
                         decimal: getDecimalSeparator(),
                         symbol: '',
-                        precision: getNumberPrecision(),
+                        precision: getNumberPrecision(event.target.value),
                       }).value
                     )
                   : ''

--- a/src/pages/credits/edit/components/Settings.tsx
+++ b/src/pages/credits/edit/components/Settings.tsx
@@ -80,6 +80,7 @@ export default function Settings() {
               handleChange('exchange_rate', parseFloat(value))
             }
             errorMessage={errors?.errors.exchange_rate}
+            disablePrecision
           />
 
           <div className="lg:pt-7">

--- a/src/pages/expenses/create/components/AdditionalInfo.tsx
+++ b/src/pages/expenses/create/components/AdditionalInfo.tsx
@@ -235,6 +235,7 @@ export function AdditionalInfo(props: ExpenseCardProps) {
                 handleChange('exchange_rate', parseFloat(value))
               }
               errorMessage={errors?.errors.exchange_rate}
+              disablePrecision
             />
           </Element>
 
@@ -254,6 +255,7 @@ export function AdditionalInfo(props: ExpenseCardProps) {
                 onConvertedAmountChange(parseFloat(value))
               }
               errorMessage={errors?.errors.foreign_amount}
+              disablePrecision
             />
           </Element>
         </>

--- a/src/pages/invoices/edit/components/Settings.tsx
+++ b/src/pages/invoices/edit/components/Settings.tsx
@@ -61,6 +61,7 @@ export default function Settings() {
               handleChange('exchange_rate', parseFloat(value) || 1.0)
             }
             errorMessage={errors?.errors.exchange_rate}
+            disablePrecision
           />
 
           <Toggle

--- a/src/pages/purchase-orders/edit/components/Settings.tsx
+++ b/src/pages/purchase-orders/edit/components/Settings.tsx
@@ -70,6 +70,7 @@ export default function Settings() {
               handleChange('exchange_rate', parseFloat(value) || 1.0)
             }
             errorMessage={errors?.errors.exchange_rate}
+            disablePrecision
           />
         </div>
 

--- a/src/pages/quotes/edit/components/Settings.tsx
+++ b/src/pages/quotes/edit/components/Settings.tsx
@@ -85,6 +85,7 @@ export default function Settings() {
               handleChange('exchange_rate', parseFloat(value))
             }
             errorMessage={errors?.errors.exchange_rate}
+            disablePrecision
           />
 
           <div className="lg:pt-7">

--- a/src/pages/recurring-expenses/components/AdditionalInfo.tsx
+++ b/src/pages/recurring-expenses/components/AdditionalInfo.tsx
@@ -245,6 +245,7 @@ export function AdditionalInfo(props: RecurringExpenseCardProps) {
                 handleChange('exchange_rate', parseFloat(value))
               }
               errorMessage={errors?.errors.exchange_rate}
+              disablePrecision
             />
           </Element>
 
@@ -264,6 +265,7 @@ export function AdditionalInfo(props: RecurringExpenseCardProps) {
                 onConvertedAmountChange(parseFloat(value))
               }
               errorMessage={errors?.errors.foreign_amount}
+              disablePrecision
             />
           </Element>
         </>

--- a/src/pages/recurring-invoices/edit/components/Settings.tsx
+++ b/src/pages/recurring-invoices/edit/components/Settings.tsx
@@ -60,6 +60,7 @@ export default function Settings() {
               handleChange('exchange_rate', parseFloat(value))
             }
             errorMessage={errors?.errors.exchange_rate}
+            disablePrecision
           />
 
           <DesignSelector


### PR DESCRIPTION
@beganovich @turbo124 The PR includes an adjustment to the logic under the number input component to accept an unlimited number of decimal places, but only for specified components. In this case, it is adjusted for the `exchange_rate` and `converted_amount` fields in `Payments`, `Expenses`, and `Recurring Expenses`. Decimal precision for the rest of the fields remains the same, aligned with settings. Screenshot:

![Screenshot 2024-10-03 at 09 10 47](https://github.com/user-attachments/assets/a0ed8c13-6d5e-4243-9b92-aa83a0302329)

Let me know your thoughts.