### PR TITLE
[Bugfix] Duplicated "Bank Transfer" Payment Type Option | Wrong Translation

### DIFF
--- a/src/common/constants/payment-type.ts
+++ b/src/common/constants/payment-type.ts
@@ -44,7 +44,7 @@ export default {
   [PaymentType.LASER]: 'payment_type_Laser',
   [PaymentType.MAESTRO]: 'payment_type_Maestro',
   [PaymentType.MASTERCARD]: 'payment_type_MasterCard',
-  [PaymentType.MOLLIE_BANK_TRANSFER]: 'payment_type_Bank Transfer',
+  [PaymentType.MOLLIE_BANK_TRANSFER]: 'payment_type_Mollie Bank Transfer',
   [PaymentType.NOVA]: 'payment_type_Nova',
   [PaymentType.PAYPAL]: 'payment_type_PayPal',
   [PaymentType.PRZELEWY24]: 'przelewy24',


### PR DESCRIPTION
@beganovich @turbo124 The PR includes changes to the translation for the "Bank Transfer" option related to "Mollie". It was not actually a duplication, the second option had an incorrect translation, which I have now fixed. Screenshot:

![Screenshot 2024-12-15 at 18 46 57](https://github.com/user-attachments/assets/19a708ad-d055-4425-8d97-e034fc31b89d)

#2162 

Let me know your thoughts.