### PR TITLE
[Bugfix] Updating Company/User Changes In Redux

### DIFF
--- a/src/common/hooks/useAuthenticated.ts
+++ b/src/common/hooks/useAuthenticated.ts
@@ -12,6 +12,7 @@ import { request } from '$app/common/helpers/request';
 import { CompanyUser } from '$app/common/interfaces/company-user';
 import {
   changeCurrentIndex,
+  resetChanges,
   updateCompanyUsers,
 } from '$app/common/stores/slices/company-users';
 import { useQueryClient } from 'react-query';
@@ -66,6 +67,7 @@ export function useAuthenticated(): boolean {
         );
 
         dispatch(updateCompanyUsers(response.data.data));
+        dispatch(resetChanges('company'));
         dispatch(changeCurrentIndex(currentIndex));
       })
       .catch(() => {

--- a/src/common/hooks/useDataTablePreferences.ts
+++ b/src/common/hooks/useDataTablePreferences.ts
@@ -21,7 +21,7 @@ import { endpoint } from '../helpers';
 import { request } from '../helpers/request';
 import { useUserChanges } from './useInjectUserChanges';
 import { useDispatch } from 'react-redux';
-import { updateUser } from '../stores/slices/user';
+import { resetChanges, updateUser } from '../stores/slices/user';
 import { useStoreSessionTableFilters } from './useStoreSessionTableFilters';
 
 interface Params {
@@ -76,6 +76,7 @@ export function useDataTablePreferences(params: Params) {
       $refetch(['company_users']);
 
       dispatch(updateUser(updatedUser));
+      dispatch(resetChanges());
     });
   };
 

--- a/src/common/hooks/usePreferences.tsx
+++ b/src/common/hooks/usePreferences.tsx
@@ -15,11 +15,7 @@ import { useTranslation } from 'react-i18next';
 import { useInjectUserChanges } from './useInjectUserChanges';
 import { ReactSettings, useReactSettings } from './useReactSettings';
 import { useDispatch, useStore } from 'react-redux';
-import {
-  injectInChanges,
-  updateChanges,
-  updateUser,
-} from '../stores/slices/user';
+import { resetChanges, updateChanges, updateUser } from '../stores/slices/user';
 import { toast } from '../helpers/toast/toast';
 import { request } from '../helpers/request';
 import { endpoint } from '../helpers';
@@ -115,8 +111,7 @@ export function usePreferences() {
         $refetch(['company_users']);
 
         dispatch(updateUser(response.data.data));
-        dispatch(injectInChanges());
-
+        dispatch(resetChanges());
         setIsVisible(false);
       })
       .catch((error: AxiosError<ValidationBag>) => {

--- a/src/common/hooks/useRefreshCompanyUsers.ts
+++ b/src/common/hooks/useRefreshCompanyUsers.ts
@@ -10,7 +10,10 @@
 
 import { request } from '../helpers/request';
 import { endpoint } from '../helpers';
-import { updateCompanyUsers } from '../stores/slices/company-users';
+import {
+  resetChanges,
+  updateCompanyUsers,
+} from '../stores/slices/company-users';
 import { useDispatch } from 'react-redux';
 
 export function useRefreshCompanyUsers() {
@@ -19,6 +22,7 @@ export function useRefreshCompanyUsers() {
   return async () => {
     return request('POST', endpoint('/api/v1/refresh')).then((response) => {
       dispatch(updateCompanyUsers(response.data.data));
+      dispatch(resetChanges('company'));
     });
   };
 }

--- a/src/components/AboutModal.tsx
+++ b/src/components/AboutModal.tsx
@@ -30,7 +30,10 @@ import { Icon } from './icons/Icon';
 import { MdInfo, MdWarning } from 'react-icons/md';
 import styled from 'styled-components';
 import { useColorScheme } from '$app/common/colors';
-import { updateCompanyUsers } from '$app/common/stores/slices/company-users';
+import {
+  updateCompanyUsers,
+  resetChanges,
+} from '$app/common/stores/slices/company-users';
 import { useDispatch } from 'react-redux';
 import { PasswordConfirmation } from './PasswordConfirmation';
 import { useOnWrongPasswordEnter } from '$app/common/hooks/useOnWrongPasswordEnter';
@@ -131,6 +134,7 @@ export function AboutModal(props: Props) {
           request('POST', endpoint('/api/v1/refresh?current_company=true'))
             .then((response) => {
               dispatch(updateCompanyUsers(response.data.data));
+              dispatch(resetChanges('company'));
               toast.dismiss();
               handleHealthCheck(true);
             })

--- a/src/components/CommonActionsPreferenceModal.tsx
+++ b/src/components/CommonActionsPreferenceModal.tsx
@@ -23,7 +23,7 @@ import { endpoint } from '$app/common/helpers';
 import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-api-response';
 import { CompanyUser } from '$app/common/interfaces/company-user';
 import { cloneDeep, isEqual, set } from 'lodash';
-import { updateUser } from '$app/common/stores/slices/user';
+import { resetChanges, updateUser } from '$app/common/stores/slices/user';
 import { useDispatch } from 'react-redux';
 import { $refetch } from '$app/common/hooks/useRefetch';
 import {
@@ -103,6 +103,7 @@ export function CommonActionsPreferenceModal(props: Props) {
       $refetch(['company_users']);
 
       dispatch(updateUser(updatedUser));
+      dispatch(resetChanges());
     });
   };
 

--- a/src/components/DataTableColumnsPicker.tsx
+++ b/src/components/DataTableColumnsPicker.tsx
@@ -14,7 +14,7 @@ import { toast } from '$app/common/helpers/toast/toast';
 import { CompanyUser } from '$app/common/interfaces/company-user';
 import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-api-response';
 import { User } from '$app/common/interfaces/user';
-import { updateUser } from '$app/common/stores/slices/user';
+import { resetChanges, updateUser } from '$app/common/stores/slices/user';
 import { RootState } from '$app/common/stores/store';
 import { cloneDeep, set } from 'lodash';
 import { useCallback, useEffect, useState } from 'react';
@@ -101,6 +101,7 @@ export function DataTableColumnsPicker(props: Props) {
       $refetch(['company_users']);
 
       dispatch(updateUser(user));
+      dispatch(resetChanges());
 
       toast.success('saved_settings');
     });

--- a/src/components/DataTableFooterColumnsPicker.tsx
+++ b/src/components/DataTableFooterColumnsPicker.tsx
@@ -22,7 +22,7 @@ import { endpoint } from '$app/common/helpers';
 import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-api-response';
 import { cloneDeep, set } from 'lodash';
 import { $refetch } from '$app/common/hooks/useRefetch';
-import { updateUser } from '$app/common/stores/slices/user';
+import { resetChanges, updateUser } from '$app/common/stores/slices/user';
 import { useDispatch } from 'react-redux';
 import { CompanyUser } from '$app/common/interfaces/company-user';
 import { useInjectUserChanges } from '$app/common/hooks/useInjectUserChanges';
@@ -92,6 +92,7 @@ export function DataTableFooterColumnsPicker(props: Props) {
           $refetch(['company_users']);
 
           dispatch(updateUser(userChanges));
+          dispatch(resetChanges());
 
           setIsModalOpen(false);
         })

--- a/src/components/HelpSidebarIcons.tsx
+++ b/src/components/HelpSidebarIcons.tsx
@@ -12,7 +12,10 @@ import Tippy from '@tippyjs/react';
 import { endpoint, isHosted, isSelfHosted } from '$app/common/helpers';
 import { request } from '$app/common/helpers/request';
 import { useCurrentAccount } from '$app/common/hooks/useCurrentAccount';
-import { updateCompanyUsers } from '$app/common/stores/slices/company-users';
+import {
+  updateCompanyUsers,
+  resetChanges,
+} from '$app/common/stores/slices/company-users';
 import { useFormik } from 'formik';
 import { useState } from 'react';
 import { Mail } from 'react-feather';
@@ -125,6 +128,7 @@ export function HelpSidebarIcons(props: Props) {
 
     request('POST', endpoint('/api/v1/refresh')).then((data) => {
       dispatch(updateCompanyUsers(data.data.data));
+      dispatch(resetChanges('company'));
       setDisabledButton(false);
       setCronsNotEnabledModal(false);
     });

--- a/src/components/banners/VerifyPhone.tsx
+++ b/src/components/banners/VerifyPhone.tsx
@@ -24,7 +24,10 @@ import VerificationInput from 'react-verification-input';
 import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-api-response';
 import { CompanyUser } from '$app/common/interfaces/company-user';
 import { useDispatch } from 'react-redux';
-import { updateCompanyUsers } from '$app/common/stores/slices/company-users';
+import {
+  resetChanges,
+  updateCompanyUsers,
+} from '$app/common/stores/slices/company-users';
 import { useCurrentAccount } from '$app/common/hooks/useCurrentAccount';
 import { useCurrentUser } from '$app/common/hooks/useCurrentUser';
 import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
@@ -66,6 +69,7 @@ function Confirmation({
       request('POST', endpoint('/api/v1/refresh')).then(
         (response: GenericSingleResourceResponse<CompanyUser>) => {
           dispatch(updateCompanyUsers(response.data.data));
+          dispatch(resetChanges('company'));
           onComplete();
         }
       );

--- a/src/components/import/ImportTemplate.tsx
+++ b/src/components/import/ImportTemplate.tsx
@@ -18,7 +18,7 @@ import { CompanyUser } from '$app/common/interfaces/company-user';
 import { cloneDeep, set } from 'lodash';
 import { toast } from '$app/common/helpers/toast/toast';
 import { $refetch } from '$app/common/hooks/useRefetch';
-import { updateUser } from '$app/common/stores/slices/user';
+import { resetChanges, updateUser } from '$app/common/stores/slices/user';
 import { User } from '$app/common/interfaces/user';
 import { useState } from 'react';
 import { useUserChanges } from '$app/common/hooks/useInjectUserChanges';
@@ -83,6 +83,7 @@ export function ImportTemplate(props: Props) {
             $refetch(['company_users']);
 
             dispatch(updateUser(updatedUser));
+            dispatch(resetChanges());
 
             onDeletedTemplate();
           })

--- a/src/components/import/ImportTemplateModal.tsx
+++ b/src/components/import/ImportTemplateModal.tsx
@@ -19,7 +19,7 @@ import { toast } from '$app/common/helpers/toast/toast';
 import { request } from '$app/common/helpers/request';
 import { endpoint } from '$app/common/helpers';
 import { $refetch } from '$app/common/hooks/useRefetch';
-import { updateUser } from '$app/common/stores/slices/user';
+import { resetChanges, updateUser } from '$app/common/stores/slices/user';
 import { useDispatch } from 'react-redux';
 import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-api-response';
 import { CompanyUser } from '$app/common/interfaces/company-user';
@@ -152,6 +152,7 @@ export function ImportTemplateModal(props: Props) {
             $refetch(['company_users']);
 
             dispatch(updateUser(updatedUser));
+            dispatch(resetChanges());
 
             handleOnClose();
 

--- a/src/pages/authentication/Register.tsx
+++ b/src/pages/authentication/Register.tsx
@@ -28,6 +28,7 @@ import { SignInProviders } from './components/SignInProviders';
 import { GenericValidationBag } from '$app/common/interfaces/validation-bag';
 import {
   changeCurrentIndex,
+  resetChanges,
   updateCompanyUsers,
 } from '$app/common/stores/slices/company-users';
 import { useTitle } from '$app/common/hooks/useTitle';
@@ -115,6 +116,7 @@ export function Register() {
           );
 
           dispatch(updateCompanyUsers(response.data.data));
+          dispatch(resetChanges('company'));
           dispatch(changeCurrentIndex(0));
         })
         .catch(

--- a/src/pages/authentication/common/hooks.ts
+++ b/src/pages/authentication/common/hooks.ts
@@ -13,6 +13,7 @@ import { AuthenticationTypes } from '$app/common/dtos/authentication';
 import { CompanyUser } from '$app/common/interfaces/company-user';
 import {
   changeCurrentIndex,
+  resetChanges,
   updateCompanyUsers,
 } from '$app/common/stores/slices/company-users';
 import { authenticate } from '$app/common/stores/slices/user';
@@ -46,6 +47,7 @@ export function useLogin() {
     );
 
     dispatch(updateCompanyUsers(response.data.data));
+    dispatch(resetChanges('company'));
     dispatch(changeCurrentIndex(currentIndex));
   };
 }

--- a/src/pages/authentication/components/SignInProviders.tsx
+++ b/src/pages/authentication/components/SignInProviders.tsx
@@ -15,6 +15,7 @@ import { request } from '$app/common/helpers/request';
 import { CompanyUser } from '$app/common/interfaces/company-user';
 import {
   changeCurrentIndex,
+  resetChanges,
   updateCompanyUsers,
 } from '$app/common/stores/slices/company-users';
 import { authenticate } from '$app/common/stores/slices/user';
@@ -76,6 +77,7 @@ export function SignInProviders() {
     );
 
     dispatch(updateCompanyUsers(response.data.data));
+    dispatch(resetChanges('company'));
     dispatch(changeCurrentIndex(currentIndex));
   };
 

