### PR TITLE
[Cleanup] Importing "location" From react-router-dom Pacakge

### DIFF
--- a/src/pages/credits/edit/components/Documents.tsx
+++ b/src/pages/credits/edit/components/Documents.tsx
@@ -14,13 +14,15 @@ import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
 import { $refetch } from '$app/common/hooks/useRefetch';
 import { DocumentsTable } from '$app/components/DocumentsTable';
 import { Upload } from '$app/pages/settings/company/documents/components';
-import { useOutletContext, useParams } from 'react-router-dom';
+import { useLocation, useOutletContext, useParams } from 'react-router-dom';
 import { Card } from '$app/components/cards';
 import { useTranslation } from 'react-i18next';
 import { CreditsContext } from '../../create/Create';
 
 export default function Documents() {
   const [t] = useTranslation();
+
+  const location = useLocation();
 
   const hasPermission = useHasPermission();
   const entityAssigned = useEntityAssigned();

--- a/src/pages/invoices/edit/components/Documents.tsx
+++ b/src/pages/invoices/edit/components/Documents.tsx
@@ -14,13 +14,15 @@ import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
 import { $refetch } from '$app/common/hooks/useRefetch';
 import { DocumentsTable } from '$app/components/DocumentsTable';
 import { Upload } from '$app/pages/settings/company/documents/components';
-import { useOutletContext, useParams } from 'react-router-dom';
+import { useLocation, useOutletContext, useParams } from 'react-router-dom';
 import { Context } from '../Edit';
 import { Card } from '$app/components/cards';
 import { useTranslation } from 'react-i18next';
 
 export default function Documents() {
   const [t] = useTranslation();
+
+  const location = useLocation();
 
   const hasPermission = useHasPermission();
   const entityAssigned = useEntityAssigned();

--- a/src/pages/purchase-orders/edit/components/Documents.tsx
+++ b/src/pages/purchase-orders/edit/components/Documents.tsx
@@ -14,13 +14,15 @@ import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
 import { $refetch } from '$app/common/hooks/useRefetch';
 import { DocumentsTable } from '$app/components/DocumentsTable';
 import { Upload } from '$app/pages/settings/company/documents/components';
-import { useOutletContext, useParams } from 'react-router-dom';
+import { useLocation, useOutletContext, useParams } from 'react-router-dom';
 import { Card } from '$app/components/cards';
 import { useTranslation } from 'react-i18next';
 import { PurchaseOrderContext } from '../../create/Create';
 
 export default function Documents() {
   const [t] = useTranslation();
+
+  const location = useLocation();
 
   const hasPermission = useHasPermission();
   const entityAssigned = useEntityAssigned();

--- a/src/pages/quotes/edit/components/Documents.tsx
+++ b/src/pages/quotes/edit/components/Documents.tsx
@@ -14,13 +14,15 @@ import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
 import { $refetch } from '$app/common/hooks/useRefetch';
 import { DocumentsTable } from '$app/components/DocumentsTable';
 import { Upload } from '$app/pages/settings/company/documents/components';
-import { useOutletContext, useParams } from 'react-router-dom';
+import { useLocation, useOutletContext, useParams } from 'react-router-dom';
 import { Card } from '$app/components/cards';
 import { useTranslation } from 'react-i18next';
 import { QuoteContext } from '../../create/Create';
 
 export default function Documents() {
   const [t] = useTranslation();
+
+  const location = useLocation();
 
   const hasPermission = useHasPermission();
   const entityAssigned = useEntityAssigned();

--- a/src/pages/recurring-invoices/edit/components/Documents.tsx
+++ b/src/pages/recurring-invoices/edit/components/Documents.tsx
@@ -14,13 +14,15 @@ import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
 import { $refetch } from '$app/common/hooks/useRefetch';
 import { DocumentsTable } from '$app/components/DocumentsTable';
 import { Upload } from '$app/pages/settings/company/documents/components';
-import { useOutletContext, useParams } from 'react-router-dom';
+import { useLocation, useOutletContext, useParams } from 'react-router-dom';
 import { Card } from '$app/components/cards';
 import { useTranslation } from 'react-i18next';
 import { RecurringInvoiceContext } from '../../create/Create';
 
 export default function Documents() {
   const [t] = useTranslation();
+
+  const location = useLocation();
 
   const hasPermission = useHasPermission();
   const entityAssigned = useEntityAssigned();


### PR DESCRIPTION
@beganovich @turbo124 The PR imports the `useLocation` hook from `react-router-dom` package instead of using the default `location` class previously used in "Documents" components, to avoid unexpected behavior. Let me know your thoughts.