### PR TITLE
[Bugfix] Missing Mapping Of Custom Fields When Converting Or Adding To Invoice

### DIFF
--- a/src/pages/expenses/common/components/AddToInvoiceAction.tsx
+++ b/src/pages/expenses/common/components/AddToInvoiceAction.tsx
@@ -113,6 +113,10 @@ export function AddToInvoiceAction(props: Props) {
                 expense.tax_amount3,
                 expense.tax_rate3
               ),
+              custom_value1: expense.custom_value1,
+              custom_value2: expense.custom_value2,
+              custom_value3: expense.custom_value3,
+              custom_value4: expense.custom_value4,
             })),
           ],
         }

--- a/src/pages/expenses/common/useInvoiceExpense.ts
+++ b/src/pages/expenses/common/useInvoiceExpense.ts
@@ -92,6 +92,10 @@ export function useInvoiceExpense(params?: Params) {
           expense.tax_amount3,
           expense.tax_rate3
         ),
+        custom_value1: expense.custom_value1,
+        custom_value2: expense.custom_value2,
+        custom_value3: expense.custom_value3,
+        custom_value4: expense.custom_value4,
       }));
 
       if (!onlyAddToInvoice) {

--- a/src/pages/projects/common/hooks/useInvoiceProject.tsx
+++ b/src/pages/projects/common/hooks/useInvoiceProject.tsx
@@ -202,6 +202,10 @@ export function useInvoiceProject() {
           ),
           task_id: task.id,
           tax_id: '',
+          custom_value1: task.custom_value1,
+          custom_value2: task.custom_value2,
+          custom_value3: task.custom_value3,
+          custom_value4: task.custom_value4,
         };
 
         const projectName = task?.project?.name


### PR DESCRIPTION
@beganovich @turbo124 The PR adds missing mappings of custom fields when converting or adding different entities to an invoice. The fixed cases include: adding an expense to an invoice, invoicing an expense, and invoicing a project. 

Closes #2246 

Let me know your thoughts.