### PR TITLE
[Cleanup] Adjusting Badges Background And Text Colors

### DIFF
--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -49,21 +49,28 @@ export function Badge(props: Props) {
     <span
       style={styles}
       className={classNames(
-        'text-xs px-2 py-1 rounded',
+        'text-xs px-2 py-1 rounded font-medium',
         {
           'bg-transparent': props.variant === 'transparent',
-          'bg-gray-500 text-white': props.variant === 'generic',
-          'bg-white border text-gray-900 hover:bg-white':
+          'bg-[#A1A1AA] bg-opacity-15 text-[#A1A1AA]':
+            props.variant === 'generic',
+          'bg-white border bg-opacity-15 text-gray-500':
             props.variant === 'white',
-          'bg-yellow-600 text-white': props.variant === 'yellow',
-          'bg-red-600 text-white': props.variant === 'red',
-          'bg-blue-300 text-white': props.variant === 'light-blue',
-          'bg-blue-400 text-white': props.variant === 'blue',
-          'bg-blue-700 text-white': props.variant === 'dark-blue',
-          'bg-orange-500 text-white': props.variant === 'orange',
-          'bg-green-500 text-white': props.variant === 'green',
-          'bg-black text-white': props.variant === 'black',
-          'bg-purple text-white': props.variant === 'purple',
+          'bg-yellow-500 bg-opacity-15 text-yellow-500':
+            props.variant === 'yellow',
+          'bg-red-500 bg-opacity-15 text-red-500': props.variant === 'red',
+          'bg-blue-300 bg-opacity-15 text-blue-300':
+            props.variant === 'light-blue',
+          'bg-blue-400 bg-opacity-15 text-blue-400': props.variant === 'blue',
+          'bg-blue-700 bg-opacity-15 text-blue-700':
+            props.variant === 'dark-blue',
+          'bg-orange-500 bg-opacity-15 text-orange-500':
+            props.variant === 'orange',
+          'bg-green-500 bg-opacity-15 text-green-500':
+            props.variant === 'green',
+          'bg-black bg-opacity-15 text-black': props.variant === 'black',
+          'bg-purple-500 bg-opacity-15 text-purple-500':
+            props.variant === 'purple',
         },
         props.className
       )}


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adjusting badge background colors and text per the new design. Screenshot:

![Screenshot 2025-03-23 at 16 33 43](https://github.com/user-attachments/assets/bd87bf90-4770-46ba-a165-74a3ad2a66c1)

Let me know your thoughts.