### PR TITLE
[Cleanup] Updating Payload For Designs Default Endpoint

### DIFF
--- a/src/pages/settings/invoice-design/InvoiceDesign.tsx
+++ b/src/pages/settings/invoice-design/InvoiceDesign.tsx
@@ -102,7 +102,9 @@ export default function InvoiceDesign() {
         request('POST', endpoint('/api/v1/designs/set/default'), {
           design_id,
           entity,
-          settings_level: activeSettings.level,
+          settings_level: isGroupSettingsActive
+            ? 'group_settings'
+            : activeSettings.level,
           ...(isClientSettingsActive && { client_id: company?.settings?.id }),
           ...(isGroupSettingsActive && {
             group_settings_id: activeSettingsValue?.id,

--- a/src/pages/settings/invoice-design/InvoiceDesign.tsx
+++ b/src/pages/settings/invoice-design/InvoiceDesign.tsx
@@ -30,6 +30,7 @@ import { route } from '$app/common/helpers/route';
 import { Page } from '$app/components/Breadcrumbs';
 import { useActiveSettingsDetails } from '$app/common/hooks/useActiveSettingsDetails';
 import { useCurrentSettingsLevel } from '$app/common/hooks/useCurrentSettingsLevel';
+import { activeSettingsAtom } from '$app/common/atoms/settings';
 
 export interface GeneralSettingsPayload {
   client_id: string;
@@ -52,6 +53,8 @@ export default function InvoiceDesign() {
     useCurrentSettingsLevel();
   const displaySaveButtonAndPreview =
     !location.pathname.includes('custom_designs');
+
+  const activeSettingsValue = useAtomValue(activeSettingsAtom);
 
   const onSave = useHandleCompanySave();
 
@@ -100,8 +103,10 @@ export default function InvoiceDesign() {
           design_id,
           entity,
           settings_level: activeSettings.level,
-          ...(isClientSettingsActive && { client_id: company?.id }),
-          ...(isGroupSettingsActive && { group_settings_id: company?.id }),
+          ...(isClientSettingsActive && { client_id: company?.settings?.id }),
+          ...(isGroupSettingsActive && {
+            group_settings_id: activeSettingsValue?.id,
+          }),
         })
       );
     });

--- a/src/pages/settings/invoice-design/InvoiceDesign.tsx
+++ b/src/pages/settings/invoice-design/InvoiceDesign.tsx
@@ -28,6 +28,8 @@ import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { route } from '$app/common/helpers/route';
 import { Page } from '$app/components/Breadcrumbs';
+import { useActiveSettingsDetails } from '$app/common/hooks/useActiveSettingsDetails';
+import { useCurrentSettingsLevel } from '$app/common/hooks/useCurrentSettingsLevel';
 
 export interface GeneralSettingsPayload {
   client_id: string;
@@ -45,6 +47,9 @@ export default function InvoiceDesign() {
   const tabs = useTabs();
   const location = useLocation();
   const company = useCompanyChanges();
+  const activeSettings = useActiveSettingsDetails();
+  const { isClientSettingsActive, isGroupSettingsActive } =
+    useCurrentSettingsLevel();
   const displaySaveButtonAndPreview =
     !location.pathname.includes('custom_designs');
 
@@ -94,6 +99,9 @@ export default function InvoiceDesign() {
         request('POST', endpoint('/api/v1/designs/set/default'), {
           design_id,
           entity,
+          settings_level: activeSettings.level,
+          ...(isClientSettingsActive && { client_id: company?.id }),
+          ...(isGroupSettingsActive && { group_settings_id: company?.id }),
         })
       );
     });


### PR DESCRIPTION
@beganovich @turbo124 The PR includes updating the payload for the `/api/v1/designs/set/default` endpoint by adding `settings_level` and `client_id/group_settings_id` properties. Let me know your thoughts.