### PR TITLE
[Bugfix] Status Dropdown Dark Mode Fixes

### DIFF
--- a/src/components/datatables/Actions.tsx
+++ b/src/components/datatables/Actions.tsx
@@ -198,6 +198,7 @@ export function Actions(props: Props) {
           !props.withoutStatusFilter && (
             <Select
               styles={{
+                ...customStyles,
                 multiValue: (styles, { data }) =>
                   merge(styles, {
                     backgroundColor: data.backgroundColor,

--- a/src/components/datatables/Actions.tsx
+++ b/src/components/datatables/Actions.tsx
@@ -197,15 +197,7 @@ export function Actions(props: Props) {
           props.defaultOptions &&
           !props.withoutStatusFilter && (
             <Select
-              styles={{
-                ...customStyles,
-                multiValue: (styles, { data }) =>
-                  merge(styles, {
-                    backgroundColor: data.backgroundColor,
-                    color: data.color,
-                    borderRadius: '3px',
-                  }),
-              }}
+              styles={customStyles}
               defaultValue={props.defaultOptions}
               onChange={(options) => onStatusChange(options)}
               placeholder={t('status')}


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for styling the status dropdown for tables in dark mode. Screenshot:

![Screenshot 2025-03-24 at 05 16 40](https://github.com/user-attachments/assets/59243964-111f-471d-b537-cdec03909d7f)

Let me know your thoughts.