### PR TITLE
[Cleanup] Table Status Popovers Redesigning

### DIFF
--- a/src/components/icons/RadioChecked.tsx
+++ b/src/components/icons/RadioChecked.tsx
@@ -1,0 +1,41 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+interface Props {
+  filledColor?: string;
+  borderColor?: string;
+  size?: string;
+}
+
+export function RadioChecked({
+  size = '1.2rem',
+  filledColor = '#000',
+  borderColor = '#000',
+}: Props) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      x="0px"
+      y="0px"
+      style={{ width: size, height: size }}
+      viewBox="0 0 18 18"
+    >
+      <path
+        d="M9.00009 17C13.4184 17 17.0001 13.4183 17.0001 9C17.0001 4.58172 13.4184 1 9.00009 1C4.58181 1 1.00009 4.58172 1.00009 9C1.00009 13.4183 4.58181 17 9.00009 17Z"
+        fill={borderColor}
+      ></path>
+      <path
+        d="M9.00009 13C11.2092 13 13.0001 11.2091 13.0001 9C13.0001 6.79086 11.2092 5 9.00009 5C6.79095 5 5.00009 6.79086 5.00009 9C5.00009 11.2091 6.79095 13 9.00009 13Z"
+        fill={filledColor}
+      ></path>
+    </svg>
+  );
+}

--- a/src/components/icons/RadioUnchecked.tsx
+++ b/src/components/icons/RadioUnchecked.tsx
@@ -1,0 +1,32 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+interface Props {
+  color?: string;
+  size?: string;
+}
+
+export function RadioUnchecked({ color = '#000', size = '1.2rem' }: Props) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      x="0px"
+      y="0px"
+      style={{ width: size, height: size }}
+      viewBox="0 0 18 18"
+    >
+      <path
+        d="M9,17c-4.411,0-8-3.589-8-8S4.589,1,9,1s8,3.589,8,8-3.589,8-8,8Zm0-14.5c-3.584,0-6.5,2.916-6.5,6.5s2.916,6.5,6.5,6.5,6.5-2.916,6.5-6.5-2.916-6.5-6.5-6.5Z"
+        fill={color}
+      ></path>
+    </svg>
+  );
+}

