### PR TITLE
[Bugfix] Implementing "Eye Icon Functionality" For Unsecure Context

### DIFF
--- a/src/components/CopyToClipboard.tsx
+++ b/src/components/CopyToClipboard.tsx
@@ -9,8 +9,10 @@
  */
 
 import { toast } from '$app/common/helpers/toast/toast';
-import { MouseEvent } from 'react';
+import { MouseEvent, useState } from 'react';
 import { MdOutlineContentCopy } from 'react-icons/md';
+import { AiFillEyeInvisible } from 'react-icons/ai';
+import { AiFillEye } from 'react-icons/ai';
 
 interface Props {
   text: string;
@@ -21,6 +23,8 @@ interface Props {
 export function CopyToClipboard(props: Props) {
   const value = props.text || '';
 
+  const [isSecureVisible, setIsSecureVisible] = useState<boolean>(false);
+
   const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
 
@@ -29,13 +33,37 @@ export function CopyToClipboard(props: Props) {
   };
 
   return (
-    <div className={`inline-flex space-x-2 ${props.className}`}>
-      <span>{props.secure ? props.text.split('').map(() => '*') : value}</span>
+    <div className={`inline-flex items-center space-x-2 ${props.className}`}>
+      <span>
+        {props.secure && !isSecureVisible
+          ? props.text.split('').map(() => '*')
+          : value}
+      </span>
 
-      {value.length > 0 && navigator.clipboard && window.isSecureContext && (
+      {value.length > 0 && navigator.clipboard && !window.isSecureContext ? (
         <button type="button" onClick={handleClick}>
           <MdOutlineContentCopy size={18} />
         </button>
+      ) : (
+        <>
+          {props.secure && (
+            <div className="inline-flex items-center cursor-pointer">
+              {isSecureVisible ? (
+                <AiFillEye
+                  className="text-gray-400"
+                  fontSize={19}
+                  onClick={() => setIsSecureVisible(false)}
+                />
+              ) : (
+                <AiFillEyeInvisible
+                  className="text-gray-400"
+                  fontSize={19}
+                  onClick={() => setIsSecureVisible(true)}
+                />
+              )}
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/components/CopyToClipboard.tsx
+++ b/src/components/CopyToClipboard.tsx
@@ -13,6 +13,7 @@ import { MouseEvent, useState } from 'react';
 import { MdOutlineContentCopy } from 'react-icons/md';
 import { AiFillEyeInvisible } from 'react-icons/ai';
 import { AiFillEye } from 'react-icons/ai';
+import { Icon } from './icons/Icon';
 
 interface Props {
   text: string;
@@ -49,15 +50,13 @@ export function CopyToClipboard(props: Props) {
           {props.secure && (
             <div className="inline-flex items-center cursor-pointer">
               {isSecureVisible ? (
-                <AiFillEye
-                  className="text-gray-400"
-                  fontSize={19}
+                <Icon
+                  element={AiFillEye}
                   onClick={() => setIsSecureVisible(false)}
                 />
               ) : (
-                <AiFillEyeInvisible
-                  className="text-gray-400"
-                  fontSize={19}
+                <Icon
+                  element={AiFillEyeInvisible}
                   onClick={() => setIsSecureVisible(true)}
                 />
               )}

--- a/src/components/CopyToClipboard.tsx
+++ b/src/components/CopyToClipboard.tsx
@@ -41,7 +41,7 @@ export function CopyToClipboard(props: Props) {
           : value}
       </span>
 
-      {value.length > 0 && navigator.clipboard && !window.isSecureContext ? (
+      {value.length > 0 && navigator.clipboard && window.isSecureContext ? (
         <button type="button" onClick={handleClick}>
           <MdOutlineContentCopy size={18} />
         </button>

--- a/src/components/CopyToClipboard.tsx
+++ b/src/components/CopyToClipboard.tsx
@@ -48,17 +48,17 @@ export function CopyToClipboard(props: Props) {
       ) : (
         <>
           {Boolean(props.secure) && (
-            <div className="inline-flex items-center cursor-pointer">
+            <div
+              className="inline-flex items-center cursor-pointer"
+              onClick={(event) => {
+                event.stopPropagation();
+                setIsSecureVisible((current) => !current);
+              }}
+            >
               {isSecureVisible ? (
-                <Icon
-                  element={AiFillEye}
-                  onClick={() => setIsSecureVisible(false)}
-                />
+                <Icon element={AiFillEye} />
               ) : (
-                <Icon
-                  element={AiFillEyeInvisible}
-                  onClick={() => setIsSecureVisible(true)}
-                />
+                <Icon element={AiFillEyeInvisible} />
               )}
             </div>
           )}

--- a/src/components/CopyToClipboard.tsx
+++ b/src/components/CopyToClipboard.tsx
@@ -47,7 +47,7 @@ export function CopyToClipboard(props: Props) {
         </button>
       ) : (
         <>
-          {props.secure && (
+          {Boolean(props.secure) && (
             <div className="inline-flex items-center cursor-pointer">
               {isSecureVisible ? (
                 <Icon


### PR DESCRIPTION
@beganovich @turbo124 The PR adds "Eye Icon Functionality" for unsecure context if the values should be secure to allow users to view hidden values. Screenshots:

<img width="806" alt="Screenshot 2024-11-29 at 13 01 54" src="https://github.com/user-attachments/assets/419dd49d-85d4-4463-8e38-9b313dd7636e">

<img width="811" alt="Screenshot 2024-11-29 at 13 02 01" src="https://github.com/user-attachments/assets/9c29db53-e195-4e55-9294-79038dbc6c19">

Closes #2236 

Let me know your thoughts.