### PR TITLE
[Cleanup] Adding Missing Templates In Selection Dropdown

### DIFF
--- a/src/components/forms/SelectField.tsx
+++ b/src/components/forms/SelectField.tsx
@@ -81,6 +81,7 @@ export function SelectField(props: SelectProps) {
       minWidth: '100%',
       backgroundColor: colors.$4,
       borderColor: colors.$4,
+      zIndex: 50,
     }),
     control: (base, { isDisabled }) => ({
       ...base,

--- a/src/pages/settings/templates-and-reminders/TemplatesAndReminders.tsx
+++ b/src/pages/settings/templates-and-reminders/TemplatesAndReminders.tsx
@@ -363,6 +363,8 @@ export function TemplatesAndReminders() {
               !isCompanySettingsActive && setTemplateBody(undefined);
             }}
             cypressRef="templateSelector"
+            customSelector
+            dismissable={false}
           >
             {statics &&
               Object.keys(statics.templates).map((template, index) => (
@@ -371,7 +373,10 @@ export function TemplatesAndReminders() {
                 </option>
               ))}
 
-            <option value="payment_failed">{t('payment_failed')}</option>
+            <option value="credit">{t('credit')}</option>
+            <option value="purchase_order">{t('purchase_order')}</option>
+
+            <option value="partial_payment">{t('partial_payment')}</option>
 
             <option value="custom1">{t('first_custom')}</option>
             <option value="custom2">{t('second_custom')}</option>


### PR DESCRIPTION
@beganovich @turbo124 The PR adds missing templates to the dropdown: "Partial Payment", "Credit", and "Purchase Order". 

Closes #2195 

Let me know your thoughts.