### PR TITLE
[Cleanup] Changing "Email History" Translations

### DIFF
--- a/src/pages/invoices/common/components/InvoiceSlider.tsx
+++ b/src/pages/invoices/common/components/InvoiceSlider.tsx
@@ -534,6 +534,10 @@ export function InvoiceSlider() {
         </div>
 
         <div className="flex flex-col divide-y">
+          {Boolean(!emailRecords.length) && (
+            <span className="text-sm px-4">{t('email_history_empty')}</span>
+          )}
+
           {emailRecords.map((emailRecord, index) => (
             <EmailRecord
               key={index}

--- a/src/pages/invoices/edit/components/EmailHistory.tsx
+++ b/src/pages/invoices/edit/components/EmailHistory.tsx
@@ -62,7 +62,7 @@ export default function EmailHistory() {
       )}
 
       {!isLoading && !emailRecords.length && (
-        <span className="px-6">{t('api_404')}</span>
+        <span className="px-6">{t('email_history_empty')}</span>
       )}
 
       {emailRecords.map((emailRecord, index) => (

--- a/src/pages/purchase-orders/edit/components/EmailHistory.tsx
+++ b/src/pages/purchase-orders/edit/components/EmailHistory.tsx
@@ -18,7 +18,6 @@ import { Spinner } from '$app/components/Spinner';
 import { Card } from '$app/components/cards';
 import { useTranslation } from 'react-i18next';
 import { useEffect, useState } from 'react';
-import { NonClickableElement } from '$app/components/cards/NonClickableElement';
 
 export default function EmailHistory() {
   const [t] = useTranslation();
@@ -63,7 +62,7 @@ export default function EmailHistory() {
       )}
 
       {!isLoading && !emailRecords.length && (
-        <NonClickableElement>{t('api_404')}</NonClickableElement>
+        <span className="px-6">{t('email_history_empty')}</span>
       )}
 
       {emailRecords.map((emailRecord, index) => (

--- a/src/pages/quotes/common/components/QuoteSlider.tsx
+++ b/src/pages/quotes/common/components/QuoteSlider.tsx
@@ -471,6 +471,10 @@ export function QuoteSlider() {
         </div>
 
         <div className="flex flex-col divide-y">
+          {Boolean(!emailRecords.length) && (
+            <span className="px-4 text-sm">{t('email_history_empty')}</span>
+          )}
+
           {emailRecords?.map((emailRecord, index) => (
             <EmailRecord
               key={index}

--- a/src/pages/quotes/edit/components/EmailHistory.tsx
+++ b/src/pages/quotes/edit/components/EmailHistory.tsx
@@ -62,7 +62,7 @@ export default function EmailHistory() {
       )}
 
       {!isLoading && !emailRecords.length && (
-        <span className="px-6">{t('api_404')}</span>
+        <span className="px-6">{t('email_history_empty')}</span>
       )}
 
       {emailRecords.map((emailRecord, index) => (


### PR DESCRIPTION
@beganovich @turbo124 The PR includes changes to empty results translations for email history in Invoices, Quotes, and Purchase Orders. Screenshot:

![Screenshot 2025-02-05 at 18 21 20](https://github.com/user-attachments/assets/8cafeada-840b-41cd-8d4e-4f3c6e53c59c)

Let me know your thoughts.