### PR TITLE
[Bugfix] "Update Prices" Modal Text Color Issue

### DIFF
--- a/src/pages/recurring-invoices/common/components/UpdatePricesAction.tsx
+++ b/src/pages/recurring-invoices/common/components/UpdatePricesAction.tsx
@@ -59,7 +59,7 @@ export const UpdatePricesAction = (props: Props) => {
         visible={isModalOpen}
         onClose={() => setIsModalOpen(false)}
       >
-        <span className="text-lg text-gray-900">{t('are_you_sure')}</span>
+        <span className="text-lg">{t('are_you_sure')}</span>
 
         <Button className="self-end" onClick={handleSave}>
           {t('yes')}


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for the "Update Prices" modal text color issue. Screenshot:

![Screenshot 2025-03-19 at 02 39 29](https://github.com/user-attachments/assets/699d7339-504e-43ef-81a7-4bf2d6339c36)

Let me know your thoughts.