### PR TITLE
[Bugfix] Fixing Svg Icon Rem Size Issue

### DIFF
--- a/src/components/icons/ArrowDown.tsx
+++ b/src/components/icons/ArrowDown.tsx
@@ -20,8 +20,7 @@ export function ArrowDown({ size = '1.2rem', color = '#000' }: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 20 20"
     >
       <line

--- a/src/components/icons/ArrowUp.tsx
+++ b/src/components/icons/ArrowUp.tsx
@@ -20,8 +20,7 @@ export function ArrowUp({ size = '1.2rem', color = '#000' }: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 20 20"
     >
       <line

--- a/src/components/icons/ArrowsTransaction.tsx
+++ b/src/components/icons/ArrowsTransaction.tsx
@@ -22,8 +22,7 @@ export function ArrowsTransaction(props: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 18 18"
     >
       <polyline

--- a/src/components/icons/Calendar.tsx
+++ b/src/components/icons/Calendar.tsx
@@ -22,8 +22,7 @@ export function Calendar(props: Params) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 18 18"
     >
       <line

--- a/src/components/icons/CalendarAlert.tsx
+++ b/src/components/icons/CalendarAlert.tsx
@@ -25,8 +25,7 @@ export function CalendarAlert({
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 18 18"
     >
       <path

--- a/src/components/icons/CalendarCheckOut.tsx
+++ b/src/components/icons/CalendarCheckOut.tsx
@@ -20,8 +20,7 @@ export function CalendarCheckOut({ size = '1.2rem', color = '#000' }: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 18 18"
     >
       <path

--- a/src/components/icons/CalendarClock.tsx
+++ b/src/components/icons/CalendarClock.tsx
@@ -25,8 +25,7 @@ export function CalendarClock({
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 18 18"
     >
       <path

--- a/src/components/icons/CardChange.tsx
+++ b/src/components/icons/CardChange.tsx
@@ -20,8 +20,7 @@ export function CardChange({ size = '1.2rem', color = '#000' }: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 18 18"
     >
       <line

--- a/src/components/icons/CardCheck.tsx
+++ b/src/components/icons/CardCheck.tsx
@@ -20,8 +20,7 @@ export function CardCheck({ size = '1.2rem', color = '#000' }: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 18 18"
     >
       <line

--- a/src/components/icons/ChartLine.tsx
+++ b/src/components/icons/ChartLine.tsx
@@ -22,8 +22,7 @@ export function ChartLine(props: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 12 12"
     >
       <polyline

--- a/src/components/icons/Check.tsx
+++ b/src/components/icons/Check.tsx
@@ -10,17 +10,17 @@
 
 type Props = {
   color?: string;
+  size?: string;
 };
 
-export function Check({ color = '#18181B' }: Props) {
+export function Check({ color = '#18181B', size = '1.1rem' }: Props) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width="1.1rem"
-      height="1.1rem"
+      style={{ width: size, height: size }}
       viewBox="0 0 20 20"
     >
       <polyline

--- a/src/components/icons/ChevronDown.tsx
+++ b/src/components/icons/ChevronDown.tsx
@@ -23,8 +23,7 @@ export function ChevronDown(props: Params) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 20 20"
     >
       <polyline

--- a/src/components/icons/CircleInfo.tsx
+++ b/src/components/icons/CircleInfo.tsx
@@ -22,8 +22,7 @@ export function CircleInfo(props: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 12 12"
     >
       <circle

--- a/src/components/icons/CircleQuestion.tsx
+++ b/src/components/icons/CircleQuestion.tsx
@@ -22,8 +22,7 @@ export function CircleQuestion(props: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 18 18"
     >
       <circle

--- a/src/components/icons/CircleWarning.tsx
+++ b/src/components/icons/CircleWarning.tsx
@@ -22,8 +22,7 @@ export function CircleWarning(props: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 24 24"
     >
       <circle

--- a/src/components/icons/ClipboardCheck.tsx
+++ b/src/components/icons/ClipboardCheck.tsx
@@ -22,8 +22,7 @@ export function ClipboardCheck(props: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 12 12"
     >
       <path

--- a/src/components/icons/CloseNavbarArrow.tsx
+++ b/src/components/icons/CloseNavbarArrow.tsx
@@ -23,8 +23,7 @@ export function CloseNavbarArrow({
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 18 18"
     >
       <line

--- a/src/components/icons/CreditCard.tsx
+++ b/src/components/icons/CreditCard.tsx
@@ -22,8 +22,7 @@ export function CreditCard(props: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 18 18"
     >
       <line

--- a/src/components/icons/CreditCardChecked.tsx
+++ b/src/components/icons/CreditCardChecked.tsx
@@ -20,8 +20,7 @@ export function CreditCardChecked({ size = '1.2rem', color = '#000' }: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 18 18"
     >
       <path

--- a/src/components/icons/Cube.tsx
+++ b/src/components/icons/Cube.tsx
@@ -21,8 +21,7 @@ export function Cube({ size = '1rem', color = '#A1A1AA', className }: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 18 18"
       className={className}
     >

--- a/src/components/icons/CurrencyExchange.tsx
+++ b/src/components/icons/CurrencyExchange.tsx
@@ -22,8 +22,7 @@ export function CurrencyExchange(props: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 18 18"
     >
       <path

--- a/src/components/icons/Exit.tsx
+++ b/src/components/icons/Exit.tsx
@@ -15,8 +15,7 @@ export function Exit() {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width="0.85rem"
-      height="0.85rem"
+      style={{ width: '0.85rem', height: '0.85rem' }}
       viewBox="0 0 12 12"
     >
       <path

--- a/src/components/icons/ExpandCollapseChevron.tsx
+++ b/src/components/icons/ExpandCollapseChevron.tsx
@@ -10,17 +10,20 @@
 
 interface Props {
   color?: string;
+  size?: string;
 }
 
-export function ExpandCollapseChevron({ color = '#FFFFFF' }: Props) {
+export function ExpandCollapseChevron({
+  color = '#FFFFFF',
+  size = '1.3rem',
+}: Props) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width="20px"
-      height="20px"
+      style={{ width: size, height: size }}
       viewBox="0 0 20 20"
     >
       <polyline

--- a/src/components/icons/ExternalLink.tsx
+++ b/src/components/icons/ExternalLink.tsx
@@ -20,8 +20,7 @@ export function ExternalLink({ color = '#000', size = '1.3rem' }: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 20 20"
     >
       <polyline

--- a/src/components/icons/FileAdd.tsx
+++ b/src/components/icons/FileAdd.tsx
@@ -20,8 +20,7 @@ export function FileAdd({ size = '1.2rem', color = '#000' }: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 12 12"
     >
       <path

--- a/src/components/icons/FileClock.tsx
+++ b/src/components/icons/FileClock.tsx
@@ -22,8 +22,7 @@ export function FileClock(props: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 18 18"
     >
       <line

--- a/src/components/icons/FileEdit.tsx
+++ b/src/components/icons/FileEdit.tsx
@@ -20,8 +20,7 @@ export function FileEdit({ size = '1.2rem', color = '#000' }: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 24 24"
     >
       <path

--- a/src/components/icons/FileSearch.tsx
+++ b/src/components/icons/FileSearch.tsx
@@ -20,8 +20,7 @@ export function FileSearch({ size = '1.2rem', color = '#000' }: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 18 18"
     >
       <line

--- a/src/components/icons/Files.tsx
+++ b/src/components/icons/Files.tsx
@@ -22,8 +22,7 @@ export function Files(props: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 18 18"
     >
       <path

--- a/src/components/icons/Flutter.tsx
+++ b/src/components/icons/Flutter.tsx
@@ -16,9 +16,8 @@ interface Props {
 export function Flutter(props: Props) {
   return (
     <svg
-      height={props.height}
+      style={{ width: props.width, height: props.height }}
       viewBox="0.29 0.22 77.26 95.75"
-      width={props.width}
       xmlns="http://www.w3.org/2000/svg"
     >
       <g fill="none" fillRule="evenodd">

--- a/src/components/icons/Gear.tsx
+++ b/src/components/icons/Gear.tsx
@@ -20,8 +20,7 @@ export function Gear({ size = '1.2rem', color = '#000' }: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 18 18"
     >
       <circle

--- a/src/components/icons/House.tsx
+++ b/src/components/icons/House.tsx
@@ -21,8 +21,7 @@ export function House({ size = '1rem', color = '#A1A1AA', className }: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 18 18"
       className={className}
     >

--- a/src/components/icons/Income.tsx
+++ b/src/components/icons/Income.tsx
@@ -22,8 +22,7 @@ export function Income({ size = '1rem', color = '#000' }: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 20 20"
     >
       <rect

--- a/src/components/icons/Invoice.tsx
+++ b/src/components/icons/Invoice.tsx
@@ -27,8 +27,7 @@ export function Invoice({
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 18 18"
       className={className}
     >

--- a/src/components/icons/Message.tsx
+++ b/src/components/icons/Message.tsx
@@ -22,8 +22,7 @@ export function Message(props: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 18 18"
     >
       <path

--- a/src/components/icons/MoonStars.tsx
+++ b/src/components/icons/MoonStars.tsx
@@ -22,8 +22,7 @@ export function MoonStars(props: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 18 18"
     >
       <path

--- a/src/components/icons/Office.tsx
+++ b/src/components/icons/Office.tsx
@@ -22,8 +22,7 @@ export function Office(props: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 18 18"
     >
       <path

--- a/src/components/icons/OpenNavbarArrow.tsx
+++ b/src/components/icons/OpenNavbarArrow.tsx
@@ -20,8 +20,7 @@ export function OpenNavbarArrow({ color = '#74747C', size = '1.3rem' }: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 18 18"
     >
       <line

--- a/src/components/icons/OpenWallet.tsx
+++ b/src/components/icons/OpenWallet.tsx
@@ -21,8 +21,7 @@ export function OpenWallet({ color = '#000', size = '1.2rem' }: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 18 18"
     >
       <path

--- a/src/components/icons/OppositeArrows.tsx
+++ b/src/components/icons/OppositeArrows.tsx
@@ -20,8 +20,7 @@ export function OppositeArrows({ color = '#000', size = '1.5rem' }: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 20 20"
     >
       <polyline

--- a/src/components/icons/Person.tsx
+++ b/src/components/icons/Person.tsx
@@ -15,8 +15,7 @@ export function Person() {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width="1rem"
-      height="1rem"
+      style={{ width: '1rem', height: '1rem' }}
       viewBox="0 0 20 20"
     >
       <circle

--- a/src/components/icons/Plus.tsx
+++ b/src/components/icons/Plus.tsx
@@ -20,8 +20,7 @@ export function Plus({ size = '1rem', color = '#A1A1AA' }: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 20 20"
     >
       <line

--- a/src/components/icons/Refresh.tsx
+++ b/src/components/icons/Refresh.tsx
@@ -27,8 +27,7 @@ export function Refresh({
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 18 18"
       className={className}
     >

--- a/src/components/icons/SackCoins.tsx
+++ b/src/components/icons/SackCoins.tsx
@@ -24,8 +24,7 @@ export function SackCoins(props: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 18 18"
     >
       <path

--- a/src/components/icons/Search.tsx
+++ b/src/components/icons/Search.tsx
@@ -20,8 +20,7 @@ export function Search({ color = '#000', size = '1.3rem' }: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 18 18"
     >
       <path

--- a/src/components/icons/Settings.tsx
+++ b/src/components/icons/Settings.tsx
@@ -22,8 +22,7 @@ export function Settings({ size = '1.2rem', color = '#000' }: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 20 20"
     >
       <path

--- a/src/components/icons/SuitCase.tsx
+++ b/src/components/icons/SuitCase.tsx
@@ -22,8 +22,7 @@ export function SuitCase(props: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 18 18"
     >
       <path

--- a/src/components/icons/Sun.tsx
+++ b/src/components/icons/Sun.tsx
@@ -22,8 +22,7 @@ export function Sun(props: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 12 12"
     >
       <circle cx="6" cy="6" r="3" strokeWidth="0" fill={color}></circle>

--- a/src/components/icons/TriangleWarning.tsx
+++ b/src/components/icons/TriangleWarning.tsx
@@ -22,8 +22,7 @@ export function TriangleWarning(props: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 24 24"
     >
       <path

--- a/src/components/icons/Users.tsx
+++ b/src/components/icons/Users.tsx
@@ -20,8 +20,7 @@ export function Users({ size = '1.2rem', color = '#000' }: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 18 18"
     >
       <circle

--- a/src/components/icons/Wallet.tsx
+++ b/src/components/icons/Wallet.tsx
@@ -22,8 +22,7 @@ export function Wallet(props: Props) {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
+      style={{ width: size, height: size }}
       viewBox="0 0 18 18"
     >
       <path


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixing an issue that the client reported on GitHub regarding the lack of support for rem values in Safari. Upon investigation, I found that people resolve this issue by using the style prop to set height and width instead of using direct props.

Closes #2379 

Let me know your thoughts.