--- a/src/pages/clients/common/components/MergeClientModal.tsx
+++ b/src/pages/clients/common/components/MergeClientModal.tsx
@@ -13,7 +13,10 @@ import { AxiosError, AxiosResponse } from 'axios';
 import { endpoint } from '$app/common/helpers';
 import { request } from '$app/common/helpers/request';
 import { toast } from '$app/common/helpers/toast/toast';
-import { updateCompanyUsers } from '$app/common/stores/slices/company-users';
+import {
+  resetChanges,
+  updateCompanyUsers,
+} from '$app/common/stores/slices/company-users';
 import { ClientSelector } from '$app/components/clients/ClientSelector';
 import { Modal } from '$app/components/Modal';
 import { PasswordConfirmation } from '$app/components/PasswordConfirmation';
@@ -79,6 +82,7 @@ export function MergeClientModal(props: Props) {
               toast.success('merged_clients');
 
               dispatch(updateCompanyUsers(response.data.data));
+              dispatch(resetChanges('company'));
 
               setMergeIntoClientId('');
 

--- a/src/pages/settings/common/hooks/useHandleCompanySave.tsx
+++ b/src/pages/settings/common/hooks/useHandleCompanySave.tsx
@@ -10,7 +10,10 @@
 
 import { AxiosError } from 'axios';
 import { endpoint } from '$app/common/helpers';
-import { updateRecord } from '$app/common/stores/slices/company-users';
+import {
+  resetChanges,
+  updateRecord,
+} from '$app/common/stores/slices/company-users';
 import { useDispatch } from 'react-redux';
 import { request } from '$app/common/helpers/request';
 import { ValidationBag } from '$app/common/interfaces/validation-bag';
@@ -86,6 +89,7 @@ export function useHandleCompanySave() {
     )
       .then((response) => {
         dispatch(updateRecord({ object: 'company', data: response.data.data }));
+        dispatch(resetChanges('company'));
 
         !adjustedExcludeToaster && toast.dismiss();
 

--- a/src/pages/settings/company/components/DeleteLogo.tsx
+++ b/src/pages/settings/company/components/DeleteLogo.tsx
@@ -11,7 +11,10 @@ import { AxiosResponse } from 'axios';
 import { endpoint } from '$app/common/helpers';
 import { useCompanyChanges } from '$app/common/hooks/useCompanyChanges';
 import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
-import { updateRecord } from '$app/common/stores/slices/company-users';
+import {
+  resetChanges,
+  updateRecord,
+} from '$app/common/stores/slices/company-users';
 import { Button } from '$app/components/forms/Button';
 import { useFormik } from 'formik';
 import { useTranslation } from 'react-i18next';
@@ -83,6 +86,7 @@ export function DeleteLogo({ isSettingsPage = true }: Props) {
           dispatch(
             updateRecord({ object: 'company', data: response.data.data })
           );
+          dispatch(resetChanges('company'));
         }
 
         if (isGroupSettingsActive) {

--- a/src/pages/settings/company/components/Logo.tsx
+++ b/src/pages/settings/company/components/Logo.tsx
@@ -18,7 +18,10 @@ import { Image } from 'react-feather';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { useLogo } from '$app/common/hooks/useLogo';
-import { updateRecord } from '$app/common/stores/slices/company-users';
+import {
+  resetChanges,
+  updateRecord,
+} from '$app/common/stores/slices/company-users';
 import { DeleteLogo } from './DeleteLogo';
 import { request } from '$app/common/helpers/request';
 import { toast } from '$app/common/helpers/toast/toast';
@@ -86,6 +89,7 @@ export function Logo({ isSettingsPage = true }: Props) {
             dispatch(
               updateRecord({ object: 'company', data: response.data.data })
             );
+            dispatch(resetChanges('company'));
           }
 
           if (isGroupSettingsActive) {

--- a/src/pages/settings/company/create/CompanyCreate.tsx
+++ b/src/pages/settings/company/create/CompanyCreate.tsx
@@ -14,7 +14,10 @@ import { AuthenticationTypes } from '$app/common/dtos/authentication';
 import { endpoint } from '$app/common/helpers';
 import { request } from '$app/common/helpers/request';
 import { toast } from '$app/common/helpers/toast/toast';
-import { updateCompanyUsers } from '$app/common/stores/slices/company-users';
+import {
+  resetChanges,
+  updateCompanyUsers,
+} from '$app/common/stores/slices/company-users';
 import { authenticate } from '$app/common/stores/slices/user';
 import { Modal } from '$app/components/Modal';
 import { useState, SetStateAction, Dispatch } from 'react';
@@ -89,6 +92,8 @@ export function CompanyCreate(props: Props) {
               const companyUser = companyUsers[createdCompanyIndex];
 
               dispatch(updateCompanyUsers(companyUsers));
+
+              dispatch(resetChanges('company'));
 
               toast.success('created_new_company');
 

--- a/src/pages/settings/company/edit/CompanyEdit.tsx
+++ b/src/pages/settings/company/edit/CompanyEdit.tsx
@@ -21,7 +21,10 @@ import { useState, SetStateAction, Dispatch } from 'react';
 import { useTranslation } from 'react-i18next';
 import { LanguageSelector } from '$app/components/LanguageSelector';
 import { Logo } from '../components';
-import { updateRecord } from '$app/common/stores/slices/company-users';
+import {
+  resetChanges,
+  updateRecord,
+} from '$app/common/stores/slices/company-users';
 import { useDispatch } from 'react-redux';
 import { useHandleCurrentCompanyChangeProperty } from '../../common/hooks/useHandleCurrentCompanyChange';
 import { isEqual } from 'lodash';
@@ -86,6 +89,7 @@ export function CompanyEdit(props: Props) {
           : props.setIsModalOpen(false);
 
         dispatch(updateRecord({ object: 'company', data: response.data.data }));
+        dispatch(resetChanges('company'));
       })
       .catch((error: AxiosError<ValidationBag>) => {
         if (error.response?.status === 422) {

--- a/src/pages/settings/e-invoice/EInvoice.tsx
+++ b/src/pages/settings/e-invoice/EInvoice.tsx
@@ -29,7 +29,10 @@ import { request } from '$app/common/helpers/request';
 import { endpoint, isHosted, isSelfHosted } from '$app/common/helpers';
 import { AxiosError, AxiosResponse } from 'axios';
 import { useDispatch } from 'react-redux';
-import { updateRecord } from '$app/common/stores/slices/company-users';
+import {
+  resetChanges,
+  updateRecord,
+} from '$app/common/stores/slices/company-users';
 import { ValidationBag } from '$app/common/interfaces/validation-bag';
 import { useDropzone } from 'react-dropzone';
 import { Image } from 'react-feather';
@@ -129,6 +132,7 @@ export function EInvoice() {
           dispatch(
             updateRecord({ object: 'company', data: response.data.data })
           );
+          dispatch(resetChanges('company'));
 
           toast.success('uploaded_document');
         })

--- a/src/pages/settings/integrations/analytics/Analytics.tsx
+++ b/src/pages/settings/integrations/analytics/Analytics.tsx
@@ -20,6 +20,7 @@ import { useTitle } from '$app/common/hooks/useTitle';
 import { ValidationBag } from '$app/common/interfaces/validation-bag';
 import {
   injectInChanges,
+  resetChanges,
   updateChanges,
   updateRecord,
 } from '$app/common/stores/slices/company-users';
@@ -80,6 +81,7 @@ export function Analytics() {
           dispatch(
             updateRecord({ object: 'company', data: response.data.data })
           );
+          dispatch(resetChanges('company'));
 
           toast.success('updated_settings');
         })

--- a/src/pages/settings/user/UserDetails.tsx
+++ b/src/pages/settings/user/UserDetails.tsx
@@ -115,6 +115,7 @@ export function UserDetails() {
         }
 
         dispatch(updateUser(response[0].data.data));
+        dispatch(resetChanges());
 
         window.dispatchEvent(new CustomEvent('user.updated'));
 

--- a/src/pages/settings/user/UserDetails.tsx
+++ b/src/pages/settings/user/UserDetails.tsx
@@ -38,6 +38,7 @@ import { TwoFactorAuthenticationModals } from './common/components/TwoFactorAuth
 import { hasLanguageChanged as hasLanguageChangedAtom } from '$app/pages/settings/localization/common/atoms';
 import { $refetch } from '$app/common/hooks/useRefetch';
 import { useOnWrongPasswordEnter } from '$app/common/hooks/useOnWrongPasswordEnter';
+import { resetChanges as resetCompanyChanges } from '$app/common/stores/slices/company-users';
 
 export function UserDetails() {
   useTitle('user_details');
@@ -119,10 +120,13 @@ export function UserDetails() {
 
         window.dispatchEvent(new CustomEvent('user.updated'));
 
-        isAdmin &&
+        if (isAdmin) {
           dispatch(
             updateRecord({ object: 'company', data: response[1].data.data })
           );
+
+          dispatch(resetCompanyChanges('company'));
+        }
       })
       .catch((error: AxiosError<ValidationBag>) => {
         if (error.response?.status === 412) {

--- a/src/pages/settings/user/common/components/SelectProviderModal.tsx
+++ b/src/pages/settings/user/common/components/SelectProviderModal.tsx
@@ -19,7 +19,10 @@ import { request } from '$app/common/helpers/request';
 import { endpoint, trans } from '$app/common/helpers';
 import { useDispatch } from 'react-redux';
 import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
-import { updateRecord } from '$app/common/stores/slices/company-users';
+import {
+  resetChanges,
+  updateRecord,
+} from '$app/common/stores/slices/company-users';
 import { useInjectUserChanges } from '$app/common/hooks/useInjectUserChanges';
 
 export function SelectProviderModal() {
@@ -52,6 +55,7 @@ export function SelectProviderModal() {
       },
     }).then((response) => {
       dispatch(updateRecord({ object: 'company', data: response.data.data }));
+      dispatch(resetChanges('company'));
 
       toast.success('updated_settings');
 

--- a/src/pages/settings/user/common/components/TwoFactorAuthenticationModals.tsx
+++ b/src/pages/settings/user/common/components/TwoFactorAuthenticationModals.tsx
@@ -13,7 +13,7 @@ import { endpoint, isHosted } from '$app/common/helpers';
 import { request } from '$app/common/helpers/request';
 import { toast } from '$app/common/helpers/toast/toast';
 import { useCurrentUser } from '$app/common/hooks/useCurrentUser';
-import { updateUser } from '$app/common/stores/slices/user';
+import { resetChanges, updateUser } from '$app/common/stores/slices/user';
 import { Modal } from '$app/components/Modal';
 import { merge } from 'lodash';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
@@ -84,7 +84,7 @@ export function TwoFactorAuthenticationModals(props: Props) {
         toast.success(response.data.message);
 
         dispatch(updateUser(merge({}, user, { google_2fa_secret: true })));
-
+        dispatch(resetChanges());
         setIsEnableModalOpen(false);
       })
       .catch((error: AxiosError<ValidationBag>) => {
@@ -104,6 +104,7 @@ export function TwoFactorAuthenticationModals(props: Props) {
         toast.success('disabled_two_factor');
 
         dispatch(updateUser(merge({}, user, { google_2fa_secret: false })));
+        dispatch(resetChanges());
 
         setIsDisableModalOpen?.(false);
       }
@@ -130,6 +131,7 @@ export function TwoFactorAuthenticationModals(props: Props) {
       toast.success('verified_phone_number');
 
       dispatch(updateUser(merge({}, user, { verified_phone_number: true })));
+      dispatch(resetChanges());
 
       setIsSmsModalOpen(false);
 

--- a/src/pages/settings/user/common/hooks/useUpdateCompanyUser.ts
+++ b/src/pages/settings/user/common/hooks/useUpdateCompanyUser.ts
@@ -14,7 +14,7 @@ import { $refetch } from '$app/common/hooks/useRefetch';
 import { CompanyUser } from '$app/common/interfaces/company-user';
 import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-api-response';
 import { User } from '$app/common/interfaces/user';
-import { updateUser } from '$app/common/stores/slices/user';
+import { resetChanges, updateUser } from '$app/common/stores/slices/user';
 import { set } from 'lodash';
 import { useDispatch } from 'react-redux';
 
@@ -32,6 +32,7 @@ export function useUpdateCompanyUser() {
       $refetch(['company_users']);
 
       dispatch(updateUser(updatedUser));
+      dispatch(resetChanges());
     });
   };
 }

--- a/src/pages/vendors/create/Create.tsx
+++ b/src/pages/vendors/create/Create.tsx
@@ -18,7 +18,10 @@ import { useTitle } from '$app/common/hooks/useTitle';
 import { ValidationBag } from '$app/common/interfaces/validation-bag';
 import { Vendor } from '$app/common/interfaces/vendor';
 import { useBlankVendorQuery } from '$app/common/queries/vendor';
-import { updateRecord } from '$app/common/stores/slices/company-users';
+import {
+  resetChanges,
+  updateRecord,
+} from '$app/common/stores/slices/company-users';
 import { Page } from '$app/components/Breadcrumbs';
 import { Default } from '$app/components/layouts/Default';
 import { useEffect, useState } from 'react';
@@ -101,6 +104,7 @@ export default function Create() {
           dispatch(
             updateRecord({ object: 'company', data: response[1].data.data })
           );
+          dispatch(resetChanges('company'));
         }
 
         navigate(route('/vendors/:id', { id: response[0].data.data.id }));


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for updating the company/user changes object in Redux after the endpoint for updating company_users or companies has been successful. While working on redesigning the main navigation bar, I noticed that two hooks work incorrectly and make unnecessary updates. I updated them, but I then noticed an issue where columns on tables don't update without refreshing the page. Therefore, I went through ALL cases when company_users or companies are updated to ensure that the changes Redux object is kept up to date. Let me know your thoughts.