### PR TITLE
[Bugfix] Group Settings Invoice Design Page Breaks

### DIFF
--- a/src/pages/settings/invoice-design/pages/general-settings/components/GeneralSettings.tsx
+++ b/src/pages/settings/invoice-design/pages/general-settings/components/GeneralSettings.tsx
@@ -835,11 +835,11 @@ export default function GeneralSettings() {
   useEffect(() => {
     if (
       company?.settings &&
-      company?.settings.company_logo_size.includes('px')
+      company?.settings.company_logo_size?.includes('px')
     ) {
       setLogoSizeType('px');
     }
-  }, [company?.settings.company_logo_size]);
+  }, [company?.settings?.company_logo_size]);
 
   useEffect(() => {
     setUpdatingRecords([]);


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for the Invoice Design page breaking when configuring group settings. This was occurring due to reading an undefined value for one property. Let me know your thoughts.

Closes #2146 