### PR TITLE
[Cleanup] Changing "E-Invoicing" Translations

### DIFF
--- a/src/components/layouts/common/hooks.ts
+++ b/src/components/layouts/common/hooks.ts
@@ -140,7 +140,7 @@ export function useSettingsRoutes() {
       enabled: isAdmin || isOwner || false,
     },
     {
-      name: t('e_invoice'),
+      name: t('e_invoicing'),
       href: '/settings/e_invoice',
       current: location.pathname.startsWith('/settings/e_invoice'),
       enabled: isAdmin || isOwner || false,

--- a/src/pages/settings/e-invoice/EInvoice.tsx
+++ b/src/pages/settings/e-invoice/EInvoice.tsx
@@ -95,7 +95,7 @@ export function EInvoice() {
 
   const pages = [
     { name: t('settings'), href: '/settings' },
-    { name: t('e_invoice'), href: '/settings/e_invoice' },
+    { name: t('e_invoicing'), href: '/settings/e_invoice' },
   ];
 
   const dispatch = useDispatch();
@@ -188,7 +188,7 @@ export function EInvoice() {
 
   return (
     <Settings
-      title={t('e_invoice')}
+      title={t('e_invoicing')}
       docsLink="en/advanced-settings/#e_invoice"
       breadcrumbs={pages}
       // onSaveClick={() => {
@@ -208,7 +208,7 @@ export function EInvoice() {
       <PEPPOLPlanBanner />
 
       {Boolean(!company?.legal_entity_id) && (
-        <Card title={t('e_invoice')}>
+        <Card title={t('e_invoicing')}>
           <Element
             leftSide={
               <PropertyCheckbox


### PR DESCRIPTION
@beganovich @turbo124 The PR includes changing translations from "E-Invoice" to "E-Invoicing". Screenshot:

<img width="1259" alt="Screenshot 2025-03-04 at 15 05 05" src="https://github.com/user-attachments/assets/332db19e-e02d-49fa-9c66-b39714185b42" />

Let me know your thoughts.