### PR TITLE
[Bugfix] Client Show Page "Documents" Tab URL

### DIFF
--- a/src/pages/clients/routes.tsx
+++ b/src/pages/clients/routes.tsx
@@ -205,7 +205,7 @@ export const clientRoutes = (
         }
       />
       <Route
-        path="documents"
+        path="documents_overview"
         element={
           <Suspense fallback={<TabLoader />}>
             <Documents />

--- a/src/pages/clients/show/hooks/useTabs.tsx
+++ b/src/pages/clients/show/hooks/useTabs.tsx
@@ -69,7 +69,7 @@ export function useTabs(params: Params) {
     },
     {
       name: t('documents'),
-      href: route('/clients/:id/documents', { id }),
+      href: route('/clients/:id/documents_overview', { id }),
       enabled:
         hasPermission('view_client') ||
         hasPermission('edit_client') ||


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for the "Documents" tab URL issue on Client show page. After making tabs for the edit page, the documents tab on client show page had exactly the same URL as the edit page documents tab, so clicking on "Documents" tab on client show page was actually navigating to the edit page tab. To resolve this, I made a distinction between them, so now the URL for documents on client show page is "/documents_overview". Let me know your thoughts.