### PR TITLE
[Cleanup] Changing Translation To "Tokenize"

### DIFF
--- a/src/pages/settings/gateways/create/components/Settings.tsx
+++ b/src/pages/settings/gateways/create/components/Settings.tsx
@@ -101,7 +101,7 @@ export function Settings(props: Props) {
       </Element>
 
       {options.some((option) => option.token_billing == true) && (
-        <Element leftSide={t('capture_card')}>
+        <Element leftSide={t('tokenize')} leftSideHelp={t('tokenize_help')}>
           <SelectField
             value={props.companyGateway.token_billing || 'off'}
             onValueChange={(value) => handleChange('token_billing', value)}


### PR DESCRIPTION
@beganovich @turbo124 The PR changes the translation from "capture_card" to "tokenize" and adds helper text. Screenshot:

![Screenshot 2024-11-08 at 19 44 06](https://github.com/user-attachments/assets/f1ae60d1-e79f-4b72-b3d7-05c6f19f1ba9)

Let me know your thoughts.