### PR TITLE
[Cleanup] Reordering Cards On Gateway Creation Page

### DIFF
--- a/src/pages/settings/gateways/create/Create.tsx
+++ b/src/pages/settings/gateways/create/Create.tsx
@@ -270,6 +270,22 @@ export function Create() {
     }
   }, [companyGateway]);
 
+  useEffect(() => {
+    if (!filteredGateways.length) return;
+
+    const gatewayIndex = filteredGateways.findIndex(
+      (gateway) => gateway.key === 'b9886f9257f0c6ee7c302f1c74475f6c'
+    );
+
+    if (gatewayIndex === -1 || gatewayIndex === 2) return;
+
+    const updatedGateways = [...filteredGateways];
+    const [gateway] = updatedGateways.splice(gatewayIndex, 1);
+    updatedGateways.splice(2, 0, gateway);
+
+    setFilteredGateways(updatedGateways);
+  }, [filteredGateways]);
+
   return (
     <Settings
       title={documentTitle}


### PR DESCRIPTION
@beganovich @turbo124 The PR includes reordering of gateway cards on the gateway creation page. The GoCardless gateway card has been moved to the third position. Screenshot:

<img width="806" alt="Screenshot 2024-12-16 at 10 08 37" src="https://github.com/user-attachments/assets/540b9199-5980-4b68-87ad-958761f4d34e" />

Let me know your thoughts.