### PR TITLE
[Bugfix] Fixing Edge Case Issue With Precision Of Numbers And Adding Fallback Value

### DIFF
--- a/src/components/ConvertCurrency.tsx
+++ b/src/components/ConvertCurrency.tsx
@@ -47,7 +47,7 @@ export function ConvertCurrency(props: Props) {
 
       <Element leftSide={t('exchange_rate')}>
         <NumberInputField
-          value={props.exchangeRate}
+          value={props.exchangeRate || ''}
           onValueChange={(value) =>
             props.onExchangeRateChange(parseFloat(value))
           }
@@ -57,7 +57,7 @@ export function ConvertCurrency(props: Props) {
 
       <Element leftSide={t('converted_amount')}>
         <NumberInputField
-          value={props.amount * parseFloat(props.exchangeRate)}
+          value={props.amount * parseFloat(props.exchangeRate) || ''}
           onValueChange={(value) =>
             props.onExchangeRateChange(parseFloat(value) / props.amount)
           }

--- a/src/components/forms/NumberInputField.tsx
+++ b/src/components/forms/NumberInputField.tsx
@@ -165,12 +165,17 @@ export function NumberInputField(props: Props) {
           placeholder={props.placeholder ?? undefined}
           onChange={(event) => {
             if (props.onValueChange && props.changeOverride) {
-              const formattedValue = event.target.value
-                ? currency(event.target.value, {
+              const enteredValue = event.target.value;
+
+              const formattedValue = enteredValue
+                ? currency(enteredValue, {
                     separator: getThousandSeparator(),
                     decimal: getDecimalSeparator(),
                     symbol: '',
-                    precision: getNumberPrecision(event.target.value),
+                    precision:
+                      getNumberPrecision(enteredValue) === undefined
+                        ? 0
+                        : getNumberPrecision(enteredValue),
                   }).value
                 : undefined;
 
@@ -179,18 +184,23 @@ export function NumberInputField(props: Props) {
           }}
           onBlur={(event) => {
             if (props.onValueChange && !props.changeOverride) {
-              props.onValueChange(
-                event.target.value
-                  ? String(
-                      currency(event.target.value, {
-                        separator: getThousandSeparator(),
-                        decimal: getDecimalSeparator(),
-                        symbol: '',
-                        precision: getNumberPrecision(event.target.value),
-                      }).value
-                    )
-                  : ''
-              );
+              const enteredValue = event.target.value;
+
+              const formattedValue = enteredValue
+                ? String(
+                    currency(enteredValue, {
+                      separator: getThousandSeparator(),
+                      decimal: getDecimalSeparator(),
+                      symbol: '',
+                      precision:
+                        getNumberPrecision(enteredValue) === undefined
+                          ? 0
+                          : getNumberPrecision(enteredValue),
+                    }).value
+                  )
+                : '0';
+
+              props.onValueChange(formattedValue);
             }
           }}
           thousandSeparator={getThousandSeparator()}

--- a/src/pages/clients/edit/components/AdditionalInfo.tsx
+++ b/src/pages/clients/edit/components/AdditionalInfo.tsx
@@ -184,7 +184,7 @@ export function AdditionalInfo({ client, errors, setClient }: Props) {
 
           <Element leftSide={t('task_rate')}>
             <NumberInputField
-              value={client?.settings?.default_task_rate}
+              value={client?.settings?.default_task_rate || ''}
               onValueChange={(value) =>
                 handleSettingsChange('default_task_rate', parseFloat(value))
               }

--- a/src/pages/expenses/create/components/AdditionalInfo.tsx
+++ b/src/pages/expenses/create/components/AdditionalInfo.tsx
@@ -224,7 +224,7 @@ export function AdditionalInfo(props: ExpenseCardProps) {
 
           <Element leftSide={t('exchange_rate')}>
             <NumberInputField
-              value={expense.exchange_rate}
+              value={expense.exchange_rate || ''}
               onValueChange={(value) =>
                 handleChange('exchange_rate', parseFloat(value))
               }

--- a/src/pages/expenses/create/components/Details.tsx
+++ b/src/pages/expenses/create/components/Details.tsx
@@ -227,7 +227,7 @@ export function Details(props: Props) {
                 />
                 <NumberInputField
                   label={t('tax_amount')}
-                  value={expense.tax_amount1}
+                  value={expense.tax_amount1 || ''}
                   onValueChange={(value) =>
                     handleChange('tax_amount1', parseFloat(value))
                   }
@@ -279,7 +279,7 @@ export function Details(props: Props) {
                 />
                 <NumberInputField
                   label={t('tax_amount')}
-                  value={expense.tax_amount2}
+                  value={expense.tax_amount2 || ''}
                   onValueChange={(value) =>
                     handleChange('tax_amount2', parseFloat(value))
                   }
@@ -330,7 +330,7 @@ export function Details(props: Props) {
                 />
                 <NumberInputField
                   label={t('tax_amount')}
-                  value={expense.tax_amount3}
+                  value={expense.tax_amount3 || ''}
                   onValueChange={(value) =>
                     handleChange('tax_amount3', parseFloat(value))
                   }
@@ -343,7 +343,7 @@ export function Details(props: Props) {
         {expense && (
           <Element leftSide={t('amount')}>
             <NumberInputField
-              value={expense.amount}
+              value={expense.amount || ''}
               onValueChange={(value) =>
                 handleChange('amount', parseFloat(value) || 0)
               }

--- a/src/pages/invoices/common/hooks/useResolveInputField.tsx
+++ b/src/pages/invoices/common/hooks/useResolveInputField.tsx
@@ -368,7 +368,7 @@ export function useResolveInputField(props: Props) {
                 : inputCurrencySeparators?.precision || 2
             }
             id={property}
-            value={resource?.line_items[index][property] as string}
+            value={resource?.line_items[index][property] || ''}
             className="auto"
             onValueChange={(value: string) => {
               onChange(

--- a/src/pages/payments/apply/Apply.tsx
+++ b/src/pages/payments/apply/Apply.tsx
@@ -234,7 +234,7 @@ export default function Apply() {
               />
               <NumberInputField
                 label={t('amount_received')}
-                value={record.amount}
+                value={record.amount || ''}
                 onValueChange={(value) =>
                   formik.setFieldValue(
                     `invoices.${index}.amount`,

--- a/src/pages/payments/create/Create.tsx
+++ b/src/pages/payments/create/Create.tsx
@@ -244,7 +244,7 @@ export default function Create() {
             leftSideHelp={t('amount_received_help')}
           >
             <NumberInputField
-              value={payment?.amount}
+              value={payment?.amount || ''}
               onValueChange={(value) =>
                 handleChange(
                   'amount',
@@ -306,7 +306,7 @@ export default function Create() {
 
                     <NumberInputField
                       label={t('amount_received')}
-                      value={invoice.amount}
+                      value={invoice.amount || ''}
                       onValueChange={(value) =>
                         handleInvoiceInputChange(
                           index,
@@ -429,7 +429,7 @@ export default function Create() {
                         )
                       }
                       className="w-full"
-                      value={credit.amount}
+                      value={credit.amount || ''}
                       withoutLabelWrapping
                     />
 
@@ -606,7 +606,7 @@ export default function Create() {
               currencyId={payment.currency_id || '1'}
               amount={
                 (collect(payment?.invoices).sum('amount') as number) +
-                  payment?.amount ?? 0
+                (payment?.amount ?? 0)
               }
               onChange={(exchangeRate, exchangeCurrencyId) => {
                 handleChange('exchange_rate', exchangeRate);

--- a/src/pages/payments/refund/Refund.tsx
+++ b/src/pages/payments/refund/Refund.tsx
@@ -241,7 +241,8 @@ export default function Refund() {
                     <div className="flex items-center space-x-2">
                       <NumberInputField
                         value={
-                          (formik.values.invoices[index] as Invoice).amount
+                          (formik.values.invoices[index] as Invoice).amount ||
+                          ''
                         }
                         onValueChange={(value) =>
                           formik.setFieldValue(

--- a/src/pages/products/common/components/ProductForm.tsx
+++ b/src/pages/products/common/components/ProductForm.tsx
@@ -70,7 +70,7 @@ export function ProductForm(props: Props) {
 
       <Element leftSide={t('price')}>
         <NumberInputField
-          value={product.price}
+          value={product.price || ''}
           onValueChange={(value) => handleChange('price', parseFloat(value))}
           errorMessage={errors?.errors.price}
         />
@@ -89,7 +89,7 @@ export function ProductForm(props: Props) {
       {company?.enable_product_quantity && (
         <Element leftSide={t('default_quantity')}>
           <NumberInputField
-            value={product.quantity}
+            value={product.quantity || ''}
             onValueChange={(value) =>
               handleChange('quantity', parseFloat(value))
             }
@@ -100,7 +100,7 @@ export function ProductForm(props: Props) {
 
       <Element leftSide={t('max_quantity')}>
         <NumberInputField
-          value={product.max_quantity}
+          value={product.max_quantity || ''}
           onValueChange={(value) =>
             handleChange('max_quantity', parseFloat(value))
           }
@@ -141,7 +141,7 @@ export function ProductForm(props: Props) {
         <>
           <Element leftSide={t('stock_quantity')}>
             <NumberInputField
-              value={product.in_stock_quantity}
+              value={product.in_stock_quantity || ''}
               onValueChange={(value) => {
                 handleChange('in_stock_quantity', Number(value));
 
@@ -167,7 +167,7 @@ export function ProductForm(props: Props) {
 
           <Element leftSide={t('notification_threshold')}>
             <NumberInputField
-              value={product.stock_notification_threshold}
+              value={product.stock_notification_threshold || ''}
               onValueChange={(value) =>
                 handleChange('stock_notification_threshold', parseFloat(value))
               }

--- a/src/pages/projects/create/Create.tsx
+++ b/src/pages/projects/create/Create.tsx
@@ -168,7 +168,7 @@ export default function Create() {
 
           <Element leftSide={t('budgeted_hours')}>
             <NumberInputField
-              value={project?.budgeted_hours}
+              value={project?.budgeted_hours || ''}
               onValueChange={(value) =>
                 handleChange('budgeted_hours', parseFloat(value))
               }
@@ -178,7 +178,7 @@ export default function Create() {
 
           <Element leftSide={t('task_rate')}>
             <NumberInputField
-              value={project?.task_rate}
+              value={project?.task_rate || ''}
               onValueChange={(value) =>
                 handleChange('task_rate', parseFloat(value))
               }

--- a/src/pages/projects/edit/Edit.tsx
+++ b/src/pages/projects/edit/Edit.tsx
@@ -105,7 +105,7 @@ export default function Edit() {
 
       <Element leftSide={t('budgeted_hours')}>
         <NumberInputField
-          value={project?.budgeted_hours}
+          value={project?.budgeted_hours || ''}
           onValueChange={(value) =>
             handleChange('budgeted_hours', parseFloat(value))
           }
@@ -115,7 +115,7 @@ export default function Edit() {
 
       <Element leftSide={t('task_rate')}>
         <NumberInputField
-          value={project?.task_rate}
+          value={project?.task_rate || ''}
           onValueChange={(value) =>
             handleChange('task_rate', parseFloat(value))
           }

--- a/src/pages/purchase-orders/edit/components/Details.tsx
+++ b/src/pages/purchase-orders/edit/components/Details.tsx
@@ -57,7 +57,7 @@ export function Details(props: PurchaseOrderCardProps) {
 
         <Element leftSide={t('partial')}>
           <NumberInputField
-            value={purchaseOrder.partial}
+            value={purchaseOrder.partial || ''}
             onValueChange={(partial) =>
               handleChange('partial', parseFloat(partial) || 0)
             }
@@ -115,7 +115,7 @@ export function Details(props: PurchaseOrderCardProps) {
           <Inline>
             <div className="w-full lg:w-1/2">
               <NumberInputField
-                value={purchaseOrder.discount}
+                value={purchaseOrder.discount || ''}
                 onValueChange={(value) =>
                   handleChange('discount', parseFloat(value) || 0)
                 }

--- a/src/pages/recurring-expenses/components/AdditionalInfo.tsx
+++ b/src/pages/recurring-expenses/components/AdditionalInfo.tsx
@@ -239,7 +239,7 @@ export function AdditionalInfo(props: RecurringExpenseCardProps) {
 
           <Element leftSide={t('exchange_rate')}>
             <NumberInputField
-              value={recurringExpense.exchange_rate}
+              value={recurringExpense.exchange_rate || ''}
               onValueChange={(value) =>
                 handleChange('exchange_rate', parseFloat(value))
               }

--- a/src/pages/recurring-expenses/components/Details.tsx
+++ b/src/pages/recurring-expenses/components/Details.tsx
@@ -233,7 +233,7 @@ export function Details(props: Props) {
                 />
                 <NumberInputField
                   label={t('tax_amount')}
-                  value={recurringExpense.tax_amount1}
+                  value={recurringExpense.tax_amount1 || ''}
                   onValueChange={(value) =>
                     handleChange('tax_amount1', parseFloat(value))
                   }
@@ -285,7 +285,7 @@ export function Details(props: Props) {
                 />
                 <NumberInputField
                   label={t('tax_amount')}
-                  value={recurringExpense.tax_amount2}
+                  value={recurringExpense.tax_amount2 || ''}
                   onValueChange={(value) =>
                     handleChange('tax_amount2', parseFloat(value))
                   }
@@ -336,7 +336,7 @@ export function Details(props: Props) {
                 />
                 <NumberInputField
                   label={t('tax_amount')}
-                  value={recurringExpense.tax_amount3}
+                  value={recurringExpense.tax_amount3 || ''}
                   onValueChange={(value) =>
                     handleChange('tax_amount3', parseFloat(value))
                   }
@@ -349,7 +349,7 @@ export function Details(props: Props) {
         {recurringExpense && (
           <Element leftSide={t('amount')}>
             <NumberInputField
-              value={recurringExpense.amount}
+              value={recurringExpense.amount || ''}
               onValueChange={(value) =>
                 handleChange('amount', parseFloat(value) || 0)
               }

--- a/src/pages/recurring-invoices/common/components/IncreasePricesAction.tsx
+++ b/src/pages/recurring-invoices/common/components/IncreasePricesAction.tsx
@@ -64,7 +64,7 @@ export const IncreasePricesAction = (props: Props) => {
       >
         <NumberInputField
           label={t('percent')}
-          value={increasingPercent}
+          value={increasingPercent || ''}
           onValueChange={(value) => {
             setIncreasingPercent(parseFloat(value));
             errors && setErrors(undefined);

--- a/src/pages/settings/gateways/create/components/LimitsAndFees.tsx
+++ b/src/pages/settings/gateways/create/components/LimitsAndFees.tsx
@@ -107,7 +107,7 @@ export function LimitsAndFees(props: Props) {
               <NumberInputField
                 value={
                   props.companyGateway.fees_and_limits?.[currentGatewayTypeId]
-                    ?.min_limit
+                    ?.min_limit || ''
                 }
                 onValueChange={(value) =>
                   handleEntryChange('min_limit', parseFloat(value) || -1)
@@ -137,7 +137,7 @@ export function LimitsAndFees(props: Props) {
               <NumberInputField
                 value={
                   props.companyGateway.fees_and_limits?.[currentGatewayTypeId]
-                    ?.max_limit
+                    ?.max_limit || ''
                 }
                 onValueChange={(value) =>
                   handleEntryChange('max_limit', parseFloat(value) || -1)
@@ -168,7 +168,7 @@ export function LimitsAndFees(props: Props) {
             <NumberInputField
               value={
                 props.companyGateway.fees_and_limits?.[currentGatewayTypeId]
-                  ?.fee_percent
+                  ?.fee_percent || ''
               }
               onValueChange={(value) =>
                 handleEntryChange('fee_percent', parseFloat(value))
@@ -181,7 +181,7 @@ export function LimitsAndFees(props: Props) {
             <NumberInputField
               value={
                 props.companyGateway.fees_and_limits?.[currentGatewayTypeId]
-                  ?.fee_amount
+                  ?.fee_amount || ''
               }
               onValueChange={(value) =>
                 handleEntryChange('fee_amount', parseFloat(value))
@@ -272,7 +272,7 @@ export function LimitsAndFees(props: Props) {
             <NumberInputField
               value={
                 props.companyGateway.fees_and_limits?.[currentGatewayTypeId]
-                  ?.fee_cap
+                  ?.fee_cap || ''
               }
               onValueChange={(value) =>
                 handleEntryChange('fee_cap', parseFloat(value))

--- a/src/pages/settings/payment-terms/Create.tsx
+++ b/src/pages/settings/payment-terms/Create.tsx
@@ -116,11 +116,13 @@ export function Create() {
         >
           <CardContainer>
             <NumberInputField
+              precision={0}
               required
-              value={paymentTerm?.num_days}
+              value={paymentTerm?.num_days || ''}
               label={t('number_of_days')}
               onValueChange={(value) => handleChange('num_days', Number(value))}
               errorMessage={errors?.errors.num_days}
+              disablePrecision
             />
           </CardContainer>
         </Card>

--- a/src/pages/settings/payment-terms/edit/Edit.tsx
+++ b/src/pages/settings/payment-terms/edit/Edit.tsx
@@ -106,11 +106,13 @@ export function Edit() {
 
             <CardContainer>
               <NumberInputField
-                value={formik.values.num_days}
+                precision={0}
+                value={formik.values.num_days || ''}
                 label={t('number_of_days')}
                 onValueChange={(value) =>
                   formik.setFieldValue('num_days', value)
                 }
+                disablePrecision
               />
             </CardContainer>
           </Card>

--- a/src/pages/settings/products/ProductSettings.tsx
+++ b/src/pages/settings/products/ProductSettings.tsx
@@ -92,6 +92,7 @@ export function ProductSettings() {
           <>
             <Element leftSide={t('notification_threshold')}>
               <NumberInputField
+                precision={0}
                 value={companyChanges?.inventory_notification_threshold || ''}
                 onValueChange={(value) =>
                   handleChange(
@@ -100,6 +101,7 @@ export function ProductSettings() {
                   )
                 }
                 errorMessage={errors?.errors.inventory_notification_threshold}
+                disablePrecision
               />
             </Element>
           </>

--- a/src/pages/settings/task-settings/TaskSettings.tsx
+++ b/src/pages/settings/task-settings/TaskSettings.tsx
@@ -417,6 +417,7 @@ export function TaskSettings() {
         {isTaskRoundToNearestCustom() && (
           <Element leftSide={t('task_round_to_nearest')}>
             <NumberInputField
+              precision={0}
               value={companyChanges?.settings?.task_round_to_nearest || -1}
               onValueChange={(value) =>
                 handleSettingsChange(
@@ -425,6 +426,7 @@ export function TaskSettings() {
                 )
               }
               disabled={disableSettingsField('task_round_to_nearest')}
+              disablePrecision
             />
           </Element>
         )}

--- a/src/pages/settings/tax-rates/Create.tsx
+++ b/src/pages/settings/tax-rates/Create.tsx
@@ -126,7 +126,7 @@ export function Create() {
             <NumberInputField
               required
               label={t('tax_rate')}
-              value={taxRate?.rate}
+              value={taxRate?.rate || ''}
               onValueChange={(value) => handleChange('rate', Number(value))}
               errorMessage={errors?.errors.rate}
             />

--- a/src/pages/settings/tax-rates/Edit.tsx
+++ b/src/pages/settings/tax-rates/Edit.tsx
@@ -136,7 +136,7 @@ export function Edit() {
               />
 
               <NumberInputField
-                value={formik.values.rate}
+                value={formik.values.rate || ''}
                 label={t('tax_rate')}
                 onValueChange={(value) => formik.setFieldValue('rate', value)}
                 errorMessage={errors?.errors?.rate}

--- a/src/pages/settings/tax-settings/components/calculate-taxes/components/EditSubRegionModal.tsx
+++ b/src/pages/settings/tax-settings/components/calculate-taxes/components/EditSubRegionModal.tsx
@@ -54,7 +54,7 @@ export function EditSubRegionModal(props: Props) {
 
       <NumberInputField
         label={t('tax_rate')}
-        value={taxSetting.tax_rate}
+        value={taxSetting.tax_rate || ''}
         onValueChange={(value) =>
           handleChange(
             `tax_data.regions.${region}.subregions.${subregion}.tax_rate`,
@@ -65,7 +65,7 @@ export function EditSubRegionModal(props: Props) {
 
       <NumberInputField
         label={t('reduced_rate')}
-        value={taxSetting.reduced_tax_rate}
+        value={taxSetting.reduced_tax_rate || ''}
         onValueChange={(value) =>
           handleChange(
             `tax_data.regions.${region}.subregions.${subregion}.reduced_tax_rate`,

--- a/src/pages/settings/templates-and-reminders/TemplatesAndReminders.tsx
+++ b/src/pages/settings/templates-and-reminders/TemplatesAndReminders.tsx
@@ -442,6 +442,7 @@ export function TemplatesAndReminders() {
               <>
                 <Element leftSide={t('days')}>
                   <NumberInputField
+                    precision={0}
                     value={
                       company?.settings[getNumDaysReminderKey(reminderIndex)] ||
                       0
@@ -452,6 +453,7 @@ export function TemplatesAndReminders() {
                         parseFloat(value) || 0
                       )
                     }
+                    disablePrecision
                   />
                 </Element>
 

--- a/src/pages/settings/user/components/Preferences.tsx
+++ b/src/pages/settings/user/components/Preferences.tsx
@@ -91,7 +91,7 @@ export function Preferences() {
         >
           <NumberInputField
             precision={0}
-            value={reactSettings?.number_precision}
+            value={reactSettings?.number_precision || ''}
             onValueChange={(value) =>
               handleChange(
                 'company_user.react_settings.number_precision',
@@ -99,6 +99,7 @@ export function Preferences() {
               )
             }
             placeholder={t('number_precision')}
+            disablePrecision
           />
         </Element>
 

--- a/src/pages/tasks/common/components/TaskDetails.tsx
+++ b/src/pages/tasks/common/components/TaskDetails.tsx
@@ -237,7 +237,7 @@ export function TaskDetails(props: Props) {
 
         <Element leftSide={t('rate')}>
           <NumberInputField
-            value={task.rate}
+            value={task.rate || ''}
             onValueChange={(value) => handleChange('rate', parseFloat(value))}
             errorMessage={errors?.errors.rate}
           />

--- a/src/pages/transactions/components/TransactionForm.tsx
+++ b/src/pages/transactions/components/TransactionForm.tsx
@@ -91,7 +91,7 @@ export function TransactionForm(props: Props) {
           border
           precision={props.currencySeparators.precision}
           className="auto"
-          value={props.transaction.amount.toString()}
+          value={props.transaction.amount || ''}
           onValueChange={(value: string) =>
             props.handleChange('amount', Number(value))
           }


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixing an edge case bug of setting default precision when converting numbers where the precision has been disabled (we do not have a specific number, precision is equal to the user's input). Also, I've added a fallback value of an empty string for fields that missed it and disabled precision and separators for fields that do not need them. Screenshot:

![Screenshot 2024-10-07 at 20 24 44](https://github.com/user-attachments/assets/80983d61-bdbd-47de-b0c4-5ec343692125)

Let me know your thoughts.