### PR TITLE
E-invoicing: Remove message about payment means

### DIFF
--- a/src/components/e-invoice/PaymentMeans.tsx
+++ b/src/components/e-invoice/PaymentMeans.tsx
@@ -356,12 +356,6 @@ export const PaymentMeans = forwardRef<PaymentMeansFormComponent, Props>(
           </SelectField>
         </Element>
 
-        {elements.length === 0 && form.values.payment_means[0].code !== '' ? (
-          <Element>
-            <p>The payment mean does not have any elements.</p>
-          </Element>
-        ) : null}
-
         {elements.includes('iban') ? (
           <Element leftSide={t('iban')} leftSideHelp={t('iban_help')}>
             <InputField


### PR DESCRIPTION
This removes message about non-existing elements for payment means.

Demo:

[Screencast_20241107_125706.webm](https://github.com/user-attachments/assets/7cd54a77-cf34-4d0f-8ea8-2406080c0d48)
