### PR TITLE
[Bugfix] Fixes For Subscriptions Link In "Quick Create" Popover

### DIFF
--- a/src/common/hooks/entities/useQuickCreateActions.ts
+++ b/src/common/hooks/entities/useQuickCreateActions.ts
@@ -107,7 +107,7 @@ export function useQuickCreateActions() {
     },
     {
       key: 'subscription',
-      url: '/settings/subscription/create',
+      url: '/settings/subscriptions/create',
       section: 'income',
       visible: (proPlan() || enterprisePlan()) && (isAdmin || isOwner),
     },


### PR DESCRIPTION
@beganovich @turbo124 The PR fixes the subscription link in the "Quick Create" popover from `/subscription/create` to `/subscriptions/create` to prevent navigation to a non-existent page. Let me now your thoughts.