### PR TITLE
[Bugfix] Reading Notifications From Old Implementation

### DIFF
--- a/src/components/Notifications.tsx
+++ b/src/components/Notifications.tsx
@@ -465,6 +465,17 @@ export function Notifications() {
     }
   }, [sockets, reactSettings.preferences.enable_public_notifications]);
 
+  // This is a temporary fix for new implementation of notifications. If you see this code in 2 years, feel free to remove it.
+  useEffect(() => {
+    const doNotificationsContainAllDetails = notifications.every(
+      ({ displayLabel }) => Boolean(displayLabel?.notificationType)
+    );
+
+    if (notifications.length > 0 && !doNotificationsContainAllDetails) {
+      setNotifications([]);
+    }
+  }, []);
+
   if (
     isSelfHosted() &&
     !reactSettings.preferences.enable_public_notifications
@@ -508,37 +519,40 @@ export function Notifications() {
       >
         {notifications.length > 0 ? (
           <div className="flex flex-col space-y-2 pt-2">
-            {notifications.map((notification, i) => (
-              <div
-                key={i}
-                className="flex items-center justify-between px-6 py-2 space-x-2"
-              >
-                <div className="flex items-center space-x-2.5">
-                  {generateIcon(notification.displayLabel.notificationType)}
+            {notifications.map(
+              (notification, i) =>
+                Boolean(notification.displayLabel) && (
+                  <div
+                    key={i}
+                    className="flex items-center justify-between px-6 py-2 space-x-2"
+                  >
+                    <div className="flex items-center space-x-2.5">
+                      {generateIcon(notification.displayLabel.notificationType)}
 
-                  <div className="flex flex-col space-y-0.5">
-                    <div
-                      className="text-sm"
-                      style={{
-                        color: colors.$3,
-                      }}
-                    >
-                      {generateDisplayLabel(notification.displayLabel)}
+                      <div className="flex flex-col space-y-0.5">
+                        <div
+                          className="text-sm"
+                          style={{
+                            color: colors.$3,
+                          }}
+                        >
+                          {generateDisplayLabel(notification.displayLabel)}
+                        </div>
+
+                        <p className="text-xs text-gray-500">
+                          {getDateTimeLabel(notification.date)}
+                        </p>
+                      </div>
                     </div>
 
-                    <p className="text-xs text-gray-500">
-                      {getDateTimeLabel(notification.date)}
-                    </p>
+                    {!notification.readAt && (
+                      <div>
+                        <Icon element={GoDotFill} size={14} color="#2176FF" />
+                      </div>
+                    )}
                   </div>
-                </div>
-
-                {!notification.readAt && (
-                  <div>
-                    <Icon element={GoDotFill} size={14} color="#2176FF" />
-                  </div>
-                )}
-              </div>
-            ))}
+                )
+            )}
           </div>
         ) : (
           <NonClickableElement>

--- a/src/components/Notifications.tsx
+++ b/src/components/Notifications.tsx
@@ -465,17 +465,6 @@ export function Notifications() {
     }
   }, [sockets, reactSettings.preferences.enable_public_notifications]);
 
-  // This is a temporary fix for new implementation of notifications. If you see this code in 2 years, feel free to remove it.
-  useEffect(() => {
-    const doNotificationsContainAllDetails = notifications.every(
-      ({ displayLabel }) => Boolean(displayLabel?.notificationType)
-    );
-
-    if (notifications.length > 0 && !doNotificationsContainAllDetails) {
-      setNotifications([]);
-    }
-  }, []);
-
   if (
     isSelfHosted() &&
     !reactSettings.preferences.enable_public_notifications


### PR DESCRIPTION
@beganovich @turbo124 The PR includes a quick fix and checks if the `displayLabel` notification object exists. If it exists, the notification will be displayed, otherwise, it will not be. Let me know your thoughts.