### PR TITLE
[Cleanup] Formatting next_send_datetime Property By Timezone | Recurring Invoices

### DIFF
--- a/src/common/hooks/useCompanyTimeZone.ts
+++ b/src/common/hooks/useCompanyTimeZone.ts
@@ -11,6 +11,7 @@
 import { useStaticsQuery } from '$app/common/queries/statics';
 import { useEffect, useState } from 'react';
 import { useCurrentCompany } from './useCurrentCompany';
+import { Timezone } from '../interfaces/statics';
 
 export function useCompanyTimeZone() {
   const company = useCurrentCompany();
@@ -23,7 +24,8 @@ export function useCompanyTimeZone() {
   useEffect(() => {
     if (statics?.timezones) {
       const result = statics.timezones.find(
-        (format: any) => format.id === company?.settings?.timezone_id ?? '1'
+        (currentTimezone: Timezone) =>
+          currentTimezone.id === company?.settings?.timezone_id ?? '1'
       );
 
       if (result) {

--- a/src/common/hooks/useDateTime.ts
+++ b/src/common/hooks/useDateTime.ts
@@ -21,10 +21,15 @@ dayjs.extend(timezone);
 interface Params {
   formatOnlyTime?: boolean;
   withTimezone?: boolean;
+  formatOnlyDate?: boolean;
 }
 
 export function useDateTime(params?: Params) {
-  const { formatOnlyTime = false, withTimezone = false } = params || {};
+  const {
+    formatOnlyTime = false,
+    withTimezone = false,
+    formatOnlyDate = false,
+  } = params || {};
 
   const { timeZone: companyTimeZone } = useCompanyTimeZone();
   const { timeFormat: companyTimeFormat } = useCompanyTimeFormat();
@@ -40,16 +45,16 @@ export function useDateTime(params?: Params) {
       return '';
     }
 
-    const finalFormat = `${dateFormat || companyDateFormat} ${
+    let finalFormat = `${dateFormat || companyDateFormat} ${
       timeFormat || companyTimeFormat
     }`;
 
-    if (formatOnlyTime && typeof date === 'number') {
-      return dayjs.unix(date).format(timeFormat || companyTimeFormat);
+    if (formatOnlyDate) {
+      finalFormat = dateFormat || companyDateFormat;
     }
 
-    if (formatOnlyTime && typeof date !== 'number') {
-      return dayjs(date).format(timeFormat || companyTimeFormat);
+    if (formatOnlyTime) {
+      finalFormat = timeFormat || companyTimeFormat;
     }
 
     if (typeof date === 'number' && !withTimezone) {

--- a/src/common/hooks/useGetTimezone.ts
+++ b/src/common/hooks/useGetTimezone.ts
@@ -1,0 +1,35 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { useStaticsQuery } from '../queries/statics';
+
+export function useGetTimezone() {
+  const { data: statics } = useStaticsQuery();
+
+  return (timeZoneId: string | undefined) => {
+    if (statics?.timezones && timeZoneId) {
+      const result = statics.timezones.find(
+        (format: any) => format.id === timeZoneId
+      );
+
+      if (result) {
+        return {
+          timeZoneId: result.id,
+          timeZone: result.name,
+        };
+      }
+    }
+
+    return {
+      timeZoneId: '1',
+      timeZone: 'America/Tijuana',
+    };
+  };
+}

--- a/src/common/hooks/useGetTimezone.ts
+++ b/src/common/hooks/useGetTimezone.ts
@@ -8,6 +8,7 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
+import { Timezone } from '../interfaces/statics';
 import { useStaticsQuery } from '../queries/statics';
 
 export function useGetTimezone() {
@@ -16,7 +17,7 @@ export function useGetTimezone() {
   return (timeZoneId: string | undefined) => {
     if (statics?.timezones && timeZoneId) {
       const result = statics.timezones.find(
-        (format: any) => format.id === timeZoneId
+        (currentTimezone: Timezone) => currentTimezone.id === timeZoneId
       );
 
       if (result) {
@@ -28,8 +29,8 @@ export function useGetTimezone() {
     }
 
     return {
-      timeZoneId: '1',
-      timeZone: 'America/Tijuana',
+      timeZoneId: '32',
+      timeZone: 'Europe/Lisbon',
     };
   };
 }

--- a/src/pages/dashboard/components/UpcomingRecurringInvoices.tsx
+++ b/src/pages/dashboard/components/UpcomingRecurringInvoices.tsx
@@ -18,12 +18,17 @@ import { DynamicLink } from '$app/components/DynamicLink';
 import { RecurringInvoice } from '$app/common/interfaces/recurring-invoice';
 import { useDateTime } from '$app/common/hooks/useDateTime';
 import { useTranslation } from 'react-i18next';
+import { useGetSetting } from '$app/common/hooks/useGetSetting';
+import { useGetTimezone } from '$app/common/hooks/useGetTimezone';
 
 export function UpcomingRecurringInvoices() {
   const [t] = useTranslation();
-  const dateTime = useDateTime();
+
+  const getSetting = useGetSetting();
   const formatMoney = useFormatMoney();
+  const getTimezone = useGetTimezone();
   const disableNavigation = useDisableNavigation();
+  const dateTime = useDateTime({ withTimezone: true });
 
   const columns: DataTableColumns<RecurringInvoice> = [
     {
@@ -60,7 +65,14 @@ export function UpcomingRecurringInvoices() {
     {
       id: 'next_send_datetime',
       label: t('next_send_date'),
-      format: (value) => dateTime(value),
+      format: (value, recurringInvoice) =>
+        dateTime(
+          value,
+          '',
+          '',
+          getTimezone(getSetting(recurringInvoice.client, 'timezone_id'))
+            .timeZone
+        ),
     },
     {
       id: 'balance',

--- a/src/pages/recurring-invoices/common/components/RecurringInvoiceSlider.tsx
+++ b/src/pages/recurring-invoices/common/components/RecurringInvoiceSlider.tsx
@@ -52,6 +52,8 @@ import { AddActivityComment } from '$app/pages/dashboard/hooks/useGenerateActivi
 import { useState } from 'react';
 import { useColorScheme } from '$app/common/colors';
 import { useCompanyTimeFormat } from '$app/common/hooks/useCompanyTimeFormat';
+import { useGetSetting } from '$app/common/hooks/useGetSetting';
+import { useGetTimezone } from '$app/common/hooks/useGetTimezone';
 
 export const recurringInvoiceSliderAtom = atom<RecurringInvoice | null>(null);
 export const recurringInvoiceSliderVisibilityAtom = atom(false);
@@ -117,11 +119,13 @@ export const RecurringInvoiceSlider = () => {
 
   const colors = useColorScheme();
 
-  const dateTime = useDateTime();
+  const getSetting = useGetSetting();
+  const getTimezone = useGetTimezone();
   const hasPermission = useHasPermission();
   const entityAssigned = useEntityAssigned();
   const disableNavigation = useDisableNavigation();
   const activityElement = useGenerateActivityElement();
+  const dateTime = useDateTime({ withTimezone: true });
 
   const formatMoney = useFormatMoney();
   const actions = useActions({
@@ -217,7 +221,14 @@ export const RecurringInvoiceSlider = () => {
             {recurringInvoice && recurringInvoice.next_send_date ? (
               <Element leftSide={t('next_send_date')}>
                 {recurringInvoice
-                  ? dateTime(recurringInvoice.next_send_datetime)
+                  ? dateTime(
+                      recurringInvoice.next_send_datetime,
+                      '',
+                      '',
+                      getTimezone(
+                        getSetting(recurringInvoice.client, 'timezone_id')
+                      ).timeZone
+                    )
                   : null}
               </Element>
             ) : null}

--- a/src/pages/recurring-invoices/common/hooks.tsx
+++ b/src/pages/recurring-invoices/common/hooks.tsx
@@ -82,6 +82,8 @@ import {
 import { useFormatNumber } from '$app/common/hooks/useFormatNumber';
 import classNames from 'classnames';
 import { AddActivityComment } from '$app/pages/dashboard/hooks/useGenerateActivityElement';
+import { useGetSetting } from '$app/common/hooks/useGetSetting';
+import { useGetTimezone } from '$app/common/hooks/useGetTimezone';
 
 interface RecurringInvoiceUtilitiesProps {
   client?: Client;
@@ -533,9 +535,11 @@ export function useRecurringInvoiceColumns() {
 
   const { dateFormat } = useCurrentCompanyDateFormats();
 
-  const dateTime = useDateTime();
+  const getSetting = useGetSetting();
+  const getTimezone = useGetTimezone();
   const formatNumber = useFormatNumber();
   const disableNavigation = useDisableNavigation();
+  const dateTime = useDateTime({ withTimezone: true });
 
   const recurringInvoiceColumns = useAllRecurringInvoiceColumns();
   type RecurringInvoiceColumns = (typeof recurringInvoiceColumns)[number];
@@ -610,7 +614,14 @@ export function useRecurringInvoiceColumns() {
       column: 'next_send_date',
       id: 'next_send_datetime',
       label: t('next_send_date'),
-      format: (value) => dateTime(value),
+      format: (value, recurringInvoice) =>
+        dateTime(
+          value,
+          '',
+          '',
+          getTimezone(getSetting(recurringInvoice.client, 'timezone_id'))
+            .timeZone
+        ),
     },
     {
       column: 'frequency',


### PR DESCRIPTION
@beganovich @turbo124 The PR includes formatting the `next_send_datetime` property for Recurring Invoices in three locations (all that I found):

- Dashboard Recurring Invoices table
- Recurring Invoices slider
- Recurring Invoices main table

Let me know your thoughts.