### PR TITLE
[Cleanup] Making Payment Means Form Available For All E-Invoice Types

### DIFF
--- a/src/components/e-invoice/PaymentMeans.tsx
+++ b/src/components/e-invoice/PaymentMeans.tsx
@@ -385,63 +385,66 @@ export const PaymentMeans = forwardRef<PaymentMeansFormComponent, Props>(
     useEffect(() => {
       form.setFieldValue(
         'payment_means.0.code',
-        get(company.e_invoice, 'Invoice.PaymentMeans.0.PaymentMeansCode.value')
+        get(
+          company.e_invoice,
+          'Invoice.PaymentMeans.0.PaymentMeansCode.value'
+        ) || '1'
       );
       form.setFieldValue(
         'payment_means.0.iban',
         get(
           company.e_invoice,
           'Invoice.PaymentMeans.0.PayeeFinancialAccount.ID.value'
-        )
+        ) || null
       );
       form.setFieldValue(
         'payment_means.0.bic_swift',
         get(
           company.e_invoice,
           'Invoice.PaymentMeans.0.PayeeFinancialAccount.FinancialInstitutionBranch.FinancialInstitution.ID.value'
-        )
+        ) || ''
       );
       form.setFieldValue(
         'payment_means.0.account_holder',
         get(
           company.e_invoice,
           'Invoice.PaymentMeans.0.PayeeFinancialAccount.Name'
-        )
+        ) || ''
       );
       form.setFieldValue(
         'payment_means.0.payer_bank_account',
         get(
           company.e_invoice,
           'Invoice.PaymentMeans.0.PayerFinancialAccount.ID.value'
-        )
+        ) || ''
       );
       form.setFieldValue(
         'payment_means.0.bsb_sort',
         get(
           company.e_invoice,
           'Invoice.PaymentMeans.0.PayeeFinancialAccount.SortCode.value'
-        )
+        ) || ''
       );
       form.setFieldValue(
         'payment_means.0.card_type',
         get(
           company.e_invoice,
           'Invoice.PaymentMeans.0.CardAccount.NetworkID.value'
-        )
+        ) || ''
       );
       form.setFieldValue(
         'payment_means.0.card_number',
         get(
           company.e_invoice,
           'Invoice.PaymentMeans.0.CardAccount.PrimaryAccountNumberID.value'
-        )
+        ) || ''
       );
       form.setFieldValue(
         'payment_means.0.card_holder',
         get(
           company.e_invoice,
           'Invoice.PaymentMeans.0.CardAccount.HolderName.value'
-        )
+        ) || ''
       );
     }, [company.e_invoice]);
 

