### PR TITLE
[Cleanup] Adjusting Colors For Dark Mode | Search

### DIFF
--- a/src/common/colors.ts
+++ b/src/common/colors.ts
@@ -46,6 +46,7 @@ export const $1 = {
   $14: '#121212', // Navigation bar background color
   $15: '#323236', // Light gray background
   $16: '#A1A1AA', // Dark gray icon
+  $17: '#9D9DA8', // Placeholder text
 };
 
 export const $2 = {
@@ -67,6 +68,7 @@ export const $2 = {
   $14: '#27272A', // Navigation bar background color
   $15: '#E4E4E7', // Light gray background
   $16: '#717179', // Dark gray icon
+  $17: '#A1A1AA', // Placeholder text
 };
 
 export const colorSchemeAtom = atomWithStorage('colorScheme', $2);

--- a/src/pages/dashboard/components/Search.tsx
+++ b/src/pages/dashboard/components/Search.tsx
@@ -303,9 +303,9 @@ export function Search$() {
         style={{ height: '2.3rem', borderColor: colors.$5 }}
       >
         <div className="flex items-center space-x-1.5 pl-1">
-          <SearchIcon color={colors.$5} />
+          <SearchIcon color={colors.$17} />
 
-          <p className="text-sm" style={{ color: colors.$5 }}>
+          <p className="text-sm" style={{ color: colors.$17 }}>
             {t('search_placeholder')}
           </p>
         </div>
@@ -314,7 +314,7 @@ export function Search$() {
           className="flex items-center border px-1.5 py-0.5"
           style={{ borderColor: colors.$5, borderRadius: '0.25rem' }}
         >
-          <p className="text-sm" style={{ color: colors.$5 }}>
+          <p className="text-sm" style={{ color: colors.$17 }}>
             Ctrl+K
           </p>
         </div>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes a small change for adjusting the colors of text in the field dedicated to opening the "Search" modal. It did not look as good as I expected in dark mode, so I just made that adjustment. Screenshot:

![Screenshot 2025-02-26 at 20 21 59](https://github.com/user-attachments/assets/649ec652-2d49-48fb-9546-6f2cfccc4c92)

Let me know your thoughts.