### PR TITLE
[Cleanup] Changing Translation Keyword For Counting Tasks

### DIFF
--- a/src/pages/projects/show/Show.tsx
+++ b/src/pages/projects/show/Show.tsx
@@ -217,7 +217,7 @@ export default function Show() {
         <div className="col-span-12 md:col-span-6 lg:col-span-3">
           <InfoCard title={t('summary')}>
             <p>
-              {t('tasks')}: {project.tasks?.length}
+              {t('active_tasks')}: {project.tasks?.length}
             </p>
 
             <p>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes changing the "tasks" translation keyword to "active_tasks" on the Project show page. Screenshot:

<img width="361" alt="Screenshot 2024-12-14 at 15 16 14" src="https://github.com/user-attachments/assets/6844145e-2215-46c0-9dd9-74d6aa06b846" />

Let me know your thoughts.