### PR TITLE
Fixes for upgrade button spacing

### DIFF
--- a/src/components/layouts/Default.tsx
+++ b/src/components/layouts/Default.tsx
@@ -455,7 +455,6 @@ export function Default(props: Props) {
               </h2>
 
               <QuickCreatePopover />
-
               <Search />
             </div>
 
@@ -483,8 +482,12 @@ export function Default(props: Props) {
                 >
                   <div className="absolute inset-x-0 top-0 h-1/2 bg-gradient-to-b from-white/20 to-transparent pointer-events-none"></div>
 
-                  <span className="relative z-10">
+                  <span className="relative z-10 hidden xl:block">
                     {isSelfHosted() ? t('white_label_button') : t('unlock_pro')}
+                  </span>
+
+                  <span className="relative z-10 xl:hidden">
+                    {t('upgrade')}
                   </span>
                 </button>
               )}

--- a/src/pages/dashboard/components/Search.tsx
+++ b/src/pages/dashboard/components/Search.tsx
@@ -33,6 +33,8 @@ import { OppositeArrows } from '$app/components/icons/OppositeArrows';
 import { ReturnKey } from './ReturnKey';
 import { ExternalLink } from '$app/components/icons/ExternalLink';
 import { SearchGroups } from './SearchGroups';
+import { BiSearch } from 'react-icons/bi';
+import { Icon } from '$app/components/icons/Icon';
 
 export function Search$() {
   const [t] = useTranslation();
@@ -287,8 +289,16 @@ export function Search$() {
 
   return (
     <>
+      <button
+        type="button"
+        onClick={() => setIsModalOpen(true)}
+        className="lg:hidden flex justify-end items-end"
+      >
+        <Icon element={BiSearch} size={22} style={{ color: colors.$3 }} />
+      </button>
+
       <div
-        className="flex items-center border rounded-md px-1 py-1 space-x-5"
+        className="hidden lg:flex items-center border rounded-md px-1 py-1 space-x-5"
         onClick={() => setIsModalOpen(true)}
         style={{ borderColor: colors.$5 }}
       >

--- a/src/pages/dashboard/components/Search.tsx
+++ b/src/pages/dashboard/components/Search.tsx
@@ -332,7 +332,11 @@ export function Search$() {
           <div className="flex flex-col pb-3">
             <div className="flex items-center space-x-3">
               <div className="flex items-center space-x-1.5 py-2 px-4 flex-1 border-b">
-                <SearchIcon color={colors.$5} size="1.6rem" />
+                {isFetching ? (
+                  <Spinner />
+                ) : (
+                  <SearchIcon color={colors.$5} size="1.6rem" />
+                )}
 
                 <div className="flex-1">
                   <InputField
@@ -347,8 +351,6 @@ export function Search$() {
                   />
                 </div>
               </div>
-
-              {isFetching && <Spinner />}
             </div>
 
             <div

--- a/src/pages/dashboard/components/Search.tsx
+++ b/src/pages/dashboard/components/Search.tsx
@@ -298,7 +298,7 @@ export function Search$() {
       </button>
 
       <div
-        className="hidden lg:flex items-center border rounded-md px-1 py-1 space-x-5"
+        className="hidden lg:flex items-center border rounded-md p-1.5 space-x-5"
         onClick={() => setIsModalOpen(true)}
         style={{ borderColor: colors.$5 }}
       >

--- a/src/pages/dashboard/components/Search.tsx
+++ b/src/pages/dashboard/components/Search.tsx
@@ -31,6 +31,7 @@ import { LuArrowUpDown, LuCornerDownLeft } from 'react-icons/lu';
 import { useAtomValue } from 'jotai';
 import { useNavigate } from 'react-router-dom';
 import { Spinner } from '$app/components/Spinner';
+import { BiSearch } from 'react-icons/bi';
 
 const Div = styled.div`
   color: ${(props) => props.theme.color};
@@ -214,8 +215,16 @@ export function Search$() {
 
   return (
     <>
+      <button
+        type="button"
+        onClick={() => setIsModalOpen(true)}
+        className="lg:hidden flex justify-end items-end"
+      >
+        <Icon element={BiSearch} size={22} style={{ color: colors.$3 }} />
+      </button>
+
       <InputField
-        className="border-transparent focus:border-transparent focus:ring-0 border-0"
+        className="hidden lg:block border-transparent focus:border-transparent focus:ring-0 border-0"
         onClick={() => setIsModalOpen(true)}
         placeholder={`${t('search_placeholder')}. (Ctrl+K)`}
         style={{ backgroundColor: colors.$1, color: colors.$3, width: '21rem' }}


### PR DESCRIPTION
This fixes a couple of things:
— Search icon instead of input box on smaller devices
— Upgrade instead of “Unlock Pro” / “Purchase White Label” on smaller devices

![image](https://github.com/user-attachments/assets/7ebb6311-752e-4407-aab0-774a5b7ebdbb)
![image](https://github.com/user-attachments/assets/e8c2495e-4a67-4684-b1f9-c3c86ab29d09)
