### PR TITLE
[Bugfix] Expense Filters Not-Updated In Preferences After Removing

### DIFF
--- a/src/pages/expenses/common/hooks.tsx
+++ b/src/pages/expenses/common/hooks.tsx
@@ -601,36 +601,42 @@ export function useExpenseFilters() {
       value: 'logged',
       color: 'white',
       backgroundColor: '#6B7280',
+      dropdownKey: '0',
     },
     {
       label: t('pending'),
       value: 'pending',
       color: 'white',
       backgroundColor: '#93C5FD',
+      dropdownKey: '0',
     },
     {
       label: t('invoiced'),
       value: 'invoiced',
       color: 'white',
       backgroundColor: statusThemeColors.$3 || '#1D4ED8',
+      dropdownKey: '0',
     },
     {
       label: t('paid'),
       value: 'paid',
       color: 'white',
       backgroundColor: statusThemeColors.$1 || '#22C55E',
+      dropdownKey: '0',
     },
     {
       label: t('unpaid'),
       value: 'unpaid',
       color: 'white',
       backgroundColor: statusThemeColors.$4 || '#e6b05c',
+      dropdownKey: '0',
     },
     {
       label: t('uncategorized'),
       value: 'uncategorized',
       color: 'white',
       backgroundColor: '#b5812c',
+      dropdownKey: '0',
     },
   ];
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for not updating user preferences once the filters have been changed. Let me know your thoughts.