### PR TITLE
[Bugfix] Auto-Fill Line Item When Search Term Is Entered In Product Selector

### DIFF
--- a/src/components/forms/Combobox.tsx
+++ b/src/components/forms/Combobox.tsx
@@ -258,6 +258,7 @@ export function Combobox<T = any>({
 
   useClickAway(comboboxRef, () => {
     setIsOpen(false);
+    onInputValueChange?.(inputValue);
 
     if (
       selectedOption &&
@@ -340,7 +341,6 @@ export function Combobox<T = any>({
                 onFocus();
               }
             }}
-            onBlur={() => onInputValueChange?.(inputValue)}
             placeholder={inputOptions.placeholder}
             disabled={readonly}
             defaultValue={


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixing an issue where line items were not auto-filling when a search term was entered into the product selector. The conflict was between the onBlur event on the input field and selecting an option by clicking. Let me know your thoughts.