### PR TITLE
[Bugfix] Formatting Number Values When Previewing Reports

### DIFF
--- a/src/common/hooks/useNumericFormatter.ts
+++ b/src/common/hooks/useNumericFormatter.ts
@@ -48,7 +48,7 @@ export function useNumericFormatter() {
     decimalSeparator?: string,
     precision?: number
   ) => {
-    return numericFormatter(numStr, {
+    return numericFormatter(numStr.replaceAll(',', ''), {
       thousandSeparator: getThousandSeparator(thousandSeparator),
       decimalSeparator: getDecimalSeparator(decimalSeparator),
       decimalScale: precision || userNumberPrecision,


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for formatting number values based on the entered decimal separator. The issue was actually with the incoming `display_value` property. This property contains "," as a thousand separator and "." as a decimal separator, but the `react-number-format` package that we use for formatting expects only to have a decimal separator, making the thousand separator unnecessary in this case. The problem only occurred for values greater than 1000, as smaller values did not include the thousand separator. Screenshots:

<img width="137" alt="Screenshot 2025-03-04 at 16 32 25" src="https://github.com/user-attachments/assets/ee0e004f-4547-4bcd-bfe1-512a1659b6a9" />

<img width="136" alt="Screenshot 2025-03-04 at 16 33 36" src="https://github.com/user-attachments/assets/bba37381-6343-4df7-9bb2-8806cece41e3" />

Closes #2388 

Let me know your thoughts.