### PR TITLE
[Cleanup] Displaying Charge Taxes Toggles

### DIFF
--- a/src/pages/settings/custom-fields/invoices/Invoices.tsx
+++ b/src/pages/settings/custom-fields/invoices/Invoices.tsx
@@ -80,11 +80,13 @@ export function Invoices() {
                 />
               }
             >
-              <Toggle
-                label={t('charge_taxes')}
-                checked={surchargeValue(index)}
-                onChange={() => setSurchargeTaxValue(index)}
-              />
+              {Boolean(company?.enabled_tax_rates) && (
+                <Toggle
+                  label={t('charge_taxes')}
+                  checked={surchargeValue(index)}
+                  onChange={() => setSurchargeTaxValue(index)}
+                />
+              )}
             </Element>
           )
         )}


### PR DESCRIPTION
@beganovich @turbo124 The PR includes changes to display "Charge Taxes" toggles only if `enable_tax_rates` is greater than zero (0). Let me know your thoughts.