### PR TITLE
[Cleanup] Replacing "Reports" And "Transactions" In Main Navbar

### DIFF
--- a/src/components/layouts/Default.tsx
+++ b/src/components/layouts/Default.tsx
@@ -335,13 +335,6 @@ export function Default(props: Props) {
       },
     },
     {
-      name: t('reports'),
-      href: '/reports',
-      icon: ChartLine,
-      current: location.pathname.startsWith('/reports'),
-      visible: hasPermission('view_reports'),
-    },
-    {
       name: t('transactions'),
       href: '/transactions',
       icon: ArrowsTransaction,
@@ -357,6 +350,13 @@ export function Default(props: Props) {
         label: t('new_transaction'),
         visible: hasPermission('create_bank_transaction'),
       },
+    },
+    {
+      name: t('reports'),
+      href: '/reports',
+      icon: ChartLine,
+      current: location.pathname.startsWith('/reports'),
+      visible: hasPermission('view_reports'),
     },
     {
       name: t('settings'),


### PR DESCRIPTION
@beganovich @turbo124 The PR includes replacing the positions of 'Reports' and 'Transactions' in the main navbar. Screenshot:

<img width="225" alt="Screenshot 2025-03-06 at 20 13 21" src="https://github.com/user-attachments/assets/1e7ef4ff-dd1e-46d4-b9c0-692f030ffcd6" />

Let me know your thoughts.