### PR TITLE
[Cleanup] Additional Check When Disabling Validation Entity Query

### DIFF
--- a/src/pages/invoices/Invoice.tsx
+++ b/src/pages/invoices/Invoice.tsx
@@ -72,10 +72,9 @@ export default function Invoice() {
   const { validationResponse } = useCheckEInvoiceValidation({
     resource: invoice,
     enableQuery:
-      Boolean(
-        company?.settings.e_invoice_type === 'PEPPOL' &&
-          company?.settings.enable_e_invoice
-      ) &&
+      company?.settings.e_invoice_type === 'PEPPOL' &&
+      company?.settings.enable_e_invoice &&
+      company?.tax_data?.acts_as_sender &&
       triggerValidationQuery &&
       id === invoice?.id,
     onFinished: () => {


### PR DESCRIPTION
@beganovich @turbo124 The PR adds an additional check when disabling the validation entity query. Since we added a check for enabling the E-Invoice tab if `company.tax_data.acts_as_sender `is turned on, it doesn't make sense to trigger the validation query if the tab is not visible. Therefore, we are adding the same check for triggering the query as we use for hiding/displaying the E-Invoice tab. Let me know your thoughts.