### PR TITLE
[Cleanup] Adjusting Icons For Payment Overview Page

### DIFF
--- a/src/pages/payments/Payment.tsx
+++ b/src/pages/payments/Payment.tsx
@@ -44,7 +44,7 @@ export default function Payment() {
 
   const { id } = useParams();
 
-  const { data } = usePaymentQuery({ id });
+  const { data } = usePaymentQuery({ id, include: 'credits' });
 
   const [paymentValue, setPaymentValue] = useState<PaymentEntity>();
 

--- a/src/pages/payments/edit/PaymentOverviewInvoice.tsx
+++ b/src/pages/payments/edit/PaymentOverviewInvoice.tsx
@@ -16,8 +16,9 @@ import { useCurrentCompanyDateFormats } from '$app/common/hooks/useCurrentCompan
 import { date as formatDate } from '$app/common/helpers';
 import { Link } from 'react-router-dom';
 import { route } from '$app/common/helpers/route';
-import { MdOutlineFileOpen } from 'react-icons/md';
 import { useColorScheme } from '$app/common/colors';
+import { Icon } from '$app/components/icons/Icon';
+import { ExternalLink } from 'react-feather';
 
 interface Props {
   payment: Payment;
@@ -43,17 +44,33 @@ export function PaymentOverviewInvoice(props: Props) {
       {props.paymentable.invoice_id && (
         <div className="grid grid-cols-1 gap-2 my-2 border border-x-5 py-4">
           <div className="flex items-center justify-center">
-            <span className="flex item-center gap-2" style={{ color: colors.$3, colorScheme: colors.$0 }}>
+            <span
+              className="flex item-center gap-2"
+              style={{ color: colors.$3, colorScheme: colors.$0 }}
+            >
               {`${t('invoice')} `}
               <Link
                 to={route('/invoices/:id/edit', {
                   id: props.paymentable.invoice_id,
                 })}
               >
-                <span className="flex items-center gap-2" style={{ color: colors.$3, colorScheme: colors.$0 }}>
-                  {setLabel(props.payment, props.paymentable)}{' '}
-                  <MdOutlineFileOpen />
-                </span>
+                <div
+                  className="flex items-center gap-2"
+                  style={{ color: colors.$3, colorScheme: colors.$0 }}
+                >
+                  <span>{setLabel(props.payment, props.paymentable)}</span>
+
+                  <div>
+                    <Icon
+                      element={ExternalLink}
+                      style={{
+                        width: '1.1rem',
+                        height: '1.1rem',
+                        marginBottom: '0.27rem',
+                      }}
+                    />
+                  </div>
+                </div>
               </Link>
             </span>
           </div>
@@ -65,19 +82,27 @@ export function PaymentOverviewInvoice(props: Props) {
                 props.payment?.currency_id
               )}
             </span>
-            <span className="mx-5" style={{ color: colors.$3, colorScheme: colors.$0 }}>
+            <span
+              className="mx-5"
+              style={{ color: colors.$3, colorScheme: colors.$0 }}
+            >
               {formatDate(
                 new Date(props.paymentable.created_at * 1000).toString(),
                 dateFormat
               )}
             </span>
             {props.paymentable.refunded > 0 && (
-              <span className="" style={{ color: "red", colorScheme: colors.$0 }}>
-                ( {formatMoney(
+              <span
+                className=""
+                style={{ color: 'red', colorScheme: colors.$0 }}
+              >
+                ({' '}
+                {formatMoney(
                   props?.paymentable?.refunded || 0,
                   props.payment.client?.country_id,
                   props.payment?.currency_id
-                )} { t('refunded')} )
+                )}{' '}
+                {t('refunded')} )
               </span>
             )}
           </div>
@@ -105,19 +130,27 @@ export function PaymentOverviewInvoice(props: Props) {
                 props.payment?.currency_id
               )}
             </span>
-            <span className="mx-5" style={{ color: colors.$3, colorScheme: colors.$0 }}>
+            <span
+              className="mx-5"
+              style={{ color: colors.$3, colorScheme: colors.$0 }}
+            >
               {formatDate(
                 new Date(props.paymentable.created_at * 1000).toString(),
                 dateFormat
               )}
             </span>
             {props.paymentable.refunded > 0 && (
-              <span className="" style={{ color: "red", colorScheme: colors.$0 }}>
-                ( {formatMoney(
+              <span
+                className=""
+                style={{ color: 'red', colorScheme: colors.$0 }}
+              >
+                ({' '}
+                {formatMoney(
                   props?.paymentable?.refunded || 0,
                   props.payment.client?.country_id,
                   props.payment?.currency_id
-                )} {t('refunded')} )
+                )}{' '}
+                {t('refunded')} )
               </span>
             )}
           </div>

--- a/src/pages/payments/edit/PaymentOverviewInvoice.tsx
+++ b/src/pages/payments/edit/PaymentOverviewInvoice.tsx
@@ -19,13 +19,26 @@ import { route } from '$app/common/helpers/route';
 import { useColorScheme } from '$app/common/colors';
 import { Icon } from '$app/components/icons/Icon';
 import { ExternalLink } from 'react-feather';
+import { Credit } from '$app/common/interfaces/credit';
 
 interface Props {
   payment: Payment;
   paymentable: Paymentable;
 }
 
-export function setLabel(payment: Payment, paymentable: Paymentable): string {
+export function setLabel(
+  payment: Payment,
+  paymentable: Paymentable,
+  isCredit?: boolean
+): string {
+  if (isCredit) {
+    const credit = payment?.credits?.find(
+      (credit: Credit) => credit.id == paymentable.credit_id
+    );
+
+    return credit?.number || '';
+  }
+
   const invoice = payment?.invoices?.find(
     (invoice: Invoice) => invoice.id == paymentable.invoice_id
   );
@@ -112,13 +125,35 @@ export function PaymentOverviewInvoice(props: Props) {
       {props.paymentable.credit_id && (
         <div className="grid grid-cols-1 gap-2 my-2 border border-x-5 py-4">
           <div className="flex items-center justify-center">
-            <span style={{ color: colors.$3, colorScheme: colors.$0 }}>
+            <span
+              className="flex item-center gap-2"
+              style={{ color: colors.$3, colorScheme: colors.$0 }}
+            >
+              {`${t('credit')} `}
               <Link
                 to={route('/credits/:id/edit', {
                   id: props.paymentable.credit_id,
                 })}
               >
-                {`${t('credit')} `}
+                <div
+                  className="flex items-center gap-2"
+                  style={{ color: colors.$3, colorScheme: colors.$0 }}
+                >
+                  <span>
+                    {setLabel(props.payment, props.paymentable, true)}
+                  </span>
+
+                  <div>
+                    <Icon
+                      element={ExternalLink}
+                      style={{
+                        width: '1.1rem',
+                        height: '1.1rem',
+                        marginBottom: '0.27rem',
+                      }}
+                    />
+                  </div>
+                </div>
               </Link>
             </span>
           </div>

--- a/src/pages/payments/edit/PaymentOverviewInvoice.tsx
+++ b/src/pages/payments/edit/PaymentOverviewInvoice.tsx
@@ -105,10 +105,7 @@ export function PaymentOverviewInvoice(props: Props) {
               )}
             </span>
             {props.paymentable.refunded > 0 && (
-              <span
-                className=""
-                style={{ color: 'red', colorScheme: colors.$0 }}
-              >
+              <span style={{ color: 'red', colorScheme: colors.$0 }}>
                 ({' '}
                 {formatMoney(
                   props?.paymentable?.refunded || 0,
@@ -175,10 +172,7 @@ export function PaymentOverviewInvoice(props: Props) {
               )}
             </span>
             {props.paymentable.refunded > 0 && (
-              <span
-                className=""
-                style={{ color: 'red', colorScheme: colors.$0 }}
-              >
+              <span style={{ color: 'red', colorScheme: colors.$0 }}>
                 ({' '}
                 {formatMoney(
                   props?.paymentable?.refunded || 0,


### PR DESCRIPTION
@beganovich @turbo124 The PR adjusts labels and icons on the Payment Overview page to maintain consistency with the rest of the app. Screenshot:

<img width="739" alt="Screenshot 2024-11-20 at 14 43 10" src="https://github.com/user-attachments/assets/2318fa54-a1cc-48bf-aab4-1154c9d3cb68">

Let me know your thoughts.