### PR TITLE
[Bugfix] Making Helper Text Visible Only For Stripe

### DIFF
--- a/src/pages/settings/gateways/create/components/Settings.tsx
+++ b/src/pages/settings/gateways/create/components/Settings.tsx
@@ -121,9 +121,14 @@ export function Settings(props: Props) {
         <Element
           key={index}
           leftSide={t(resolveGatewayTypeTranslation(option.gatewayTypeId))}
-          leftSideHelp={t(
-            `${resolveGatewayTypeTranslation(option.gatewayTypeId)}_stripe_help`
-          )}
+          {...((gateway?.key === 'd14dd26a37cecc30fdd65700bfb55b23' ||
+            gateway?.key === 'd14dd26a47cecc30fdd65700bfb67b34') && {
+            leftSideHelp: t(
+              `${resolveGatewayTypeTranslation(
+                option.gatewayTypeId
+              )}_stripe_help`
+            ),
+          })}
         >
           <Toggle
             checked={isChecked(option.gatewayTypeId)}


### PR DESCRIPTION
@beganovich @turbo124 The PR includes an adjustment to make the helper text visible only for the 'Stripe' gateway and not for any others. Screenshots:

![Screenshot 2024-11-12 at 00 31 12](https://github.com/user-attachments/assets/605db1d5-5a91-45db-b8f7-e99bf43257c8)

![Screenshot 2024-11-12 at 00 31 25](https://github.com/user-attachments/assets/97761e30-cd02-440c-99d2-ebaf11a4ee25)

Let me know your thoughts.