### PR TITLE
[Bugfix] Displaying All Created Custom Designs | Invoice Design

### DIFF
--- a/src/common/queries/designs.ts
+++ b/src/common/queries/designs.ts
@@ -30,7 +30,7 @@ export function useDesignsQuery() {
     () =>
       request(
         'GET',
-        endpoint('/api/v1/designs?status=active&sort=name|asc')
+        endpoint('/api/v1/designs?status=active&sort=name|asc&per_page=100')
       ).then((response: AxiosResponse<GenericManyResponse<Design>>) =>
         response.data.data.filter(
           (design) =>

--- a/src/pages/settings/invoice-design/pages/general-settings/components/GeneralSettings.tsx
+++ b/src/pages/settings/invoice-design/pages/general-settings/components/GeneralSettings.tsx
@@ -872,6 +872,8 @@ export default function GeneralSettings() {
             onValueChange={(value) => handleChange('invoice_design_id', value)}
             disabled={disableSettingsField('invoice_design_id')}
             errorMessage={errors?.errors['settings.invoice_design_id']}
+            customSelector
+            dismissable={false}
           >
             {designs &&
               designsFilter('invoice', designs).map((design: Design) => (
@@ -922,6 +924,8 @@ export default function GeneralSettings() {
             onValueChange={(value) => handleChange('quote_design_id', value)}
             disabled={disableSettingsField('quote_design_id')}
             errorMessage={errors?.errors['settings.quote_design_id']}
+            customSelector
+            dismissable={false}
           >
             {designs &&
               designsFilter('quote', designs).map((design: Design) => (
@@ -972,6 +976,8 @@ export default function GeneralSettings() {
             onValueChange={(value) => handleChange('credit_design_id', value)}
             disabled={disableSettingsField('credit_design_id')}
             errorMessage={errors?.errors['settings.credit_design_id']}
+            customSelector
+            dismissable={false}
           >
             {designs &&
               designsFilter('credit', designs).map((design: Design) => (
@@ -1024,6 +1030,8 @@ export default function GeneralSettings() {
             }
             disabled={disableSettingsField('purchase_order_design_id')}
             errorMessage={errors?.errors['settings.purchase_order_design_id']}
+            customSelector
+            dismissable={false}
           >
             {designs &&
               designsFilter('purchase_order', designs).map((design: Design) => (
@@ -1078,7 +1086,8 @@ export default function GeneralSettings() {
             }
             disabled={disableSettingsField('statement_design_id')}
             errorMessage={errors?.errors['settings.statement_design_id']}
-            withBlank={true}
+            customSelector
+            withBlank
           >
             {statementDesigns &&
               statementDesigns.map((design: Design) => (
@@ -1108,7 +1117,8 @@ export default function GeneralSettings() {
             }
             disabled={disableSettingsField('delivery_note_design_id')}
             errorMessage={errors?.errors['settings.delivery_note_design_id']}
-            withBlank={true}
+            customSelector
+            withBlank
           >
             {invoiceDesigns &&
               invoiceDesigns.map((design: Design) => (
@@ -1138,7 +1148,8 @@ export default function GeneralSettings() {
             }
             disabled={disableSettingsField('payment_receipt_design_id')}
             errorMessage={errors?.errors['settings.payment_receipt_design_id']}
-            withBlank={true}
+            customSelector
+            withBlank
           >
             {paymentDesigns &&
               paymentDesigns.map((design: Design) => (
@@ -1168,7 +1179,8 @@ export default function GeneralSettings() {
             }
             disabled={disableSettingsField('payment_refund_design_id')}
             errorMessage={errors?.errors['settings.payment_refund_design_id']}
-            withBlank={true}
+            customSelector
+            withBlank
           >
             {paymentDesigns &&
               paymentDesigns.map((design: Design) => (
@@ -1195,6 +1207,8 @@ export default function GeneralSettings() {
           onValueChange={(value) => handleChange('page_layout', value)}
           disabled={disableSettingsField('page_layout')}
           errorMessage={errors?.errors['settings.page_layout']}
+          customSelector
+          dismissable={false}
         >
           <option value="portrait">{t('portrait')}</option>
           <option value="landscape">{t('landscape')}</option>
@@ -1216,6 +1230,8 @@ export default function GeneralSettings() {
           onValueChange={(value) => handleChange('page_size', value)}
           disabled={disableSettingsField('page_size')}
           errorMessage={errors?.errors['settings.page_size']}
+          customSelector
+          dismissable={false}
         >
           <option value="A5">A5</option>
           <option value="A4">A4</option>
@@ -1245,6 +1261,8 @@ export default function GeneralSettings() {
           onValueChange={(value) => handleChange('font_size', parseInt(value))}
           disabled={disableSettingsField('font_size')}
           errorMessage={errors?.errors['settings.font_size']}
+          customSelector
+          dismissable={false}
         >
           {range(6, 41, 2).map((number) => (
             <option key={number} value={number}>
@@ -1284,6 +1302,8 @@ export default function GeneralSettings() {
               value={logoSizeType}
               onValueChange={(value) => setLogoSizeType(value as 'px' | '%')}
               disabled={disableSettingsField('company_logo_size')}
+              customSelector
+              dismissable={false}
             >
               <option value="%">{t('percent')}</option>
               <option value="px">{t('pixels')}</option>
@@ -1309,6 +1329,8 @@ export default function GeneralSettings() {
           onValueChange={(value) => handleChange('primary_font', value)}
           disabled={disableSettingsField('primary_font')}
           errorMessage={errors?.errors['settings.primary_font']}
+          customSelector
+          dismissable={false}
         >
           {fonts.map((font) => (
             <option key={font.label} value={font.value}>
@@ -1333,6 +1355,8 @@ export default function GeneralSettings() {
           onValueChange={(value) => handleChange('secondary_font', value)}
           disabled={disableSettingsField('secondary_font')}
           errorMessage={errors?.errors['settings.secondary_font']}
+          customSelector
+          dismissable={false}
         >
           {fonts.map((font) => (
             <option key={font.label} value={font.value}>
@@ -1512,6 +1536,8 @@ export default function GeneralSettings() {
             handleChange('page_numbering_alignment', value)
           }
           errorMessage={errors?.errors['settings.page_numbering_alignment']}
+          customSelector
+          dismissable={false}
         >
           <option value="C">{t('center')}</option>
           <option value="R">{t('right')}</option>


### PR DESCRIPTION
@beganovich @turbo124 The PR has two updates: it sets the `per_page` parameter in the designs query from 20 to `100` to display all designs, and updates the page's selectors to match the app's new styling those includes search functionality.

Closes #2205 

Let me know your thoughts.