### PR TITLE
E-invoicing: Hide current country

### DIFF
--- a/src/pages/settings/e-invoice/common/components/EUTaxDetails.tsx
+++ b/src/pages/settings/e-invoice/common/components/EUTaxDetails.tsx
@@ -135,6 +135,10 @@ function Configure() {
       return false;
     }
 
+    if (company.settings.country_id === countryId) {
+      return false;
+    }
+
     return !get(
       company.tax_data.regions.EU.subregions,
       `${iso31662}.vat_number`


### PR DESCRIPTION
This hides current country from being added in additional tax configurations.