### PR TITLE
[Cleanup] Implementing Warning Banner For Payments If Amout Is Negative

### DIFF
--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -9,16 +9,17 @@
  */
 
 import classNames from 'classnames';
-import { ReactNode } from 'react';
+import { CSSProperties, ReactNode } from 'react';
 
 interface Props {
   variant: 'orange' | 'red';
   children: ReactNode;
   className?: string;
   id?: string;
+  style?: CSSProperties;
 }
 
-export function Banner({ variant, children, className, id }: Props) {
+export function Banner({ variant, children, className, id, style }: Props) {
   return (
     <div
       id={id}
@@ -30,6 +31,7 @@ export function Banner({ variant, children, className, id }: Props) {
         },
         className
       )}
+      style={style}
     >
       {children}
     </div>

--- a/src/pages/payments/Payment.tsx
+++ b/src/pages/payments/Payment.tsx
@@ -35,9 +35,13 @@ import {
   useSocketEvent,
   WithSocketId,
 } from '$app/common/queries/sockets';
+import classNames from 'classnames';
+import { useColorScheme } from '$app/common/colors';
 
 export default function Payment() {
   const [t] = useTranslation();
+
+  const colors = useColorScheme();
 
   const hasPermission = useHasPermission();
   const entityAssigned = useEntityAssigned();
@@ -105,9 +109,25 @@ export default function Payment() {
           disableSaveButton: !paymentValue,
         })}
       aboveMainContainer={
-        <Banner id="paymentUpdateBanner" className="hidden" variant="orange">
-          {t('payment_status_changed')}
-        </Banner>
+        <>
+          <Banner id="paymentUpdateBanner" className="hidden" variant="orange">
+            {t('payment_status_changed')}
+          </Banner>
+
+          {Boolean(paymentValue && paymentValue.amount < 0) && (
+            <Banner
+              variant="orange"
+              className={classNames({
+                'border-t': !document
+                  .getElementById('paymentUpdateBanner')
+                  ?.classList.contains('hidden'),
+              })}
+              style={{ borderColor: colors.$5 }}
+            >
+              {t('negative_payment_warning')}
+            </Banner>
+          )}
+        </>
       }
     >
       <Container breadcrumbs={[]}>


### PR DESCRIPTION
@beganovich @turbo124 The PR implements a warning banner that appears when a negative amount is entered. Screenshot:

<img width="1261" alt="Screenshot 2024-11-20 at 19 01 40" src="https://github.com/user-attachments/assets/63bd1752-875d-4e94-ba17-c3a154e98c90">

Let me know your thoughts.