--- a/src/pages/expenses/common/components/ExpenseCategory.tsx
+++ b/src/pages/expenses/common/components/ExpenseCategory.tsx
@@ -8,7 +8,6 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
-import { StatusBadge } from '$app/components/StatusBadge';
 import {
   hexToRGB,
   isColorLight,
@@ -19,7 +18,6 @@ import { useClickAway } from 'react-use';
 import { useColorScheme } from '$app/common/colors';
 import { Expense } from '$app/common/interfaces/expense';
 import { useExpenseCategoriesQuery } from '$app/common/queries/expense-categories';
-import { DropdownElement } from '$app/components/dropdown/DropdownElement';
 import Tippy from '@tippyjs/react/headless';
 import { Dispatch, SetStateAction } from 'react';
 import { useSave } from '../../edit/hooks/useSave';
@@ -27,6 +25,11 @@ import { useTranslation } from 'react-i18next';
 import { CreateExpenseCategoryModal } from '$app/pages/settings/expense-categories/components/CreateExpenseCategoryModal';
 import { ExpenseCategory as ExpenseCategoryType } from '$app/common/interfaces/expense-category';
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
+import styled from 'styled-components';
+import { RadioChecked } from '$app/components/icons/RadioChecked';
+import { RadioUnchecked } from '$app/components/icons/RadioUnchecked';
+import { Plus } from '$app/components/icons/Plus';
+import { ChevronDown } from '$app/components/icons/ChevronDown';
 
 interface DropdownProps {
   visible: boolean;
@@ -35,6 +38,12 @@ interface DropdownProps {
   setVisible: Dispatch<SetStateAction<boolean>>;
   expense: Expense;
 }
+
+const OptionElement = styled.div`
+  &:hover {
+    background-color: ${(props) => props.theme.hoverColor};
+  }
+`;
 
 function ExpenseCategoriesDropdown(props: DropdownProps) {
   const [t] = useTranslation();
@@ -65,7 +74,7 @@ function ExpenseCategoriesDropdown(props: DropdownProps) {
         interactive={true}
         render={() => (
           <div
-            className="border box rounded-md shadow-lg focus:outline-none"
+            className="border box rounded-md shadow-lg focus:outline-none p-1"
             style={{
               backgroundColor: colors.$1,
               borderColor: colors.$4,
@@ -74,52 +83,100 @@ function ExpenseCategoriesDropdown(props: DropdownProps) {
             }}
             onClick={(event) => event.stopPropagation()}
           >
+            <div className="flex flex-col max-h-80 overflow-y-auto">
+              {expenseCategories?.map((expenseCategory, index) => (
+                <OptionElement
+                  key={index}
+                  className="flex items-center p-2 space-x-2 rounded-sm cursor-pointer"
+                  onClick={() => {
+                    setVisible(false);
+                    save({ ...expense, category_id: expenseCategory.id });
+                  }}
+                  theme={{
+                    hoverColor: colors.$7,
+                  }}
+                >
+                  <div>
+                    {expenseCategory.id === expense.category_id ? (
+                      <RadioChecked
+                        size="1.2rem"
+                        filledColor={colors.$1}
+                        borderColor={colors.$3}
+                      />
+                    ) : (
+                      <RadioUnchecked size="1.2rem" color={colors.$17} />
+                    )}
+                  </div>
+
+                  <span className="truncate">{expenseCategory.name}</span>
+                </OptionElement>
+              ))}
+            </div>
+
+            {Boolean(!expenseCategories?.length) && (
+              <div className="font-medium text-center py-2 text-xs">
+                {t('no_records_found')}
+              </div>
+            )}
+
             {hasPermission('create_expense') && (
-              <DropdownElement
-                className="font-medium text-center py-3"
+              <OptionElement
+                className="flex items-center font-medium text-center p-2 rounded-sm cursor-pointer"
                 onClick={() => {
                   setIsModalOpen(true);
                   setVisible(false);
                 }}
-                cypressRef="newExpenseCategoryAction"
+                theme={{
+                  hoverColor: colors.$7,
+                }}
               >
-                {t('new_expense_category')}
-              </DropdownElement>
-            )}
+                <div className="flex items-center gap-2">
+                  <Plus color={colors.$17} size="1.2rem" />
 
-            <div className="flex flex-col max-h-80 overflow-y-auto">
-              {expenseCategories?.map(
-                (expenseCategory, index) =>
-                  expenseCategory.id !== expense.category_id && (
-                    <DropdownElement
-                      key={index}
-                      onClick={() => {
-                        setVisible(false);
-                        save({ ...expense, category_id: expenseCategory.id });
-                      }}
-                    >
-                      {expenseCategory.name}
-                    </DropdownElement>
-                  )
-              )}
-            </div>
+                  <span>{t('create_new')}</span>
+                </div>
+              </OptionElement>
+            )}
           </div>
         )}
         visible={visible}
       >
-        <div className="cursor-pointer" data-cy="expenseCategoryBadge">
-          <StatusBadge
-            for={{}}
-            code={expense.category?.name || (t('uncategorized') as string)}
+        <div
+          className="flex items-center cursor-pointer"
+          data-cy="expenseCategoryBadge"
+        >
+          <div
+            className="text-xs rounded-l px-2 py-1 border-r border-white font-medium"
             style={{
-              color: adjustColorDarkness(hex, darknessAmount),
-              backgroundColor: expense.category?.color || '',
+              color: expense.category?.color
+                ? adjustColorDarkness(hex, darknessAmount)
+                : '#1f2937',
+              backgroundColor: expense.category?.color || '#f3f4f6',
+            }}
+          >
+            {expense.category?.name || (t('uncategorized') as string)}
+          </div>
+
+          <div
+            className="flex items-center justify-center rounded-r py-1 h-full"
+            style={{
+              backgroundColor: expense.category?.color || '#f3f4f6',
+              width: '1.5rem',
             }}
             onClick={() =>
               !isFormBusy &&
               setVisible((currentVisibility) => !currentVisibility)
             }
-          />
+          >
+            <ChevronDown
+              color={
+                expense.category?.color
+                  ? adjustColorDarkness(hex, darknessAmount)
+                  : '#1f2937'
+              }
+              size="1rem"
+            />
+          </div>
         </div>
       </Tippy>
 

--- a/src/pages/tasks/common/components/TaskStatus.tsx
+++ b/src/pages/tasks/common/components/TaskStatus.tsx
@@ -23,6 +23,8 @@ import { useClickAway } from 'react-use';
 import { TaskStatusesDropdown } from './TaskStatusesDropdown';
 import { useStatusThemeColorScheme } from '$app/pages/settings/user/components/StatusColorTheme';
 import { Tooltip } from '$app/components/Tooltip';
+import { ChevronDown } from '$app/components/icons/ChevronDown';
+import { useColorScheme } from '$app/common/colors';
 
 interface Props {
   entity: Task;
@@ -32,6 +34,8 @@ export function TaskStatus(props: Props) {
   const [t] = useTranslation();
 
   const ref = useRef(null);
+
+  const colors = useColorScheme();
 
   const adjustColorDarkness = useAdjustColorDarkness();
   const statusThemeColors = useStatusThemeColorScheme();
@@ -87,15 +91,19 @@ export function TaskStatus(props: Props) {
 
     return (
       <div ref={ref} onClick={(event) => event.stopPropagation()}>
-        <Tooltip
-          width="auto"
-          message={t('change_status') as string}
-          withoutArrow
-          placement="bottom"
-        >
-          <StatusBadge
-            for={{}}
-            code={status.name}
+        <div className="flex items-center">
+          <div
+            className="text-xs rounded-l px-2 py-1 border-r border-white font-medium"
+            style={{
+              color: adjustColorDarkness(hex, darknessAmount),
+              backgroundColor: status.color,
+            }}
+          >
+            {status.name}
+          </div>
+
+          <div
+            className="flex items-center justify-center rounded-r px-1 py-1 h-full"
             style={{
               color: adjustColorDarkness(hex, darknessAmount),
               backgroundColor: status.color,
@@ -103,8 +111,13 @@ export function TaskStatus(props: Props) {
             onClick={() =>
               !isFormBusy && setVisibleDropdown((current) => !current)
             }
-          />
-        </Tooltip>
+          >
+            <ChevronDown
+              color={adjustColorDarkness(hex, darknessAmount)}
+              size="1rem"
+            />
+          </div>
+        </div>
 
         <TaskStatusesDropdown
           visible={visibleDropdown}

--- a/src/pages/tasks/common/components/TaskStatus.tsx
+++ b/src/pages/tasks/common/components/TaskStatus.tsx
@@ -11,7 +11,6 @@
 import { Badge } from '$app/components/Badge';
 import { useTranslation } from 'react-i18next';
 import { Task } from '$app/common/interfaces/task';
-import { StatusBadge } from '$app/components/StatusBadge';
 import { parseTimeLog } from '$app/pages/tasks/common/helpers/calculate-time';
 import {
   hexToRGB,
@@ -22,7 +21,6 @@ import { useRef, useState } from 'react';
 import { useClickAway } from 'react-use';
 import { TaskStatusesDropdown } from './TaskStatusesDropdown';
 import { useStatusThemeColorScheme } from '$app/pages/settings/user/components/StatusColorTheme';
-import { Tooltip } from '$app/components/Tooltip';
 import { ChevronDown } from '$app/components/icons/ChevronDown';
 import { useColorScheme } from '$app/common/colors';
 
@@ -103,10 +101,11 @@ export function TaskStatus(props: Props) {
           </div>
 
           <div
-            className="flex items-center justify-center rounded-r px-1 py-1 h-full"
+            className="flex items-center justify-center rounded-r py-1 h-full"
             style={{
               color: adjustColorDarkness(hex, darknessAmount),
               backgroundColor: status.color,
+              width: '1.5rem',
             }}
             onClick={() =>
               !isFormBusy && setVisibleDropdown((current) => !current)
@@ -132,20 +131,23 @@ export function TaskStatus(props: Props) {
 
   return (
     <div ref={ref} onClick={(event) => event.stopPropagation()}>
-      <Tooltip
-        width="auto"
-        message={t('change_status') as string}
-        withoutArrow
-        placement="bottom"
-      >
-        <StatusBadge
-          for={{}}
-          code="logged"
+      <div className="flex items-center">
+        <div className="text-xs rounded-l px-2 py-1 border-r border-white font-medium bg-gray-100 text-gray-800">
+          {t('logged')}
+        </div>
+
+        <div
+          className="flex items-center justify-center rounded-r py-1 h-full bg-gray-100"
           onClick={() =>
             !isFormBusy && setVisibleDropdown((current) => !current)
           }
-        />
-      </Tooltip>
+          style={{
+            width: '1.5rem',
+          }}
+        >
+          <ChevronDown color="#1f2937" size="1rem" />
+        </div>
+      </div>
 
       <TaskStatusesDropdown
         visible={visibleDropdown}

--- a/src/pages/tasks/common/components/TaskStatusesDropdown.tsx
+++ b/src/pages/tasks/common/components/TaskStatusesDropdown.tsx
@@ -66,35 +66,39 @@ export function TaskStatusesDropdown(props: Props) {
             style={{
               backgroundColor: colors.$1,
               borderColor: colors.$4,
-              minWidth: '14rem',
-              maxWidth: '15rem',
+              minWidth: '13rem',
+              maxWidth: '20rem',
             }}
           >
-            {taskStatuses?.data.map((taskStatus, index) => (
-              <OptionElement
-                key={index}
-                className="flex items-center p-2 space-x-2 rounded-sm"
-                onClick={() => {
-                  setVisible(false);
-                  handleUpdateTask({ ...task, status_id: taskStatus.id });
-                }}
-                theme={{
-                  hoverColor: colors.$7,
-                }}
-              >
-                {taskStatus.id === task.status_id ? (
-                  <RadioChecked
-                    size="1.1rem"
-                    filledColor={colors.$1}
-                    borderColor={colors.$3}
-                  />
-                ) : (
-                  <RadioUnchecked size="1.1rem" color={colors.$5} />
-                )}
+            <div className="flex flex-col max-h-80 overflow-y-auto">
+              {taskStatuses?.data.map((taskStatus, index) => (
+                <OptionElement
+                  key={index}
+                  className="flex items-center p-2 space-x-2 rounded-sm"
+                  onClick={() => {
+                    setVisible(false);
+                    handleUpdateTask({ ...task, status_id: taskStatus.id });
+                  }}
+                  theme={{
+                    hoverColor: colors.$7,
+                  }}
+                >
+                  <div>
+                    {taskStatus.id === task.status_id ? (
+                      <RadioChecked
+                        size="1.2rem"
+                        filledColor={colors.$1}
+                        borderColor={colors.$3}
+                      />
+                    ) : (
+                      <RadioUnchecked size="1.2rem" color={colors.$17} />
+                    )}
+                  </div>
 
-                <span>{taskStatus.name}</span>
-              </OptionElement>
-            ))}
+                  <span className="truncate">{taskStatus.name}</span>
+                </OptionElement>
+              ))}
+            </div>
 
             {Boolean(!taskStatuses?.data.length) && (
               <div className="font-medium text-center py-2 text-xs">
@@ -114,7 +118,7 @@ export function TaskStatusesDropdown(props: Props) {
                 }}
               >
                 <div className="flex items-center gap-2">
-                  <Plus color={colors.$5} size="1.1rem" />
+                  <Plus color={colors.$17} size="1.2rem" />
 
                   <span>{t('create_new')}</span>
                 </div>

--- a/src/pages/tasks/common/components/TaskStatusesDropdown.tsx
+++ b/src/pages/tasks/common/components/TaskStatusesDropdown.tsx
@@ -66,20 +66,20 @@ export function TaskStatusesDropdown(props: Props) {
             style={{
               backgroundColor: colors.$1,
               borderColor: colors.$4,
-              minWidth: '12rem',
-              maxWidth: '14.7rem',
+              minWidth: '14rem',
+              maxWidth: '15rem',
             }}
           >
             {taskStatuses?.data.map((taskStatus, index) => (
               <OptionElement
                 key={index}
-                className="flex items-center p-2 space-x-2"
+                className="flex items-center p-2 space-x-2 rounded-sm"
                 onClick={() => {
                   setVisible(false);
                   handleUpdateTask({ ...task, status_id: taskStatus.id });
                 }}
                 theme={{
-                  hoverColor: colors.$4,
+                  hoverColor: colors.$7,
                 }}
               >
                 {taskStatus.id === task.status_id ? (
@@ -110,7 +110,7 @@ export function TaskStatusesDropdown(props: Props) {
                   setVisible(false);
                 }}
                 theme={{
-                  hoverColor: colors.$4,
+                  hoverColor: colors.$7,
                 }}
               >
                 <div className="flex items-center gap-2">

--- a/src/pages/tasks/common/components/TaskStatusesDropdown.tsx
+++ b/src/pages/tasks/common/components/TaskStatusesDropdown.tsx
@@ -10,7 +10,6 @@
 
 import { useColorScheme } from '$app/common/colors';
 import { useTaskStatusesQuery } from '$app/common/queries/task-statuses';
-import { DropdownElement } from '$app/components/dropdown/DropdownElement';
 import Tippy from '@tippyjs/react/headless';
 import { Dispatch, SetStateAction, useState } from 'react';
 import { useUpdateTask } from '../hooks/useUpdateTask';
@@ -19,6 +18,16 @@ import { useTranslation } from 'react-i18next';
 import { CreateTaskStatusModal } from '$app/pages/settings/task-statuses/components/CreateTaskStatusModal';
 import { TaskStatus } from '$app/common/interfaces/task-status';
 import { useAdmin } from '$app/common/hooks/permissions/useHasPermission';
+import { Plus } from '$app/components/icons/Plus';
+import styled from 'styled-components';
+import { RadioChecked } from '$app/components/icons/RadioChecked';
+import { RadioUnchecked } from '$app/components/icons/RadioUnchecked';
+
+const OptionElement = styled.div`
+  &:hover {
+    background-color: ${(props) => props.theme.hoverColor};
+  }
+`;
 
 interface Props {
   visible: boolean;
@@ -53,7 +62,7 @@ export function TaskStatusesDropdown(props: Props) {
         interactive={true}
         render={() => (
           <div
-            className="border box rounded-md shadow-lg focus:outline-none"
+            className="border box rounded-md shadow-lg focus:outline-none p-1"
             style={{
               backgroundColor: colors.$1,
               borderColor: colors.$4,
@@ -61,37 +70,55 @@ export function TaskStatusesDropdown(props: Props) {
               maxWidth: '14.7rem',
             }}
           >
-            {(isAdmin || isOwner) && (
-              <DropdownElement
-                className="font-medium text-center py-3"
+            {taskStatuses?.data.map((taskStatus, index) => (
+              <OptionElement
+                key={index}
+                className="flex items-center p-2 space-x-2"
                 onClick={() => {
-                  setIsModalOpen(true);
                   setVisible(false);
+                  handleUpdateTask({ ...task, status_id: taskStatus.id });
+                }}
+                theme={{
+                  hoverColor: colors.$4,
                 }}
               >
-                {t('new_task_status')}
-              </DropdownElement>
-            )}
+                {taskStatus.id === task.status_id ? (
+                  <RadioChecked
+                    size="1.1rem"
+                    filledColor={colors.$1}
+                    borderColor={colors.$3}
+                  />
+                ) : (
+                  <RadioUnchecked size="1.1rem" color={colors.$5} />
+                )}
 
-            {taskStatuses?.data.map(
-              (taskStatus, index) =>
-                taskStatus.id !== task.status_id && (
-                  <DropdownElement
-                    key={index}
-                    onClick={() => {
-                      setVisible(false);
-                      handleUpdateTask({ ...task, status_id: taskStatus.id });
-                    }}
-                  >
-                    {taskStatus.name}
-                  </DropdownElement>
-                )
-            )}
+                <span>{taskStatus.name}</span>
+              </OptionElement>
+            ))}
 
             {Boolean(!taskStatuses?.data.length) && (
               <div className="font-medium text-center py-2 text-xs">
                 {t('no_records_found')}
               </div>
+            )}
+
+            {(isAdmin || isOwner) && (
+              <OptionElement
+                className="flex items-center font-medium text-center p-2 rounded-sm"
+                onClick={() => {
+                  setIsModalOpen(true);
+                  setVisible(false);
+                }}
+                theme={{
+                  hoverColor: colors.$4,
+                }}
+              >
+                <div className="flex items-center gap-2">
+                  <Plus color={colors.$5} size="1.1rem" />
+
+                  <span>{t('create_new')}</span>
+                </div>
+              </OptionElement>
             )}
           </div>
         )}


### PR DESCRIPTION
@beganovich @turbo124 The PR includes redesigning status change popovers for expenses and tasks using the Figma design. Screenshot:

![Screenshot 2025-03-24 at 14 30 58](https://github.com/user-attachments/assets/9a413e22-6665-461e-a23b-43657e57eb14)

Let me know your thoughts.