### PR TITLE
E-invoicing: Set stale time for quota route

### DIFF
--- a/src/pages/settings/e-invoice/peppol/Preferences.tsx
+++ b/src/pages/settings/e-invoice/peppol/Preferences.tsx
@@ -186,6 +186,7 @@ export function useQuota() {
     enabled:
       isSelfHosted() && import.meta.env.VITE_ENABLE_PEPPOL_STANDARD === 'true',
     retry: () => false,
+    staleTime: Infinity,
   });
 
   const count = () => {


### PR DESCRIPTION
This sets quotas route to fetch only once per visit preventing multiple requests.