### PR TITLE
[Feature] Implementing Backup Section On E-Invoice Tab | Invoice Edit Page

### DIFF
--- a/src/common/interfaces/invoice.ts
+++ b/src/common/interfaces/invoice.ts
@@ -84,7 +84,11 @@ export interface Invoice {
   reminder_schedule?: string;
   e_invoice?: EInvoiceType;
   is_locked?: boolean;
-  backup?: string;
+  backup?: Backup;
+}
+
+export interface Backup {
+  guid?: string;
 }
 
 export interface Activity {

--- a/src/common/interfaces/invoice.ts
+++ b/src/common/interfaces/invoice.ts
@@ -84,6 +84,7 @@ export interface Invoice {
   reminder_schedule?: string;
   e_invoice?: EInvoiceType;
   is_locked?: boolean;
+  backup?: string;
 }
 
 export interface Activity {

--- a/src/pages/invoices/edit/components/EInvoice.tsx
+++ b/src/pages/invoices/edit/components/EInvoice.tsx
@@ -236,30 +236,24 @@ export default function EInvoice() {
                 borderColor: colors.$5,
               }}
             >
-              {!invoice?.backup && (
+              {invoice?.backup?.guid && (
                 <div className="whitespace-nowrap font-medium w-24">
                   {t('reference')}:
                 </div>
               )}
 
-              {JSON.parse(invoice?.backup ?? '{}')?.guid ? (
+              {invoice?.backup?.guid ? (
                 <div className="flex flex-col space-y-2.5">
-                  {Object.entries(JSON.parse(invoice?.backup ?? '{}')).map(
-                    ([key, value], index) => (
-                      <div key={index} className="flex items-center space-x-4">
-                        <span className="font-medium">{t(key)}:</span>
-
-                        <span>{value as string}</span>
-                      </div>
-                    )
-                  )}
+                  <div className="flex items-center space-x-4">
+                    <span className="font-medium"></span>
+                    <span>{invoice?.backup?.guid}</span>
+                  </div>
 
                   {activities?.find(
                     (activity) => activity.activity_type_id === 147
                   ) && (
                     <div className="flex items-center space-x-4">
                       <span className="font-medium">{t('error')}:</span>
-
                       <div>{getActivityText()}</div>
                     </div>
                   )}

--- a/src/pages/invoices/edit/components/EInvoice.tsx
+++ b/src/pages/invoices/edit/components/EInvoice.tsx
@@ -89,15 +89,15 @@ export default function EInvoice() {
 
   const [isFormBusy, setIsFormBusy] = useState<boolean>(false);
 
-  const handleRetry = () => {
+  const handleSend = () => {
     if (!isFormBusy) {
       toast.processing();
       setIsFormBusy(true);
 
-      request(
-        'PUT',
-        endpoint('/api/v1/invoices/:id/retry_e_send', { id: invoice?.id })
-      )
+      request('POST', endpoint('/api/v1/einvoice/peppol/send'), {
+        entity: 'invoice',
+        entity_id: invoice?.id,
+      })
         .then(() => {
           $refetch(['invoices']);
           toast.success('success');
@@ -228,7 +228,7 @@ export default function EInvoice() {
       </Card>
 
       {Boolean(invoice?.status_id === InvoiceStatus.Sent) && (
-        <Card title={t('backup')}>
+        <Card title={t('status')}>
           <div className="flex px-6 text-sm">
             <div
               className="flex items-center space-x-4 border-l-2 pl-4 py-4"
@@ -238,13 +238,13 @@ export default function EInvoice() {
             >
               {!invoice?.backup && (
                 <div className="whitespace-nowrap font-medium w-24">
-                  {t('backup')}:
+                  {t('reference')}:
                 </div>
               )}
 
-              {invoice?.backup ? (
+              {JSON.parse(invoice?.backup ?? '{}')?.guid ? (
                 <div className="flex flex-col space-y-2.5">
-                  {Object.entries(JSON.parse(invoice.backup)).map(
+                  {Object.entries(JSON.parse(invoice?.backup ?? '{}')).map(
                     ([key, value], index) => (
                       <div key={index} className="flex items-center space-x-4">
                         <span className="font-medium">{t(key)}:</span>
@@ -267,11 +267,11 @@ export default function EInvoice() {
               ) : (
                 <Button
                   behavior="button"
-                  onClick={handleRetry}
+                  onClick={handleSend}
                   disabled={isFormBusy}
                   disableWithoutIcon
                 >
-                  {t('retry')}
+                  {t('send')}
                 </Button>
               )}
             </div>

--- a/src/pages/invoices/edit/components/EInvoice.tsx
+++ b/src/pages/invoices/edit/components/EInvoice.tsx
@@ -84,7 +84,9 @@ export default function EInvoice() {
     enabled:
       invoice !== null &&
       location.pathname.includes('e_invoice') &&
-      Boolean(invoice?.status_id === InvoiceStatus.Sent && invoice?.backup),
+      Boolean(
+        invoice?.status_id === InvoiceStatus.Sent && invoice?.backup?.guid
+      ),
     staleTime: Infinity,
   });
 

--- a/src/pages/invoices/edit/components/EInvoice.tsx
+++ b/src/pages/invoices/edit/components/EInvoice.tsx
@@ -55,6 +55,7 @@ export interface Context {
 }
 
 const VALIDATION_ENTITIES = ['invoice', 'client', 'company'];
+const EINVOICE_ACTIVITY_TYPES = [145, 146, 147] as number[];
 
 export default function EInvoice() {
   const [t] = useTranslation();
@@ -106,9 +107,8 @@ export default function EInvoice() {
     }
   };
 
-  const getActivityText = () => {
-    let text = trans('activity_147', {}) as unknown as ReactNode[];
-
+  const getActivityText = (activity: InvoiceActivity) => {
+    let text = trans(`activity_${activity.activity_type_id}`, {}) as unknown as ReactNode[];
     const invoiceElement = (
       <Link to={route('/invoices/:id/edit', { id: invoice?.id })}>
         {invoice?.number}
@@ -242,32 +242,32 @@ export default function EInvoice() {
                 </div>
               )}
 
-              {invoice?.backup?.guid ? (
-                <div className="flex flex-col space-y-2.5">
-                  <div className="flex items-center space-x-4">
-                    <span className="font-medium"></span>
-                    <span>{invoice?.backup?.guid}</span>
-                  </div>
-
-                  {activities?.find(
-                    (activity) => activity.activity_type_id === 147
-                  ) && (
-                    <div className="flex items-center space-x-4">
-                      <span className="font-medium">{t('error')}:</span>
-                      <div>{getActivityText()}</div>
-                    </div>
-                  )}
+            {invoice?.backup?.guid ? (
+              <div className="flex flex-col space-y-2.5">
+                <div className="flex items-center space-x-4">
+                  <span className="font-medium"></span>
+                  <span>{invoice?.backup?.guid}</span>
                 </div>
-              ) : (
-                <Button
-                  behavior="button"
-                  onClick={handleSend}
-                  disabled={isFormBusy}
-                  disableWithoutIcon
-                >
-                  {t('send')}
-                </Button>
-              )}
+
+                {activities?.filter((activity) => {
+                  return EINVOICE_ACTIVITY_TYPES.includes(activity.activity_type_id)
+                  }).map((activity) => (
+                  <div key={activity.id} className="flex items-center space-x-4">
+                    <span className="font-medium">{t('message')}:</span>
+                    <div>{getActivityText(activity)}</div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <Button
+                behavior="button"
+                onClick={handleSend}
+                disabled={isFormBusy}
+                disableWithoutIcon
+              >
+                {t('send')}
+              </Button>
+            )}
             </div>
           </div>
         </Card>

--- a/src/pages/invoices/edit/components/EInvoice.tsx
+++ b/src/pages/invoices/edit/components/EInvoice.tsx
@@ -107,8 +107,11 @@ export default function EInvoice() {
     }
   };
 
-  const getActivityText = (activity: InvoiceActivity) => {
-    let text = trans(`activity_${activity.activity_type_id}`, {}) as unknown as ReactNode[];
+  const getActivityText = (activityTypeId: number) => {
+    let text = trans(
+      `activity_${activityTypeId}`,
+      {}
+    ) as unknown as ReactNode[];
     const invoiceElement = (
       <Link to={route('/invoices/:id/edit', { id: invoice?.id })}>
         {invoice?.number}
@@ -237,37 +240,41 @@ export default function EInvoice() {
               }}
             >
               {invoice?.backup?.guid && (
-                <div className="whitespace-nowrap font-medium w-24">
+                <span className="whitespace-nowrap font-medium">
                   {t('reference')}:
-                </div>
+                </span>
               )}
 
-            {invoice?.backup?.guid ? (
-              <div className="flex flex-col space-y-2.5">
-                <div className="flex items-center space-x-4">
-                  <span className="font-medium"></span>
+              {invoice?.backup?.guid ? (
+                <div className="flex flex-col space-y-2.5">
                   <span>{invoice?.backup?.guid}</span>
-                </div>
 
-                {activities?.filter((activity) => {
-                  return EINVOICE_ACTIVITY_TYPES.includes(activity.activity_type_id)
-                  }).map((activity) => (
-                  <div key={activity.id} className="flex items-center space-x-4">
-                    <span className="font-medium">{t('message')}:</span>
-                    <div>{getActivityText(activity)}</div>
-                  </div>
-                ))}
-              </div>
-            ) : (
-              <Button
-                behavior="button"
-                onClick={handleSend}
-                disabled={isFormBusy}
-                disableWithoutIcon
-              >
-                {t('send')}
-              </Button>
-            )}
+                  {activities
+                    ?.filter((activity) =>
+                      EINVOICE_ACTIVITY_TYPES.includes(
+                        activity.activity_type_id
+                      )
+                    )
+                    .map((activity) => (
+                      <div
+                        key={activity.id}
+                        className="flex items-center space-x-4"
+                      >
+                        <span className="font-medium">{t('message')}:</span>
+                        <div>{getActivityText(activity.activity_type_id)}</div>
+                      </div>
+                    ))}
+                </div>
+              ) : (
+                <Button
+                  behavior="button"
+                  onClick={handleSend}
+                  disabled={isFormBusy}
+                  disableWithoutIcon
+                >
+                  {t('send')}
+                </Button>
+              )}
             </div>
           </div>
         </Card>

--- a/src/pages/invoices/edit/components/EInvoice.tsx
+++ b/src/pages/invoices/edit/components/EInvoice.tsx
@@ -39,6 +39,7 @@ import { GenericManyResponse } from '$app/common/interfaces/generic-many-respons
 import { InvoiceActivity } from '$app/common/interfaces/invoice-activity';
 import { useQuery } from 'react-query';
 import reactStringReplace from 'react-string-replace';
+import { useColorScheme } from '$app/common/colors';
 
 export interface Context {
   invoice: Invoice | undefined;
@@ -59,6 +60,7 @@ export default function EInvoice() {
   const [t] = useTranslation();
 
   const location = useLocation();
+  const colors = useColorScheme();
 
   const context: Context = useOutletContext();
 
@@ -228,22 +230,39 @@ export default function EInvoice() {
       {Boolean(invoice?.status_id === InvoiceStatus.Sent) && (
         <Card title={t('backup')}>
           <div className="flex px-6 text-sm">
-            <div className="flex items-center space-x-4 border-l-2 border-gray-500 pl-4 py-4">
-              <div className="whitespace-nowrap font-medium w-24">
-                {t(invoice?.backup ? 'guide' : 'backup')}:
-              </div>
+            <div
+              className="flex items-center space-x-4 border-l-2 pl-4 py-4"
+              style={{
+                borderColor: colors.$5,
+              }}
+            >
+              {!invoice?.backup && (
+                <div className="whitespace-nowrap font-medium w-24">
+                  {t('backup')}:
+                </div>
+              )}
 
               {invoice?.backup ? (
                 <div className="flex flex-col space-y-2.5">
-                  {Object.values(JSON.parse(invoice.backup)).map(
-                    (errorMessage, index) => (
-                      <span key={index}>{errorMessage as string}</span>
+                  {Object.entries(JSON.parse(invoice.backup)).map(
+                    ([key, value], index) => (
+                      <div key={index} className="flex items-center space-x-4">
+                        <span className="font-medium">{t(key)}:</span>
+
+                        <span>{value as string}</span>
+                      </div>
                     )
                   )}
 
                   {activities?.find(
                     (activity) => activity.activity_type_id === 147
-                  ) && <div>{getActivityText()}</div>}
+                  ) && (
+                    <div className="flex items-center space-x-4">
+                      <span className="font-medium">{t('error')}:</span>
+
+                      <div>{getActivityText()}</div>
+                    </div>
+                  )}
                 </div>
               ) : (
                 <Button


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of a "Backup" card on the "E-Invoice" tab. Screenshots:

<img width="1262" alt="Screenshot 2024-11-26 at 11 18 48" src="https://github.com/user-attachments/assets/b9701c64-ae0f-4688-8245-3605982f3373">

<img width="1261" alt="Screenshot 2024-11-26 at 11 37 40" src="https://github.com/user-attachments/assets/4f479eb6-5334-427d-93e4-392a0d63b81f">

`Note`: We are missing the "guid" and "retry" translation keywords, so please add them to the files if you agree.

Let me know your thoughts.