### PR TITLE
[Bugfix] Marking Quote Sent Bulk Action Fixes

### DIFF
--- a/src/pages/quotes/common/hooks/useBulkAction.ts
+++ b/src/pages/quotes/common/hooks/useBulkAction.ts
@@ -22,7 +22,7 @@ const successMessages = {
   convert_to_invoice: 'converted_quote',
   convert_to_project: 'converted_quote',
   email: 'emailed_quotes',
-  sent: 'marked_quote_as_sent',
+  mark_sent: 'marked_quote_as_sent',
 };
 
 export const useBulkAction = () => {
@@ -40,7 +40,7 @@ export const useBulkAction = () => {
       | 'convert_to_project'
       | 'email'
       | 'approve'
-      | 'sent'
+      | 'mark_sent'
   ) => {
     toast.processing();
 

--- a/src/pages/quotes/common/hooks/useCustomBulkActions.tsx
+++ b/src/pages/quotes/common/hooks/useCustomBulkActions.tsx
@@ -167,7 +167,7 @@ export function useCustomBulkActions() {
       showMarkSentAction(selectedResources) && (
         <DropdownElement
           onClick={() => {
-            bulk(selectedIds, 'sent');
+            bulk(selectedIds, 'mark_sent');
             setSelected([]);
           }}
           icon={<Icon element={MdMarkEmailRead} />}


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for the name of the bulk action which needs to mark a quote as sent. It was "sent" instead of "mark_sent". Let me know your thoughts.