### PR TITLE
[Bugfix] Non-Persisting Payment Means Setting | E-Invoice

### DIFF
--- a/src/components/e-invoice/PaymentMeans.tsx
+++ b/src/components/e-invoice/PaymentMeans.tsx
@@ -30,8 +30,7 @@ import { AxiosError } from 'axios';
 import { useFormik } from 'formik';
 import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { get } from 'lodash';
-import { updateCompanyUsers } from '$app/common/stores/slices/company-users';
-import { useDispatch } from 'react-redux';
+import { useRefreshCompanyUsers } from '$app/common/hooks/useRefreshCompanyUsers';
 
 type Entity = 'company' | 'invoice' | 'client';
 
@@ -321,7 +320,8 @@ export const PaymentMeans = forwardRef<PaymentMeansFormComponent, Props>(
     const company = useCurrentCompany();
 
     const [t] = useTranslation();
-    const dispatch = useDispatch();
+
+    const refreshCompanyUsers = useRefreshCompanyUsers();
 
     const [errors, setErrors] = useState<ValidationBag | null>(null);
 
@@ -350,9 +350,7 @@ export const PaymentMeans = forwardRef<PaymentMeansFormComponent, Props>(
           .then(() => {
             toast.success('saved_einvoice_details');
 
-            request('POST', endpoint('/api/v1/refresh')).then((data) => {
-              dispatch(updateCompanyUsers(data.data.data));
-            });
+            refreshCompanyUsers();
           })
           .catch((error: AxiosError<ValidationBag>) => {
             if (error.response?.status === 422) {

--- a/src/components/e-invoice/PaymentMeans.tsx
+++ b/src/components/e-invoice/PaymentMeans.tsx
@@ -30,6 +30,8 @@ import { AxiosError } from 'axios';
 import { useFormik } from 'formik';
 import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { get } from 'lodash';
+import { updateCompanyUsers } from '$app/common/stores/slices/company-users';
+import { useDispatch } from 'react-redux';
 
 type Entity = 'company' | 'invoice' | 'client';
 
@@ -319,6 +321,8 @@ export const PaymentMeans = forwardRef<PaymentMeansFormComponent, Props>(
     const company = useCurrentCompany();
 
     const [t] = useTranslation();
+    const dispatch = useDispatch();
+
     const [errors, setErrors] = useState<ValidationBag | null>(null);
 
     const form = useFormik({
@@ -345,6 +349,10 @@ export const PaymentMeans = forwardRef<PaymentMeansFormComponent, Props>(
         request('POST', endpoint('/api/v1/einvoice/configurations'), values)
           .then(() => {
             toast.success('saved_einvoice_details');
+
+            request('POST', endpoint('/api/v1/refresh')).then((data) => {
+              dispatch(updateCompanyUsers(data.data.data));
+            });
           })
           .catch((error: AxiosError<ValidationBag>) => {
             if (error.response?.status === 422) {


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for payment means settings not persisting when successfully saved. This was happening because company_users were not being refreshed after the `/api/v1/einvoice/configurations` endpoint succeeded. It now appears to be fixed on my end. Let me know your thoughts.