### PR TITLE
[Cleanup] Purge Client Warning/Confirmation Modal

### DIFF
--- a/src/pages/clients/common/components/PurgeClientAction.tsx
+++ b/src/pages/clients/common/components/PurgeClientAction.tsx
@@ -12,7 +12,7 @@ import { Client } from '$app/common/interfaces/client';
 import { DropdownElement } from '$app/components/dropdown/DropdownElement';
 import { Icon } from '$app/components/icons/Icon';
 import { useTranslation } from 'react-i18next';
-import { MdDeleteForever, MdWarning } from 'react-icons/md';
+import { MdDeleteForever } from 'react-icons/md';
 import { usePurgeClient } from '../hooks/usePurgeClient';
 import { PasswordConfirmation } from '$app/components/PasswordConfirmation';
 import { Dispatch, SetStateAction, useState } from 'react';
@@ -45,13 +45,9 @@ export function PurgeClientAction(props: Props) {
         onClose={setIsWarningModalOpen}
       >
         <div className="flex flex-col space-y-6">
-          <div className="flex items-center space-x-2">
-            <Icon element={MdWarning} size={35} color="orange" />
-
-            <span className="text-center font-medium">
-              {t('purge_client_warning')}
-            </span>
-          </div>
+          <span className="text-left font-medium">
+            {t('purge_client_warning')}
+          </span>
 
           <Button
             onClick={() => {

--- a/src/pages/clients/common/components/PurgeClientAction.tsx
+++ b/src/pages/clients/common/components/PurgeClientAction.tsx
@@ -12,10 +12,12 @@ import { Client } from '$app/common/interfaces/client';
 import { DropdownElement } from '$app/components/dropdown/DropdownElement';
 import { Icon } from '$app/components/icons/Icon';
 import { useTranslation } from 'react-i18next';
-import { MdDeleteForever } from 'react-icons/md';
+import { MdDeleteForever, MdWarning } from 'react-icons/md';
 import { usePurgeClient } from '../hooks/usePurgeClient';
 import { PasswordConfirmation } from '$app/components/PasswordConfirmation';
 import { Dispatch, SetStateAction, useState } from 'react';
+import { Modal } from '$app/components/Modal';
+import { Button } from '$app/components/forms';
 
 interface Props {
   client: Client;
@@ -28,6 +30,7 @@ export function PurgeClientAction(props: Props) {
 
   const [isPasswordConfirmModalOpen, setPasswordConfirmModalOpen] =
     useState<boolean>(false);
+  const [isWarningModalOpen, setIsWarningModalOpen] = useState<boolean>(false);
 
   const handlePurgeClient = usePurgeClient({
     setIsPurgeOrMergeActionCalled,
@@ -36,8 +39,36 @@ export function PurgeClientAction(props: Props) {
 
   return (
     <>
+      <Modal
+        title={t('purge_client')}
+        visible={isWarningModalOpen}
+        onClose={setIsWarningModalOpen}
+      >
+        <div className="flex flex-col space-y-6">
+          <div className="flex items-center space-x-2">
+            <Icon element={MdWarning} size={35} color="orange" />
+
+            <span className="text-center font-medium">
+              {t('purge_client_warning')}
+            </span>
+          </div>
+
+          <Button
+            onClick={() => {
+              setIsWarningModalOpen(false);
+
+              setTimeout(() => {
+                setPasswordConfirmModalOpen(true);
+              }, 310);
+            }}
+          >
+            {t('continue')}
+          </Button>
+        </div>
+      </Modal>
+
       <DropdownElement
-        onClick={() => setPasswordConfirmModalOpen(true)}
+        onClick={() => setIsWarningModalOpen(true)}
         icon={<Icon element={MdDeleteForever} />}
       >
         {t('purge')}


### PR DESCRIPTION
@beganovich @turbo124 The PR adds a warning/confirmation modal when purging a client. Screenshot:

![Screenshot 2025-01-24 at 00 44 06](https://github.com/user-attachments/assets/1a541df7-d264-4cb1-95c4-bb25c46973d1)

`Note`: This is not plain text in the screenshot. I used the `purge_client_warning` translation keyword to get it. Please let me know if I should change it.

Let me know your thoughts.