### PR TITLE
[Bugfix] Fixed Issue Of Downloading Delivery Note

### DIFF
--- a/src/pages/invoices/common/hooks/useDownloadPdf.ts
+++ b/src/pages/invoices/common/hooks/useDownloadPdf.ts
@@ -25,8 +25,8 @@ export function useDownloadPdf(props: Props) {
   const queryClient = useQueryClient();
   const url = useGeneratePdfUrl({ resourceType: props.resource });
 
-  return (resource: MailerResource) => {
-    const downloadableUrl = url(resource);
+  return (resource: MailerResource, deliveryNote?: boolean) => {
+    const downloadableUrl = url(resource, deliveryNote);
 
     if (downloadableUrl) {
       toast.processing();

--- a/src/pages/invoices/common/hooks/useGeneratePdfUrl.ts
+++ b/src/pages/invoices/common/hooks/useGeneratePdfUrl.ts
@@ -19,9 +19,16 @@ interface Props {
 }
 
 export function useGeneratePdfUrl(props: Props) {
-  return (resource: MailerResource) => {
+  return (resource: MailerResource, deliveryNote?: boolean) => {
     if (resource.invitations.length === 0) {
       return;
+    }
+
+    if (deliveryNote) {
+      return endpoint('/api/v1/:resource/:id/delivery_note', {
+        resource: `${props.resourceType}s`,
+        id: resource.id,
+      });
     }
 
     if (

--- a/src/pages/invoices/pdf/components/Actions.tsx
+++ b/src/pages/invoices/pdf/components/Actions.tsx
@@ -87,7 +87,7 @@ export function Actions(props: Props) {
 
       <Button
         className="flex items-center space-x-1"
-        onClick={() => downloadPdf(invoice)}
+        onClick={() => downloadPdf(invoice, deliveryNote)}
       >
         <Icon element={MdDownload} color="white" />
         <span>{t('download')}</span>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for the invoice PDF page. Previously, when delivery note was turned on, a plain invoice was still being downloaded. The URL has been fixed to generate the correct document type when delivery note is turned on. Let me know your thoughts.