--- a/src/components/e-invoice/PaymentMeans.tsx
+++ b/src/components/e-invoice/PaymentMeans.tsx
@@ -326,7 +326,7 @@ export const PaymentMeans = forwardRef<PaymentMeansFormComponent, Props>(
         entity: props.entity,
         payment_means: [
           {
-            code: '',
+            code: '1',
             iban: null,
             bic_swift: '',
             payer_bank_account: '',
@@ -454,6 +454,7 @@ export const PaymentMeans = forwardRef<PaymentMeansFormComponent, Props>(
               form.setFieldValue('payment_means.0.code', value)
             }
             errorMessage={errors?.errors?.['payment_means.0.code']}
+            dismissable={false}
             customSelector
           >
             {Object.entries(PAYMENT_MEANS_CODE_LIST).map(([key, label]) => (

--- a/src/components/e-invoice/PaymentMeans.tsx
+++ b/src/components/e-invoice/PaymentMeans.tsx
@@ -140,94 +140,92 @@ const PAYMENT_MEANS_CODE_LIST = {
   97: 'Clearing between partners',
   ZZZ: 'Mutually defined',
 };
-  
+
 const PAYMENT_MEANS_FORM_ELEMENTS = {
-    '1': [], // Instrument not defined
-    '2': ['iban', 'bic_swift'], // ACH credit
-    '3': ['payer_bank_account', 'iban', 'bic_swift'], // ACH debit
-    '4': ['payer_bank_account', 'iban', 'bic_swift'], // ACH demand debit reversal
-    '5': ['iban', 'bic_swift'], // ACH demand credit reversal
-    '6': ['iban', 'bic_swift'], // ACH demand credit
-    '7': ['payer_bank_account', 'iban', 'bic_swift'], // ACH demand debit
-    '8': [], // Hold
-    '9': ['iban', 'bic_swift'], // National or regional clearing
-    '10': [], // In cash
-    '11': ['iban', 'bic_swift'], // ACH savings credit reversal
-    '12': ['payer_bank_account', 'iban', 'bic_swift'], // ACH savings debit reversal
-    '13': ['iban', 'bic_swift'], // ACH savings credit
-    '14': ['payer_bank_account', 'iban', 'bic_swift'], // ACH savings debit
-    '15': ['account_holder', 'bsb_sort'], // Bookentry credit
-    '16': ['account_holder', 'bsb_sort'], // Bookentry debit
-    '17': ['iban', 'bic_swift'], // ACH demand CCD credit
-    '18': ['payer_bank_account', 'iban', 'bic_swift'], // ACH demand CCD debit
-    '19': ['iban', 'bic_swift'], // ACH demand CTP credit
-    '20': [], // Cheque
-    '21': [], // Banker's draft
-    '22': [], // Certified banker's draft
-    '23': [], // Bank cheque
-    '24': [], // Bill of exchange awaiting acceptance
-    '25': [], // Certified cheque
-    '26': [], // Local cheque
-    '27': ['payer_bank_account', 'iban', 'bic_swift'], // ACH demand CTP debit
-    '28': ['iban', 'bic_swift'], // ACH demand CTX credit
-    '29': ['payer_bank_account', 'iban', 'bic_swift'], // ACH demand CTX debit
-     '30': ['iban', 'bic_swift', 'account_holder'], // Credit transfer
-    '31': ['iban', 'bic_swift', 'account_holder'], // Debit transfer
-    '32': ['iban', 'bic_swift', 'account_holder'], // ACH demand CCD+ credit
-    '33': ['payer_bank_account', 'iban', 'bic_swift', 'account_holder'], // ACH demand CCD+ debit
-    '34': ['iban', 'bic_swift', 'account_holder'], // ACH PPD
-    '35': ['iban', 'bic_swift', 'account_holder'], // ACH savings CCD credit
-    '36': ['payer_bank_account', 'iban', 'bic_swift', 'account_holder'], // ACH savings CCD debit
-    '37': ['iban', 'bic_swift', 'account_holder'], // ACH savings CTP credit
-    '38': ['payer_bank_account', 'iban', 'bic_swift', 'account_holder'], // ACH savings CTP debit
-    '39': ['iban', 'bic_swift', 'account_holder'], // ACH savings CTX credit
-    '40': ['payer_bank_account', 'iban', 'bic_swift', 'account_holder'], // ACH savings CTX debit
-    '41': ['iban', 'bic_swift', 'account_holder'], // ACH savings CCD+ credit
-    '42': ['iban', 'bic_swift', 'account_holder'], // Payment to bank account
-    '43': ['payer_bank_account', 'iban', 'bic_swift', 'account_holder'], // ACH savings CCD+ debit
-    '44': [], // Accepted bill of exchange
-    '45': ['iban', 'bic_swift'], // Referenced home-banking credit transfer
-    '46': ['iban', 'bic_swift'], // Interbank debit transfer
-    '47': ['iban', 'bic_swift'], // Home-banking debit transfer
-    '48': ['card_type', 'card_number'], // Bank card
-    '49': ['payer_bank_account', 'iban', 'bic_swift'], // Direct debit
-    '50': ['account_holder'], // Payment by postgiro
-    '51': ['iban', 'bic_swift'], // FR, norme 6 97-Telereglement CFONB
-    '52': ['iban', 'bic_swift'], // Urgent commercial payment
-    '53': ['iban', 'bic_swift'], // Urgent Treasury Payment
-    '54': ['card_type', 'card_number', 'card_holder'], // Credit card
-    '55': ['card_type', 'card_number', 'card_holder'], // Debit card
-    '56': ['account_holder'], // Bankgiro
-    '57': ['iban', 'bic_swift'], // Standing agreement
-    '58': ['iban', 'bic_swift'], // SEPA credit transfer
-    '59': ['payer_bank_account', 'iban', 'bic_swift'], // SEPA direct debit
-    '60': [], // Promissory note
-    '61': [], // Promissory note signed by debtor
-    '62': ['bic_swift'], // Promissory note signed by debtor and endorsed by bank
-    '63': [], // Promissory note signed by debtor and endorsed
-    '64': ['bic_swift'], // Promissory note signed by bank
-    '65': ['bic_swift'], // Promissory note signed by bank and endorsed by another
-    '66': [], // Promissory note signed by third party
-    '67': ['bic_swift'], // Promissory note signed by third party and endorsed by bank
-    '68': ['iban'], // Online payment service
-    '69': ['iban', 'bic_swift'], // Transfer Advice
-    '70': [], // Bill drawn by creditor on debtor
-    '74': ['bic_swift'], // Bill drawn by creditor on bank
-    '75': ['bic_swift'], // Bill drawn by creditor, endorsed by bank
-    '76': ['bic_swift'], // Bill drawn by creditor on bank and endorsed
-    '77': [], // Bill drawn by creditor on third party
-    '78': [], // Bill drawn by creditor on third party, accepted
-    '91': [], // Not transferable banker's draft
-    '92': [], // Not transferable local cheque
-    '93': ['iban', 'bic_swift'], // Reference giro
-    '94': ['iban', 'bic_swift'], // Urgent giro
-    '95': ['iban', 'bic_swift'], // Free format giro
-    '96': [], // Requested method not used
-    '97': ['account_holder'], // Clearing between partners
-    'ZZZ': [], // Mutually defined
+  '1': [], // Instrument not defined
+  '2': ['iban', 'bic_swift'], // ACH credit
+  '3': ['payer_bank_account', 'iban', 'bic_swift'], // ACH debit
+  '4': ['payer_bank_account', 'iban', 'bic_swift'], // ACH demand debit reversal
+  '5': ['iban', 'bic_swift'], // ACH demand credit reversal
+  '6': ['iban', 'bic_swift'], // ACH demand credit
+  '7': ['payer_bank_account', 'iban', 'bic_swift'], // ACH demand debit
+  '8': [], // Hold
+  '9': ['iban', 'bic_swift'], // National or regional clearing
+  '10': [], // In cash
+  '11': ['iban', 'bic_swift'], // ACH savings credit reversal
+  '12': ['payer_bank_account', 'iban', 'bic_swift'], // ACH savings debit reversal
+  '13': ['iban', 'bic_swift'], // ACH savings credit
+  '14': ['payer_bank_account', 'iban', 'bic_swift'], // ACH savings debit
+  '15': ['account_holder', 'bsb_sort'], // Bookentry credit
+  '16': ['account_holder', 'bsb_sort'], // Bookentry debit
+  '17': ['iban', 'bic_swift'], // ACH demand CCD credit
+  '18': ['payer_bank_account', 'iban', 'bic_swift'], // ACH demand CCD debit
+  '19': ['iban', 'bic_swift'], // ACH demand CTP credit
+  '20': [], // Cheque
+  '21': [], // Banker's draft
+  '22': [], // Certified banker's draft
+  '23': [], // Bank cheque
+  '24': [], // Bill of exchange awaiting acceptance
+  '25': [], // Certified cheque
+  '26': [], // Local cheque
+  '27': ['payer_bank_account', 'iban', 'bic_swift'], // ACH demand CTP debit
+  '28': ['iban', 'bic_swift'], // ACH demand CTX credit
+  '29': ['payer_bank_account', 'iban', 'bic_swift'], // ACH demand CTX debit
+  '30': ['iban', 'bic_swift', 'account_holder'], // Credit transfer
+  '31': ['iban', 'bic_swift', 'account_holder'], // Debit transfer
+  '32': ['iban', 'bic_swift', 'account_holder'], // ACH demand CCD+ credit
+  '33': ['payer_bank_account', 'iban', 'bic_swift', 'account_holder'], // ACH demand CCD+ debit
+  '34': ['iban', 'bic_swift', 'account_holder'], // ACH PPD
+  '35': ['iban', 'bic_swift', 'account_holder'], // ACH savings CCD credit
+  '36': ['payer_bank_account', 'iban', 'bic_swift', 'account_holder'], // ACH savings CCD debit
+  '37': ['iban', 'bic_swift', 'account_holder'], // ACH savings CTP credit
+  '38': ['payer_bank_account', 'iban', 'bic_swift', 'account_holder'], // ACH savings CTP debit
+  '39': ['iban', 'bic_swift', 'account_holder'], // ACH savings CTX credit
+  '40': ['payer_bank_account', 'iban', 'bic_swift', 'account_holder'], // ACH savings CTX debit
+  '41': ['iban', 'bic_swift', 'account_holder'], // ACH savings CCD+ credit
+  '42': ['iban', 'bic_swift', 'account_holder'], // Payment to bank account
+  '43': ['payer_bank_account', 'iban', 'bic_swift', 'account_holder'], // ACH savings CCD+ debit
+  '44': [], // Accepted bill of exchange
+  '45': ['iban', 'bic_swift'], // Referenced home-banking credit transfer
+  '46': ['iban', 'bic_swift'], // Interbank debit transfer
+  '47': ['iban', 'bic_swift'], // Home-banking debit transfer
+  '48': ['card_type', 'card_number'], // Bank card
+  '49': ['payer_bank_account', 'iban', 'bic_swift'], // Direct debit
+  '50': ['account_holder'], // Payment by postgiro
+  '51': ['iban', 'bic_swift'], // FR, norme 6 97-Telereglement CFONB
+  '52': ['iban', 'bic_swift'], // Urgent commercial payment
+  '53': ['iban', 'bic_swift'], // Urgent Treasury Payment
+  '54': ['card_type', 'card_number', 'card_holder'], // Credit card
+  '55': ['card_type', 'card_number', 'card_holder'], // Debit card
+  '56': ['account_holder'], // Bankgiro
+  '57': ['iban', 'bic_swift'], // Standing agreement
+  '58': ['iban', 'bic_swift'], // SEPA credit transfer
+  '59': ['payer_bank_account', 'iban', 'bic_swift'], // SEPA direct debit
+  '60': [], // Promissory note
+  '61': [], // Promissory note signed by debtor
+  '62': ['bic_swift'], // Promissory note signed by debtor and endorsed by bank
+  '63': [], // Promissory note signed by debtor and endorsed
+  '64': ['bic_swift'], // Promissory note signed by bank
+  '65': ['bic_swift'], // Promissory note signed by bank and endorsed by another
+  '66': [], // Promissory note signed by third party
+  '67': ['bic_swift'], // Promissory note signed by third party and endorsed by bank
+  '68': ['iban'], // Online payment service
+  '69': ['iban', 'bic_swift'], // Transfer Advice
+  '70': [], // Bill drawn by creditor on debtor
+  '74': ['bic_swift'], // Bill drawn by creditor on bank
+  '75': ['bic_swift'], // Bill drawn by creditor, endorsed by bank
+  '76': ['bic_swift'], // Bill drawn by creditor on bank and endorsed
+  '77': [], // Bill drawn by creditor on third party
+  '78': [], // Bill drawn by creditor on third party, accepted
+  '91': [], // Not transferable banker's draft
+  '92': [], // Not transferable local cheque
+  '93': ['iban', 'bic_swift'], // Reference giro
+  '94': ['iban', 'bic_swift'], // Urgent giro
+  '95': ['iban', 'bic_swift'], // Free format giro
+  '96': [], // Requested method not used
+  '97': ['account_holder'], // Clearing between partners
+  ZZZ: [], // Mutually defined
 };
-
-
 
 // public static array $payment_means_requirements_codes = [
 //     '1' => [], // Instrument not defined
@@ -380,7 +378,7 @@ export const PaymentMeans = forwardRef<PaymentMeansFormComponent, Props>(
         ? PAYMENT_MEANS_FORM_ELEMENTS[
             form.values.payment_means[0]
               .code as keyof typeof PAYMENT_MEANS_FORM_ELEMENTS
-          ]
+          ] || []
         : [];
     }, [form.values.payment_means]);
 
@@ -389,37 +387,61 @@ export const PaymentMeans = forwardRef<PaymentMeansFormComponent, Props>(
         'payment_means.0.code',
         get(company.e_invoice, 'Invoice.PaymentMeans.0.PaymentMeansCode.value')
       );
-        form.setFieldValue(
+      form.setFieldValue(
         'payment_means.0.iban',
-        get(company.e_invoice, 'Invoice.PaymentMeans.0.PayeeFinancialAccount.ID.value')
+        get(
+          company.e_invoice,
+          'Invoice.PaymentMeans.0.PayeeFinancialAccount.ID.value'
+        )
       );
       form.setFieldValue(
         'payment_means.0.bic_swift',
-        get(company.e_invoice, 'Invoice.PaymentMeans.0.PayeeFinancialAccount.FinancialInstitutionBranch.FinancialInstitution.ID.value')
+        get(
+          company.e_invoice,
+          'Invoice.PaymentMeans.0.PayeeFinancialAccount.FinancialInstitutionBranch.FinancialInstitution.ID.value'
+        )
       );
       form.setFieldValue(
         'payment_means.0.account_holder',
-        get(company.e_invoice, 'Invoice.PaymentMeans.0.PayeeFinancialAccount.Name')
+        get(
+          company.e_invoice,
+          'Invoice.PaymentMeans.0.PayeeFinancialAccount.Name'
+        )
       );
       form.setFieldValue(
         'payment_means.0.payer_bank_account',
-        get(company.e_invoice, 'Invoice.PaymentMeans.0.PayerFinancialAccount.ID.value')
+        get(
+          company.e_invoice,
+          'Invoice.PaymentMeans.0.PayerFinancialAccount.ID.value'
+        )
       );
       form.setFieldValue(
         'payment_means.0.bsb_sort',
-        get(company.e_invoice, 'Invoice.PaymentMeans.0.PayeeFinancialAccount.SortCode.value')
+        get(
+          company.e_invoice,
+          'Invoice.PaymentMeans.0.PayeeFinancialAccount.SortCode.value'
+        )
       );
       form.setFieldValue(
         'payment_means.0.card_type',
-        get(company.e_invoice, 'Invoice.PaymentMeans.0.CardAccount.NetworkID.value')
+        get(
+          company.e_invoice,
+          'Invoice.PaymentMeans.0.CardAccount.NetworkID.value'
+        )
       );
       form.setFieldValue(
         'payment_means.0.card_number',
-        get(company.e_invoice, 'Invoice.PaymentMeans.0.CardAccount.PrimaryAccountNumberID.value')
+        get(
+          company.e_invoice,
+          'Invoice.PaymentMeans.0.CardAccount.PrimaryAccountNumberID.value'
+        )
       );
       form.setFieldValue(
         'payment_means.0.card_holder',
-        get(company.e_invoice, 'Invoice.PaymentMeans.0.CardAccount.HolderName.value')
+        get(
+          company.e_invoice,
+          'Invoice.PaymentMeans.0.CardAccount.HolderName.value'
+        )
       );
     }, [company.e_invoice]);
 

--- a/src/pages/settings/e-invoice/EInvoice.tsx
+++ b/src/pages/settings/e-invoice/EInvoice.tsx
@@ -415,10 +415,7 @@ export function EInvoice() {
         <Preferences />
       ) : null}
 
-      {company?.settings.enable_e_invoice &&
-      company?.legal_entity_id &&
-      company.settings.e_invoice_type === 'PEPPOL' &&
-      shouldShowPEPPOLOption() ? (
+      {company?.settings.enable_e_invoice ? (
         <PaymentMeans
           ref={eInvoiceRef}
           currentEInvoice={company?.e_invoice || {}}


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adjusting the logic so the 'Payment Means' form is available for all e-invoice types with ONLY one criterion: `enable_e_invoice` must be turned on. Screenshot:

![Screenshot 2024-11-11 at 18 44 40](https://github.com/user-attachments/assets/546129a8-8349-47e3-96b9-d250da8ad444)

Let me know your thoughts.