### PR TITLE
Hot fix for entities with large number of line items

### DIFF
--- a/src/pages/credits/common/hooks.tsx
+++ b/src/pages/credits/common/hooks.tsx
@@ -155,6 +155,9 @@ export function useCreditUtilities(props: CreditUtilitiesProps) {
   ) => {
     const lineItems = credit?.line_items || [];
 
+    if (lineItems[index][key] === value) {
+      return;
+    }
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     lineItems[index][key] = value;

--- a/src/pages/quotes/common/hooks.tsx
+++ b/src/pages/quotes/common/hooks.tsx
@@ -162,6 +162,10 @@ export function useQuoteUtilities(props: QuoteUtilitiesProps) {
   ) => {
     const lineItems = quote?.line_items || [];
 
+    if (lineItems[index][key] === value) {
+      return;
+    }
+    
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     lineItems[index][key] = value;

--- a/src/pages/recurring-invoices/common/hooks.tsx
+++ b/src/pages/recurring-invoices/common/hooks.tsx
@@ -152,6 +152,9 @@ export function useRecurringInvoiceUtilities(
   ) => {
     const lineItems = recurringInvoice?.line_items || [];
 
+    if (lineItems[index][key] === value) {
+      return;
+    }
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     lineItems[index][key] = value;


### PR DESCRIPTION
Implements a fix for hooks on line item updates preventing every line from rerendering inappropriately.

Covers credits, quotes and recurring invoices.

Invoices was already covered.

Purchase Orders uses a different approach with cloneDeep, we will need to assess the best approach and unify the structure of this across all entities.

@beganovich for urgent push to main when reviewed please.