### PR TITLE
GoCardless OAuth2: Scope testing to company

### DIFF
--- a/src/pages/settings/gateways/create/Create.tsx
+++ b/src/pages/settings/gateways/create/Create.tsx
@@ -38,6 +38,7 @@ import { request } from '$app/common/helpers/request';
 import { arrayMoveImmutable } from 'array-move';
 import { useHandleGoCardless } from '$app/pages/settings/gateways/create/hooks/useHandleGoCardless';
 import classNames from 'classnames';
+import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 
 const gatewaysStyles = [
   { name: 'paypal_ppcp', width: 110 },
@@ -99,6 +100,8 @@ export function Create() {
 
   const onSave = useHandleCreate(companyGateway, setErrors);
 
+  const company = useCurrentCompany();
+
   const handleChange = (value: string, isManualChange?: boolean) => {
     const gateway = gateways.find((gateway) => gateway.id === value);
 
@@ -114,8 +117,8 @@ export function Create() {
 
     if (
       gateway?.key === 'b9886f9257f0c6ee7c302f1c74475f6c' &&
-      isHosted() &&
-      import.meta.env.VITE_GOCARDLESS_OAUTH_TESTING === 'true'
+      // isHosted() &&
+      import.meta.env.VITE_GOCARDLESS_OAUTH_TESTING_COMPANY === company?.id
     ) {
       return handleGoCardless();
     }
@@ -124,6 +127,8 @@ export function Create() {
       setTabIndex(1);
     }
   };
+
+  console.log(company.id);
 
   const handleSetup = () => {
     request('POST', endpoint('/api/v1/one_time_token'), {

--- a/src/pages/settings/gateways/create/components/Credentials.tsx
+++ b/src/pages/settings/gateways/create/components/Credentials.tsx
@@ -29,6 +29,7 @@ import { GoCardlessOAuth2 } from './gateways/GoCardlessOAuth2';
 import { useHandleGoCardless } from '$app/pages/settings/gateways/create/hooks/useHandleGoCardless';
 import { useResolveConfigValue } from '$app/pages/settings/gateways/create/hooks/useResolveConfigValue';
 import { useLocation } from 'react-router-dom';
+import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 
 interface Props {
   gateway: Gateway;
@@ -59,11 +60,13 @@ export function Credentials(props: Props) {
 
   const hostedGateways = [STRIPE_CONNECT, WEPAY, PAYPAL_PPCP];
 
+  const company = useCurrentCompany();
+
   if (
     isHosted() &&
     props.gateway.key === GOCARDLESS &&
     config('oauth2') === true &&
-    import.meta.env.VITE_GOCARDLESS_OAUTH_TESTING === 'true'
+    import.meta.env.VITE_GOCARDLESS_OAUTH_TESTING_COMPANY === company?.id
   ) {
     hostedGateways.push(GOCARDLESS);
   }
@@ -149,7 +152,8 @@ export function Credentials(props: Props) {
           props.gateway.key === GOCARDLESS &&
           isHosted() &&
           config('oauth2') !== true &&
-          import.meta.env.VITE_GOCARDLESS_OAUTH_TESTING === 'true' && (
+          import.meta.env.VITE_GOCARDLESS_OAUTH_TESTING_COMPANY ===
+            company?.id && (
             <Element leftSide={t('OAuth 2.0')}>
               <Button
                 behavior="button"


### PR DESCRIPTION
To enable this in production, we need to pass `VITE_GOCARDLESS_OAUTH_TESTING_COMPANY` on the build. Ensure the value is `hashed_id` since we compare the company ID with the one from the API response.