### PR TITLE
[Cleanup] Removing C2C Action For Invoice "Number" Column

### DIFF
--- a/src/pages/invoices/common/hooks/useInvoiceColumns.tsx
+++ b/src/pages/invoices/common/hooks/useInvoiceColumns.tsx
@@ -26,7 +26,6 @@ import { useReactSettings } from '$app/common/hooks/useReactSettings';
 import { useDisableNavigation } from '$app/common/hooks/useDisableNavigation';
 import { DynamicLink } from '$app/components/DynamicLink';
 import { useFormatCustomFieldValue } from '$app/common/hooks/useFormatCustomFieldValue';
-import { CopyToClipboardIconOnly } from '$app/components/CopyToClipBoardIconOnly';
 import {
   extractTextFromHTML,
   sanitizeHTML,
@@ -147,16 +146,12 @@ export function useInvoiceColumns(): DataTableColumns<Invoice> {
       id: 'number',
       label: t('number'),
       format: (value, invoice) => (
-        <div className="flex space-x-2">
-          <DynamicLink
-            to={route('/invoices/:id/edit', { id: invoice.id })}
-            renderSpan={disableNavigation('invoice', invoice)}
-          >
-            {value}
-          </DynamicLink>
-
-          <CopyToClipboardIconOnly text={invoice.number} />
-        </div>
+        <DynamicLink
+          to={route('/invoices/:id/edit', { id: invoice.id })}
+          renderSpan={disableNavigation('invoice', invoice)}
+        >
+          {value}
+        </DynamicLink>
       ),
     },
     {


### PR DESCRIPTION
@beganovich @turbo124 The PR removes the C2C action from the invoice "Number" column. Screenshot:

<img width="1061" alt="Screenshot 2024-11-19 at 15 24 59" src="https://github.com/user-attachments/assets/c8469207-5a02-4ab9-9374-f94873e159d6">

Let me know your thoughts.