### PR TITLE
GoCardless: Remove debugging statements

### DIFF
--- a/src/pages/settings/gateways/create/Create.tsx
+++ b/src/pages/settings/gateways/create/Create.tsx
@@ -39,7 +39,6 @@ import { arrayMoveImmutable } from 'array-move';
 import { useHandleGoCardless } from '$app/pages/settings/gateways/create/hooks/useHandleGoCardless';
 import classNames from 'classnames';
 import { HelpWidget } from '$app/components/HelpWidget';
-import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 
 const gatewaysStyles = [
   { name: 'paypal_ppcp', width: 110 },
@@ -101,8 +100,6 @@ export function Create() {
 
   const onSave = useHandleCreate(companyGateway, setErrors);
 
-  const company = useCurrentCompany();
-
   const handleChange = (value: string, isManualChange?: boolean) => {
     const gateway = gateways.find((gateway) => gateway.id === value);
 
@@ -116,11 +113,7 @@ export function Create() {
       return handleStripeSetup();
     }
 
-    if (
-      gateway?.key === 'b9886f9257f0c6ee7c302f1c74475f6c' &&
-      isHosted() &&
-      import.meta.env.VITE_GOCARDLESS_TESTING_COMPANY === company?.id
-    ) {
+    if (gateway?.key === 'b9886f9257f0c6ee7c302f1c74475f6c' && isHosted()) {
       return handleGoCardless();
     }
 

--- a/src/pages/settings/gateways/create/components/Credentials.tsx
+++ b/src/pages/settings/gateways/create/components/Credentials.tsx
@@ -32,7 +32,6 @@ import { useLocation } from 'react-router-dom';
 import { $help } from '$app/components/HelpWidget';
 import { useAccentColor } from '$app/common/hooks/useAccentColor';
 import { HelpCircle } from 'react-feather';
-import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 
 interface Props {
   gateway: Gateway;
@@ -63,13 +62,10 @@ export function Credentials(props: Props) {
 
   const hostedGateways = [STRIPE_CONNECT, WEPAY, PAYPAL_PPCP];
 
-  const company = useCurrentCompany();
-
   if (
     isHosted() &&
     props.gateway.key === GOCARDLESS &&
-    config('oauth2') === true &&
-    import.meta.env.VITE_GOCARDLESS_TESTING_COMPANY === company?.id
+    config('oauth2') === true
   ) {
     hostedGateways.push(GOCARDLESS);
   }
@@ -172,8 +168,7 @@ export function Credentials(props: Props) {
         {props.gateway &&
           props.gateway.key === GOCARDLESS &&
           isHosted() &&
-          config('oauth2') !== true &&
-          import.meta.env.VITE_GOCARDLESS_TESTING_COMPANY === company?.id && (
+          config('oauth2') !== true && (
             <Element leftSide={t('OAuth 2.0')}>
               <Button
                 behavior="button"


### PR DESCRIPTION
This removes GoCardless OAuth2 scoping to testing company, making it available for everyone (hosted).
