### PR TITLE
[Cleanup] Adding Helper Text For Gateways

### DIFF
--- a/src/pages/settings/gateways/create/components/LimitsAndFees.tsx
+++ b/src/pages/settings/gateways/create/components/LimitsAndFees.tsx
@@ -134,7 +134,7 @@ export function LimitsAndFees(props: Props) {
             .filter(([, entry]) => entry.is_enabled)
             .map(([gatewayTypeId], index) => (
               <option key={index} value={gatewayTypeId}>
-                {resolveGatewayTypeTranslation(gatewayTypeId)}
+                {t(resolveGatewayTypeTranslation(gatewayTypeId))}
               </option>
             ))}
         </SelectField>

--- a/src/pages/settings/gateways/create/components/Settings.tsx
+++ b/src/pages/settings/gateways/create/components/Settings.tsx
@@ -122,11 +122,7 @@ export function Settings(props: Props) {
           key={index}
           leftSide={t(resolveGatewayTypeTranslation(option.gatewayTypeId))}
           leftSideHelp={t(
-            t(
-              `${resolveGatewayTypeTranslation(
-                option.gatewayTypeId
-              )}_stripe_help`
-            )
+            `${resolveGatewayTypeTranslation(option.gatewayTypeId)}_stripe_help`
           )}
         >
           <Toggle

--- a/src/pages/settings/gateways/create/components/Settings.tsx
+++ b/src/pages/settings/gateways/create/components/Settings.tsx
@@ -120,7 +120,14 @@ export function Settings(props: Props) {
       {options.map((option, index) => (
         <Element
           key={index}
-          leftSide={resolveGatewayTypeTranslation(option.gatewayTypeId)}
+          leftSide={t(resolveGatewayTypeTranslation(option.gatewayTypeId))}
+          leftSideHelp={t(
+            t(
+              `${resolveGatewayTypeTranslation(
+                option.gatewayTypeId
+              )}_stripe_help`
+            )
+          )}
         >
           <Toggle
             checked={isChecked(option.gatewayTypeId)}

--- a/src/pages/settings/gateways/create/hooks/useResolveGatewayTypeTranslation.ts
+++ b/src/pages/settings/gateways/create/hooks/useResolveGatewayTypeTranslation.ts
@@ -9,14 +9,9 @@
  */
 
 import gatewayType from '$app/common/constants/gateway-type';
-import { useTranslation } from 'react-i18next';
 
 export function useResolveGatewayTypeTranslation() {
-  const [t] = useTranslation();
-
   return (id: string) => {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    return t(gatewayType[id] || 'other');
+    return gatewayType[id as keyof typeof gatewayType] || 'other';
   };
 }


### PR DESCRIPTION
@beganovich @turbo124 The PR adds helper text for gateways in the "Settings" tab. The pattern for helper text is `gatewayName_stripe_help`. Screenshot:

![Screenshot 2024-11-08 at 19 33 55](https://github.com/user-attachments/assets/3b1c3531-34a1-4190-bf50-6f08d59dd943)

Let me know your thoughts.