### PR TITLE
[Cleanup] General Table Styling Adjustment

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -123,7 +123,7 @@ export function App() {
   };
 
   useEffect(() => {
-    document.body.style.backgroundColor = colorScheme.$2;
+    document.body.style.backgroundColor = colorScheme.$23;
     document.body.style.colorScheme = colorScheme.$0;
   }, [colorScheme]);
 

--- a/src/common/colors.ts
+++ b/src/common/colors.ts
@@ -52,6 +52,8 @@ export const $1 = {
   $20: '#323236', // Dropdown element hover background color
   $21: '#1f2e41', // Divider color
   $22: '#a1a1aa', // Label color
+  $23: '#121212', // Content background color
+  $24: '#323236', // Border color
 };
 
 export const $2 = {
@@ -79,6 +81,8 @@ export const $2 = {
   $20: '#09090B13', // Dropdown element hover background color
   $21: '#09090B1A', // Divider color
   $22: '#717179', // Label color
+  $23: '#F4F4F5', // Content background color
+  $24: '#09090B26', // Border color
 };
 
 export const colorSchemeAtom = atomWithStorage('colorScheme', $2);

--- a/src/common/colors.ts
+++ b/src/common/colors.ts
@@ -46,7 +46,7 @@ export const $1 = {
   $14: '#121212', // Navigation bar background color
   $15: '#323236', // Light gray background
   $16: '#A1A1AA', // Dark gray icon
-  $17: '#9D9DA8', // Placeholder text
+  $17: '#9D9DA8', // Placeholder text, table header text color
   $18: '#FFFFFF', // Button background color
   $19: '#323236', // Light border color
   $20: '#323236', // Dropdown element hover background color
@@ -72,7 +72,7 @@ export const $2 = {
   $14: '#27272A', // Navigation bar background color
   $15: '#E4E4E7', // Light gray background
   $16: '#717179', // Dark gray icon
-  $17: '#A1A1AA', // Placeholder text
+  $17: '#A1A1AA', // Placeholder text, table header text color
   $18: '#27272A', // Button background color
   $19: '#09090B12', // Light border color
   $20: '#09090B13', // Dropdown element hover background color

--- a/src/common/hooks/usePreferences.tsx
+++ b/src/common/hooks/usePreferences.tsx
@@ -144,7 +144,7 @@ export function usePreferences() {
               onClick={() => setIsVisible(true)}
               style={{
                 backgroundColor: colors.$1,
-                borderColor: colors.$5,
+                borderColor: colors.$20,
               }}
             >
               <Gear color={colors.$3} />

--- a/src/common/hooks/usePreferences.tsx
+++ b/src/common/hooks/usePreferences.tsx
@@ -144,7 +144,7 @@ export function usePreferences() {
               onClick={() => setIsVisible(true)}
               style={{
                 backgroundColor: colors.$1,
-                borderColor: colors.$20,
+                borderColor: colors.$24,
               }}
             >
               <Gear color={colors.$3} />

--- a/src/common/hooks/useResizeColumn.ts
+++ b/src/common/hooks/useResizeColumn.ts
@@ -74,18 +74,17 @@ export function useResizeColumn(resizable: string | undefined) {
 
   const handleMouseMove = useCallback(
     (e: MouseEvent | React.MouseEvent) => {
-      document.body.style.cursor = inResizeZone(e) && resizable ? 'ew-resize' : '';
+      document.body.style.cursor =
+        inResizeZone(e) && resizable ? 'ew-resize' : '';
 
       if (!isResizing || !thRef.current || currentWidth === null) return;
 
       const dx = e.clientX - startX;
       const newWidth = startWidth + dx - 45; // Safe offset for snapping to the right when starting the drag
 
-      console.log({ dx, newWidth });
-      
       if (newWidth >= 1) {
         setCurrentWidth(newWidth);
-        
+
         thRef.current.style.width = `${newWidth}px`;
       }
     },

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -102,7 +102,6 @@ interface StyleOptions {
   tBodyStyle?: CSSProperties;
   thClassName?: string;
   tdClassName?: string;
-  addRowSeparator?: boolean;
   thStyle?: CSSProperties;
   withoutThVerticalPadding?: boolean;
   useOnlyCurrentSortDirectionIcon?: boolean;
@@ -110,7 +109,6 @@ interface StyleOptions {
   disableThUppercase?: boolean;
   descIcon?: ReactNode;
   ascIcon?: ReactNode;
-  rowSeparatorColor?: string;
 }
 
 interface Props<T> extends CommonProps {
@@ -691,12 +689,11 @@ export function DataTable<T extends object>(props: Props<T>) {
         <Tbody style={styleOptions?.tBodyStyle}>
           {isLoading && (
             <Tr
-              className={classNames({
-                'border-b border-gray-200': styleOptions?.addRowSeparator,
+              className={classNames('border-b', {
                 'last:border-b-0': hasVerticalOverflow,
               })}
               style={{
-                borderColor: styleOptions?.rowSeparatorColor,
+                borderColor: colors.$20,
               }}
             >
               <Td colSpan={100}>
@@ -707,12 +704,11 @@ export function DataTable<T extends object>(props: Props<T>) {
 
           {isError && (
             <Tr
-              className={classNames({
-                'border-b border-gray-200': styleOptions?.addRowSeparator,
+              className={classNames('border-b', {
                 'last:border-b-0': hasVerticalOverflow,
               })}
               style={{
-                borderColor: styleOptions?.rowSeparatorColor,
+                borderColor: colors.$20,
               }}
             >
               <Td className="text-center" colSpan={100}>
@@ -723,12 +719,11 @@ export function DataTable<T extends object>(props: Props<T>) {
 
           {data && data.data.data.length === 0 && (
             <Tr
-              className={classNames({
-                'border-b border-gray-200': styleOptions?.addRowSeparator,
+              className={classNames('border-b', {
                 'last:border-b-0': hasVerticalOverflow,
               })}
               style={{
-                borderColor: styleOptions?.rowSeparatorColor,
+                borderColor: colors.$20,
               }}
             >
               <Td className={styleOptions?.tdClassName} colSpan={100}>
@@ -741,13 +736,12 @@ export function DataTable<T extends object>(props: Props<T>) {
             data?.data?.data?.map((resource: any, index: number) => (
               <Tr
                 key={index}
-                className={classNames({
-                  'border-b border-gray-200': styleOptions?.addRowSeparator,
+                className={classNames('border-b', {
                   'last:border-b-0': hasVerticalOverflow,
                 })}
-                backgroundColor={index % 2 === 0 ? themeColors.$7 : ''}
+                backgroundColor={index % 2 === 0 ? colors.$7 : ''}
                 style={{
-                  borderColor: styleOptions?.rowSeparatorColor,
+                  borderColor: colors.$20,
                 }}
               >
                 {!props.withoutActions && !hideEditableOptions && (

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -742,6 +742,9 @@ export function DataTable<T extends object>(props: Props<T>) {
                 backgroundColor={index % 2 === 0 ? colors.$7 : ''}
                 style={{
                   borderColor: colors.$20,
+                  backgroundColor: selected.includes(resource.id)
+                    ? colors.$7
+                    : 'transparent',
                 }}
               >
                 {!props.withoutActions && !hideEditableOptions && (

--- a/src/components/HelpWidget.tsx
+++ b/src/components/HelpWidget.tsx
@@ -153,8 +153,6 @@ export function $help(id: string, options?: HelpOptions) {
     `div#help-widget-${id}`
   ) as HTMLDivElement | null;
 
-  console.log(div);
-
   if (div) {
     div.classList.toggle('hidden');
 

--- a/src/components/datatables/Actions.tsx
+++ b/src/components/datatables/Actions.tsx
@@ -333,7 +333,7 @@ export function Actions(props: Props) {
     control: (base) => ({
       ...base,
       backgroundColor: colors.$1,
-      borderColor: colors.$20,
+      borderColor: colors.$24,
       borderRadius: '0.375rem',
       padding: '0 6px',
     }),

--- a/src/components/datatables/Actions.tsx
+++ b/src/components/datatables/Actions.tsx
@@ -333,7 +333,7 @@ export function Actions(props: Props) {
     control: (base) => ({
       ...base,
       backgroundColor: colors.$1,
-      borderColor: colors.$5,
+      borderColor: colors.$20,
       borderRadius: '0.375rem',
       padding: '0 6px',
     }),

--- a/src/components/datatables/DateRangePicker.tsx
+++ b/src/components/datatables/DateRangePicker.tsx
@@ -102,7 +102,7 @@ export function DateRangePicker(props: Props) {
             style={{
               backgroundColor: colors.$2,
               border: `1px solid ${colors.$5}`,
-              width: 300
+              width: 300,
             }}
             onClick={(event) => event.stopPropagation()}
           >
@@ -139,7 +139,7 @@ export function DateRangePicker(props: Props) {
         >
           <Icon
             element={Calendar}
-            color={isCurrentDateRangeActive() ? 'lightgreen' : 'white'}
+            color={isCurrentDateRangeActive() ? '#22c55e' : colors.$17}
             style={{ width: '1.4rem', height: '1.4rem' }}
           />
         </div>

--- a/src/components/dropdown/Dropdown.tsx
+++ b/src/components/dropdown/Dropdown.tsx
@@ -126,7 +126,7 @@ export function Dropdown(props: Props) {
             theme={{
               backgroundColor: colors.$18,
               color: colors.$1,
-              borderColor: colors.$5,
+              borderColor: colors.$24,
             }}
             type="button"
             disabled={props.disabled}

--- a/src/components/forms/Button.tsx
+++ b/src/components/forms/Button.tsx
@@ -75,7 +75,7 @@ export function Button(props: Props) {
         theme={{
           backgroundColor: props.type === 'primary' ? colors.$18 : colors.$1,
           color: props.type === 'primary' ? colors.$1 : colors.$3,
-          borderColor: props.type === 'primary' ? 'transparent' : colors.$20,
+          borderColor: props.type === 'primary' ? 'transparent' : colors.$24,
           hoverColor: props.type === 'primary' ? colors.$18 : colors.$4,
         }}
         className={classNames(
@@ -100,7 +100,7 @@ export function Button(props: Props) {
       theme={{
         backgroundColor: props.type === 'primary' ? colors.$18 : colors.$1,
         color: props.type === 'primary' ? colors.$1 : colors.$3,
-        borderColor: props.type === 'primary' ? 'transparent' : colors.$20,
+        borderColor: props.type === 'primary' ? 'transparent' : colors.$24,
         hoverColor: props.type === 'primary' ? colors.$18 : colors.$4,
       }}
       className={classNames(

--- a/src/components/forms/Button.tsx
+++ b/src/components/forms/Button.tsx
@@ -75,7 +75,7 @@ export function Button(props: Props) {
         theme={{
           backgroundColor: props.type === 'primary' ? colors.$18 : colors.$1,
           color: props.type === 'primary' ? colors.$1 : colors.$3,
-          borderColor: props.type === 'primary' ? 'transparent' : colors.$5,
+          borderColor: props.type === 'primary' ? 'transparent' : colors.$20,
           hoverColor: props.type === 'primary' ? colors.$18 : colors.$4,
         }}
         className={classNames(
@@ -100,7 +100,7 @@ export function Button(props: Props) {
       theme={{
         backgroundColor: props.type === 'primary' ? colors.$18 : colors.$1,
         color: props.type === 'primary' ? colors.$1 : colors.$3,
-        borderColor: props.type === 'primary' ? 'transparent' : colors.$5,
+        borderColor: props.type === 'primary' ? 'transparent' : colors.$20,
         hoverColor: props.type === 'primary' ? colors.$18 : colors.$4,
       }}
       className={classNames(

--- a/src/components/forms/InputField.tsx
+++ b/src/components/forms/InputField.tsx
@@ -81,7 +81,7 @@ export function InputField(props: Props) {
         <DebounceInput
           style={{
             backgroundColor: colors.$1,
-            borderColor: colors.$5,
+            borderColor: colors.$20,
             color: colors.$3,
             ...props.style,
           }}

--- a/src/components/forms/InputField.tsx
+++ b/src/components/forms/InputField.tsx
@@ -81,7 +81,6 @@ export function InputField(props: Props) {
         <DebounceInput
           style={{
             backgroundColor: colors.$1,
-            borderColor: colors.$20,
             color: colors.$3,
             ...props.style,
           }}
@@ -100,7 +99,7 @@ export function InputField(props: Props) {
             `w-full py-2 px-3 rounded-md text-sm disabled:opacity-75 disabled:cursor-not-allowed focus:outline-none focus:ring-0 ${props.className}`,
             {
               'border border-gray-300': props.border !== false,
-              'border-[#d1d5db] focus:border-black': !reactSettings.dark_mode,
+              'border-[#09090B26] focus:border-black': !reactSettings.dark_mode,
               'border-[#1f2e41] focus:border-white': reactSettings.dark_mode,
             }
           )}

--- a/src/components/forms/SelectField.tsx
+++ b/src/components/forms/SelectField.tsx
@@ -208,7 +208,7 @@ export function SelectField(props: SelectProps) {
                 style={{
                   height: '2.5rem',
                   backgroundColor: colors.$1,
-                  borderColor: isFocused ? '#2463eb' : colors.$20,
+                  borderColor: isFocused ? '#2463eb' : colors.$24,
                   ...controlStyle,
                 }}
                 {...innerProps}

--- a/src/components/forms/SelectField.tsx
+++ b/src/components/forms/SelectField.tsx
@@ -208,7 +208,7 @@ export function SelectField(props: SelectProps) {
                 style={{
                   height: '2.5rem',
                   backgroundColor: colors.$1,
-                  borderColor: isFocused ? '#2463eb' : colors.$5,
+                  borderColor: isFocused ? '#2463eb' : colors.$20,
                   ...controlStyle,
                 }}
                 {...innerProps}

--- a/src/components/forms/SelectField.tsx
+++ b/src/components/forms/SelectField.tsx
@@ -208,7 +208,7 @@ export function SelectField(props: SelectProps) {
                 style={{
                   height: '2.5rem',
                   backgroundColor: colors.$1,
-                  borderColor: isFocused ? '#2463eb' : colors.$24,
+                  borderColor: isFocused ? colors.$3 : colors.$24,
                   ...controlStyle,
                 }}
                 {...innerProps}

--- a/src/components/icons/ChevronUp.tsx
+++ b/src/components/icons/ChevronUp.tsx
@@ -8,21 +8,17 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
-interface Params {
-  size?: string;
+interface Props {
   color?: string;
-  withoutColor?: boolean;
+  size?: string;
   strokeWidth?: string;
 }
 
-export function ChevronDown(props: Params) {
-  const {
-    color = '#000',
-    size = '1.2rem',
-    withoutColor = false,
-    strokeWidth = '2',
-  } = props;
-
+export function ChevronUp({
+  color = '#000',
+  size = '1.2rem',
+  strokeWidth = '2',
+}: Props) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -33,9 +29,9 @@ export function ChevronDown(props: Params) {
       viewBox="0 0 20 20"
     >
       <polyline
-        points="3.5 7.5 10 14 16.5 7.5"
+        points="16.5 12.5 10 6 3.5 12.5"
         fill="none"
-        {...(!withoutColor && { stroke: color })}
+        stroke={color}
         strokeLinecap="round"
         strokeLinejoin="round"
         strokeWidth={strokeWidth}

--- a/src/components/import/ImportButton.tsx
+++ b/src/components/import/ImportButton.tsx
@@ -38,7 +38,7 @@ export function ImportButton(props: Props) {
         className="flex items-center space-x-2.5 border rounded-md px-3 2xl:px-4 py-2 shadow-sm"
         theme={{
           hoverColor: colors.$4,
-          borderColor: colors.$5,
+          borderColor: colors.$20,
           backgroundColor: colors.$1,
         }}
       >

--- a/src/components/import/ImportButton.tsx
+++ b/src/components/import/ImportButton.tsx
@@ -38,7 +38,7 @@ export function ImportButton(props: Props) {
         className="flex items-center space-x-2.5 border rounded-md px-3 2xl:px-4 py-2 shadow-sm"
         theme={{
           hoverColor: colors.$4,
-          borderColor: colors.$20,
+          borderColor: colors.$24,
           backgroundColor: colors.$1,
         }}
       >

--- a/src/components/layouts/Default.tsx
+++ b/src/components/layouts/Default.tsx
@@ -580,7 +580,7 @@ export function Default(props: Props) {
             )}
 
           <div
-            style={{ color: colors.$3, backgroundColor: colors.$2 }}
+            style={{ color: colors.$3, backgroundColor: colors.$23 }}
             className="p-4 md:py-8 xl:p-8 dark:text-gray-100"
           >
             {props.children}

--- a/src/components/tables/Pagination.tsx
+++ b/src/components/tables/Pagination.tsx
@@ -76,7 +76,7 @@ export function Pagination(props: Props) {
             theme={{
               hoverColor: colors.$4,
               backgroundColor: colors.$1,
-              borderColor: colors.$20,
+              borderColor: colors.$24,
             }}
             onClick={() => goToPage(1)}
           >
@@ -88,7 +88,7 @@ export function Pagination(props: Props) {
             theme={{
               hoverColor: colors.$4,
               backgroundColor: colors.$1,
-              borderColor: colors.$20,
+              borderColor: colors.$24,
             }}
             onClick={() => goToPage(props.currentPage - 1)}
           >
@@ -106,7 +106,7 @@ export function Pagination(props: Props) {
             theme={{
               hoverColor: colors.$4,
               backgroundColor: colors.$1,
-              borderColor: colors.$20,
+              borderColor: colors.$24,
             }}
             onClick={() => goToPage(props.currentPage + 1)}
           >
@@ -118,7 +118,7 @@ export function Pagination(props: Props) {
             theme={{
               hoverColor: colors.$4,
               backgroundColor: colors.$1,
-              borderColor: colors.$20,
+              borderColor: colors.$24,
             }}
             onClick={() => goToPage(props.totalPages)}
           >

--- a/src/components/tables/Pagination.tsx
+++ b/src/components/tables/Pagination.tsx
@@ -76,7 +76,7 @@ export function Pagination(props: Props) {
             theme={{
               hoverColor: colors.$4,
               backgroundColor: colors.$1,
-              borderColor: colors.$5,
+              borderColor: colors.$20,
             }}
             onClick={() => goToPage(1)}
           >
@@ -88,7 +88,7 @@ export function Pagination(props: Props) {
             theme={{
               hoverColor: colors.$4,
               backgroundColor: colors.$1,
-              borderColor: colors.$5,
+              borderColor: colors.$20,
             }}
             onClick={() => goToPage(props.currentPage - 1)}
           >
@@ -106,7 +106,7 @@ export function Pagination(props: Props) {
             theme={{
               hoverColor: colors.$4,
               backgroundColor: colors.$1,
-              borderColor: colors.$5,
+              borderColor: colors.$20,
             }}
             onClick={() => goToPage(props.currentPage + 1)}
           >
@@ -118,7 +118,7 @@ export function Pagination(props: Props) {
             theme={{
               hoverColor: colors.$4,
               backgroundColor: colors.$1,
-              borderColor: colors.$5,
+              borderColor: colors.$20,
             }}
             onClick={() => goToPage(props.totalPages)}
           >

--- a/src/components/tables/Table.tsx
+++ b/src/components/tables/Table.tsx
@@ -103,7 +103,7 @@ export function Table(props: Props) {
       >
         <div
           className={classNames(
-            'overflow-hidden border rounded border-b border-t',
+            'overflow-hidden border rounded-md border-b border-t',
             {
               'border-b-0': props.withoutBottomBorder,
               'border-t-0': props.withoutTopBorder,
@@ -114,7 +114,7 @@ export function Table(props: Props) {
           style={{
             backgroundColor: colors.$1,
             color: colors.$3,
-            borderColor: colors.$20,
+            borderColor: colors.$24,
           }}
         >
           <div

--- a/src/components/tables/Table.tsx
+++ b/src/components/tables/Table.tsx
@@ -23,10 +23,13 @@ interface Props extends CommonProps {
   isDataLoading?: boolean;
   resizable?: string;
   isReadyForHeightCalculation?: boolean;
+  withoutBorder?: boolean;
 }
 
 export function Table(props: Props) {
   const { onVerticalOverflowChange } = props;
+
+  const colors = useColorScheme();
 
   const [tableParentHeight, setTableParentHeight] = useState<number>();
   const [tableHeight, setTableHeight] = useState<number>();
@@ -87,8 +90,6 @@ export function Table(props: Props) {
     }
   }, [isVerticallyOverflow, props.isReadyForHeightCalculation]);
 
-  const colors = useColorScheme();
-
   return (
     <div
       className={classNames('flex flex-col', {
@@ -113,12 +114,12 @@ export function Table(props: Props) {
           style={{
             backgroundColor: colors.$1,
             color: colors.$3,
-            borderColor: colors.$4,
+            borderColor: colors.$20,
           }}
         >
           <div
             ref={handleTableParentHeight}
-            className={`overflow-auto min-w-full rounded ${props.className}`}
+            className={`overflow-auto min-w-full rounded-md shadow-sm ${props.className}`}
             style={{
               ...props.style,
               height: manualTableHeight,

--- a/src/components/tables/Th.tsx
+++ b/src/components/tables/Th.tsx
@@ -68,7 +68,7 @@ export function Th$(props: Props) {
     <th
       ref={thRef}
       style={{
-        color: props.textColor || colors.$9,
+        color: props.textColor || colors.$17,
         borderColor: colors.$4,
         width: currentWidth,
         ...props.style,
@@ -76,13 +76,12 @@ export function Th$(props: Props) {
       onMouseDown={handleMouseDown}
       onDoubleClick={handleDoubleClick}
       className={classNames(
-        `px-2 lg:px-2.5 xl:px-4 text-left font-medium tracking-wider whitespace-nowrap ${props.className}`,
+        `px-2 lg:px-2.5 xl:px-4 text-left font-normal tracking-wider whitespace-nowrap ${props.className}`,
         {
           'border-r relative': props.resizable,
-          uppercase: !props.disableUppercase,
-          'py-2': !props.withoutVerticalPadding,
-          'text-xs': props.textSize === 'extraSmall' || !props.textSize,
-          'text-sm': props.textSize === 'small',
+          'py-2.5': !props.withoutVerticalPadding,
+          'text-xs': props.textSize === 'extraSmall',
+          'text-sm': props.textSize === 'small' || !props.textSize,
         }
       )}
       onMouseMove={handleMouseMove}

--- a/src/components/tables/Th.tsx
+++ b/src/components/tables/Th.tsx
@@ -15,6 +15,7 @@ import { useColorScheme } from '$app/common/colors';
 import { useResizeColumn } from '$app/common/hooks/useResizeColumn';
 import { ChevronDown } from '../icons/ChevronDown';
 import { ChevronUp } from '../icons/ChevronUp';
+import styled from 'styled-components';
 
 export interface ColumnSortPayload {
   sort: string;
@@ -38,6 +39,14 @@ interface Props extends CommonProps {
 const defaultProps: Props = {
   isCurrentlyUsed: false,
 };
+
+const StyledSpan = styled.span`
+  background-color: ${({ theme }) => theme.backgroundColor};
+
+  &:hover {
+    background-color: ${({ theme }) => theme.hoverBackgroundColor};
+  }
+`;
 
 export function Th$(props: Props) {
   props = { ...defaultProps, ...props };
@@ -70,7 +79,7 @@ export function Th$(props: Props) {
       ref={thRef}
       style={{
         color: props.textColor || colors.$17,
-        borderColor: colors.$4,
+        borderColor: colors.$20,
         width: currentWidth,
         ...props.style,
       }}
@@ -167,14 +176,13 @@ export function Th$(props: Props) {
       </div>
 
       {props.resizable ? (
-        <span
-          className={classNames(
-            'column-resizer block absolute inset-y-0 right-0 m-0 w-1 h-full p-0 cursor-col-resize border border-transparent hover:bg-white hover:transition duration-50',
-            {
-              'bg-white': isResizing,
-            }
-          )}
-        ></span>
+        <StyledSpan
+          className="column-resizer block absolute inset-y-0 right-0 m-0 w-1 h-full p-0 cursor-col-resize border border-transparent hover:transition duration-50"
+          theme={{
+            backgroundColor: isResizing ? colors.$3 : 'transparent',
+            hoverBackgroundColor: colors.$3,
+          }}
+        ></StyledSpan>
       ) : null}
     </th>
   );

--- a/src/components/tables/Th.tsx
+++ b/src/components/tables/Th.tsx
@@ -12,8 +12,9 @@ import React, { useState, useCallback, ReactNode } from 'react';
 import classNames from 'classnames';
 import CommonProps from '../../common/interfaces/common-props.interface';
 import { useColorScheme } from '$app/common/colors';
-import { FaSort, FaSortDown, FaSortUp } from 'react-icons/fa';
 import { useResizeColumn } from '$app/common/hooks/useResizeColumn';
+import { ChevronDown } from '../icons/ChevronDown';
+import { ChevronUp } from '../icons/ChevronUp';
 
 export interface ColumnSortPayload {
   sort: string;
@@ -41,6 +42,8 @@ const defaultProps: Props = {
 export function Th$(props: Props) {
   props = { ...defaultProps, ...props };
 
+  const colors = useColorScheme();
+
   const {
     thRef,
     currentWidth,
@@ -61,8 +64,6 @@ export function Th$(props: Props) {
       });
     }
   }, [order, props.onColumnClick, props.id]);
-
-  const colors = useColorScheme();
 
   return (
     <th
@@ -120,23 +121,41 @@ export function Th$(props: Props) {
               ) : (
                 <>
                   {props.isCurrentlyUsed ? (
-                    <div className="flex flex-col items-center justify-center -space-y-4">
-                      <FaSortUp
-                        className={classNames({
-                          'opacity-30': order !== 'asc',
-                        })}
-                        size={16}
-                      />
+                    <div className="flex flex-col items-center justify-center -space-y-1">
+                      <div>
+                        <ChevronUp
+                          size="0.7rem"
+                          strokeWidth="3"
+                          color={order === 'asc' ? colors.$3 : colors.$17}
+                        />
+                      </div>
 
-                      <FaSortDown
-                        className={classNames({
-                          'opacity-30': order !== 'desc',
-                        })}
-                        size={16}
-                      />
+                      <div>
+                        <ChevronDown
+                          size="0.7rem"
+                          strokeWidth="3"
+                          color={order === 'desc' ? colors.$3 : colors.$17}
+                        />
+                      </div>
                     </div>
                   ) : (
-                    <FaSort size={16} className="opacity-30" />
+                    <div className="flex flex-col items-center justify-center -space-y-1">
+                      <div>
+                        <ChevronUp
+                          size="0.7rem"
+                          color={colors.$17}
+                          strokeWidth="3"
+                        />
+                      </div>
+
+                      <div>
+                        <ChevronDown
+                          size="0.7rem"
+                          color={colors.$17}
+                          strokeWidth="3"
+                        />
+                      </div>
+                    </div>
                   )}
                 </>
               )}

--- a/src/components/tables/Thead.tsx
+++ b/src/components/tables/Thead.tsx
@@ -8,7 +8,7 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
-import { useAccentColor } from '$app/common/hooks/useAccentColor';
+import { useColorScheme } from '$app/common/colors';
 import CommonProps from '../../common/interfaces/common-props.interface';
 
 interface Props extends CommonProps {
@@ -18,12 +18,14 @@ interface Props extends CommonProps {
 export function Thead(props: Props) {
   const { backgroundColor } = props;
 
-  const accentColor = useAccentColor();
+  const colors = useColorScheme();
 
   return (
     <thead
+      className="border-b"
       style={{
-        backgroundColor: backgroundColor || accentColor,
+        backgroundColor: backgroundColor || colors.$1,
+        borderColor: colors.$20,
         ...props.style,
       }}
     >

--- a/src/pages/dashboard/components/Activity.tsx
+++ b/src/pages/dashboard/components/Activity.tsx
@@ -40,7 +40,7 @@ export function Activity() {
       withoutBodyPadding
       headerClassName="px-3 sm:px-4 py-3 sm:py-4"
       childrenClassName="px-0"
-      style={{ borderColor: colors.$20 }}
+      style={{ borderColor: colors.$24 }}
       headerStyle={{ borderColor: colors.$20 }}
       withoutHeaderPadding
     >

--- a/src/pages/dashboard/components/Activity.tsx
+++ b/src/pages/dashboard/components/Activity.tsx
@@ -40,8 +40,8 @@ export function Activity() {
       withoutBodyPadding
       headerClassName="px-3 sm:px-4 py-3 sm:py-4"
       childrenClassName="px-0"
-      style={{ borderColor: colors.$5 }}
-      headerStyle={{ borderColor: colors.$5 }}
+      style={{ borderColor: colors.$20 }}
+      headerStyle={{ borderColor: colors.$20 }}
       withoutHeaderPadding
     >
       {isLoading && (

--- a/src/pages/dashboard/components/ExpiredQuotes.tsx
+++ b/src/pages/dashboard/components/ExpiredQuotes.tsx
@@ -88,8 +88,8 @@ export function ExpiredQuotes() {
       className="h-96 relative shadow-sm"
       headerClassName="px-3 sm:px-4 py-3 sm:py-4"
       withoutBodyPadding
-      style={{ borderColor: colors.$5 }}
-      headerStyle={{ borderColor: colors.$5 }}
+      style={{ borderColor: colors.$20 }}
+      headerStyle={{ borderColor: colors.$20 }}
       withoutHeaderPadding
     >
       <div className="px-4 pt-4">
@@ -103,7 +103,6 @@ export function ExpiredQuotes() {
           withoutPadding
           withoutPerPageAsPreference
           styleOptions={{
-            addRowSeparator: true,
             withoutBottomBorder: true,
             withoutTopBorder: true,
             withoutLeftBorder: true,
@@ -118,9 +117,8 @@ export function ExpiredQuotes() {
             tBodyStyle: { border: 0 },
             thTextSize: 'small',
             thStyle: {
-              borderBottom: `1px solid ${colors.$5}`,
+              borderBottom: `1px solid ${colors.$20}`,
             },
-            rowSeparatorColor: colors.$5,
             ascIcon: <ArrowUp size="1.1rem" color="#6b7280" />,
             descIcon: <ArrowDown size="1.1rem" color="#6b7280" />,
           }}

--- a/src/pages/dashboard/components/ExpiredQuotes.tsx
+++ b/src/pages/dashboard/components/ExpiredQuotes.tsx
@@ -88,7 +88,7 @@ export function ExpiredQuotes() {
       className="h-96 relative shadow-sm"
       headerClassName="px-3 sm:px-4 py-3 sm:py-4"
       withoutBodyPadding
-      style={{ borderColor: colors.$20 }}
+      style={{ borderColor: colors.$24 }}
       headerStyle={{ borderColor: colors.$20 }}
       withoutHeaderPadding
     >

--- a/src/pages/dashboard/components/PastDueInvoices.tsx
+++ b/src/pages/dashboard/components/PastDueInvoices.tsx
@@ -99,8 +99,8 @@ export function PastDueInvoices() {
       className="h-96 relative shadow-sm"
       headerClassName="px-3 sm:px-4 py-3 sm:py-4"
       withoutBodyPadding
-      style={{ borderColor: colors.$5 }}
-      headerStyle={{ borderColor: colors.$5 }}
+      style={{ borderColor: colors.$20 }}
+      headerStyle={{ borderColor: colors.$20 }}
       withoutHeaderPadding
     >
       <div className="px-4 pt-4">
@@ -114,7 +114,6 @@ export function PastDueInvoices() {
           withoutPadding
           withoutPerPageAsPreference
           styleOptions={{
-            addRowSeparator: true,
             withoutBottomBorder: true,
             withoutTopBorder: true,
             withoutLeftBorder: true,
@@ -129,9 +128,8 @@ export function PastDueInvoices() {
             tBodyStyle: { border: 0 },
             thTextSize: 'small',
             thStyle: {
-              borderBottom: `1px solid ${colors.$5}`,
+              borderBottom: `1px solid ${colors.$20}`,
             },
-            rowSeparatorColor: colors.$5,
             ascIcon: <ArrowUp size="1.1rem" color="#6b7280" />,
             descIcon: <ArrowDown size="1.1rem" color="#6b7280" />,
           }}

--- a/src/pages/dashboard/components/PastDueInvoices.tsx
+++ b/src/pages/dashboard/components/PastDueInvoices.tsx
@@ -99,7 +99,7 @@ export function PastDueInvoices() {
       className="h-96 relative shadow-sm"
       headerClassName="px-3 sm:px-4 py-3 sm:py-4"
       withoutBodyPadding
-      style={{ borderColor: colors.$20 }}
+      style={{ borderColor: colors.$24 }}
       headerStyle={{ borderColor: colors.$20 }}
       withoutHeaderPadding
     >

--- a/src/pages/dashboard/components/RecentPayments.tsx
+++ b/src/pages/dashboard/components/RecentPayments.tsx
@@ -110,8 +110,8 @@ export function RecentPayments() {
       className="h-96 relative shadow-sm"
       headerClassName="px-3 sm:px-4 py-3 sm:py-4"
       withoutBodyPadding
-      style={{ borderColor: colors.$5 }}
-      headerStyle={{ borderColor: colors.$5 }}
+      style={{ borderColor: colors.$20 }}
+      headerStyle={{ borderColor: colors.$20 }}
       withoutHeaderPadding
     >
       <div className="px-4 pt-4">
@@ -125,7 +125,6 @@ export function RecentPayments() {
           withoutPadding
           withoutPerPageAsPreference
           styleOptions={{
-            addRowSeparator: true,
             withoutBottomBorder: true,
             withoutTopBorder: true,
             withoutLeftBorder: true,
@@ -140,9 +139,8 @@ export function RecentPayments() {
             tBodyStyle: { border: 0 },
             thTextSize: 'small',
             thStyle: {
-              borderBottom: `1px solid ${colors.$5}`,
+              borderBottom: `1px solid ${colors.$20}`,
             },
-            rowSeparatorColor: colors.$5,
             ascIcon: <ArrowUp size="1.1rem" color="#6b7280" />,
             descIcon: <ArrowDown size="1.1rem" color="#6b7280" />,
           }}

--- a/src/pages/dashboard/components/RecentPayments.tsx
+++ b/src/pages/dashboard/components/RecentPayments.tsx
@@ -110,7 +110,7 @@ export function RecentPayments() {
       className="h-96 relative shadow-sm"
       headerClassName="px-3 sm:px-4 py-3 sm:py-4"
       withoutBodyPadding
-      style={{ borderColor: colors.$20 }}
+      style={{ borderColor: colors.$24 }}
       headerStyle={{ borderColor: colors.$20 }}
       withoutHeaderPadding
     >

--- a/src/pages/dashboard/components/Totals.tsx
+++ b/src/pages/dashboard/components/Totals.tsx
@@ -295,7 +295,7 @@ export function Totals() {
 
             <div
               className="flex rounded-lg overflow-hidden border shadow-sm"
-              style={{ borderColor: colors.$5 }}
+              style={{ borderColor: colors.$20 }}
             >
               <ChartScaleBox
                 className="flex items-center px-4 cursor-pointer text-sm"
@@ -307,6 +307,7 @@ export function Totals() {
                   hoverBgColor: chartScale === 'day' ? colors.$3 : colors.$4,
                 }}
                 style={{
+                  borderColor: colors.$20,
                   color: chartScale === 'day' ? colors.$1 : colors.$3,
                 }}
               >
@@ -324,7 +325,7 @@ export function Totals() {
                   hoverBgColor: chartScale === 'week' ? colors.$3 : colors.$4,
                 }}
                 style={{
-                  borderColor: colors.$4,
+                  borderColor: colors.$20,
                   color: chartScale === 'week' ? colors.$1 : colors.$3,
                 }}
               >
@@ -342,7 +343,7 @@ export function Totals() {
                   hoverBgColor: chartScale === 'month' ? colors.$3 : colors.$4,
                 }}
                 style={{
-                  borderColor: colors.$4,
+                  borderColor: colors.$20,
                   color: chartScale === 'month' ? colors.$1 : colors.$3,
                 }}
               >
@@ -416,14 +417,14 @@ export function Totals() {
             className="col-span-10 xl:col-span-3 shadow-sm"
             headerClassName="px-3 sm:px-4 py-3 sm:py-4"
             withoutBodyPadding
-            style={{ borderColor: colors.$5 }}
-            headerStyle={{ borderColor: colors.$5 }}
+            style={{ borderColor: colors.$20 }}
+            headerStyle={{ borderColor: colors.$20 }}
             withoutHeaderPadding
           >
             <div className="flex flex-col px-4">
               <div
                 className="flex justify-between items-center border-b border-dashed py-5"
-                style={{ borderColor: colors.$5 }}
+                style={{ borderColor: colors.$21 }}
               >
                 <span className="text-gray-500">{t('invoices')}</span>
 
@@ -444,7 +445,7 @@ export function Totals() {
 
               <div
                 className="flex justify-between items-center border-b border-dashed py-5"
-                style={{ borderColor: colors.$5 }}
+                style={{ borderColor: colors.$21 }}
               >
                 <span className="text-gray-500">{t('payments')}</span>
 
@@ -465,7 +466,7 @@ export function Totals() {
 
               <div
                 className="flex justify-between items-center border-b border-dashed py-5"
-                style={{ borderColor: colors.$5 }}
+                style={{ borderColor: colors.$21 }}
               >
                 <span className="text-gray-500">{t('expenses')}</span>
 
@@ -486,7 +487,7 @@ export function Totals() {
 
               <div
                 className="flex justify-between items-center border-b border-dashed py-5"
-                style={{ borderColor: colors.$5 }}
+                style={{ borderColor: colors.$21 }}
               >
                 <span className="text-gray-500">{t('outstanding')}</span>
 
@@ -513,7 +514,7 @@ export function Totals() {
                 <Badge
                   variant="transparent"
                   className="border"
-                  style={{ borderColor: colors.$5 }}
+                  style={{ borderColor: colors.$20 }}
                 >
                   <span className="mx-2 text-base font-mono">
                     {totalsData[currency]?.outstanding?.outstanding_count || 0}
@@ -530,8 +531,8 @@ export function Totals() {
             className="col-span-10 xl:col-span-7 shadow-sm"
             headerClassName="px-3 sm:px-4 py-3 sm:py-4"
             childrenClassName="px-4"
-            style={{ borderColor: colors.$5 }}
-            headerStyle={{ borderColor: colors.$5 }}
+            style={{ borderColor: colors.$20 }}
+            headerStyle={{ borderColor: colors.$20 }}
             withoutHeaderPadding
           >
             <Chart

--- a/src/pages/dashboard/components/Totals.tsx
+++ b/src/pages/dashboard/components/Totals.tsx
@@ -295,7 +295,7 @@ export function Totals() {
 
             <div
               className="flex rounded-lg overflow-hidden border shadow-sm"
-              style={{ borderColor: colors.$20 }}
+              style={{ borderColor: colors.$24 }}
             >
               <ChartScaleBox
                 className="flex items-center px-4 cursor-pointer text-sm"
@@ -307,7 +307,7 @@ export function Totals() {
                   hoverBgColor: chartScale === 'day' ? colors.$3 : colors.$4,
                 }}
                 style={{
-                  borderColor: colors.$20,
+                  borderColor: colors.$24,
                   color: chartScale === 'day' ? colors.$1 : colors.$3,
                 }}
               >
@@ -325,7 +325,7 @@ export function Totals() {
                   hoverBgColor: chartScale === 'week' ? colors.$3 : colors.$4,
                 }}
                 style={{
-                  borderColor: colors.$20,
+                  borderColor: colors.$24,
                   color: chartScale === 'week' ? colors.$1 : colors.$3,
                 }}
               >
@@ -343,7 +343,7 @@ export function Totals() {
                   hoverBgColor: chartScale === 'month' ? colors.$3 : colors.$4,
                 }}
                 style={{
-                  borderColor: colors.$20,
+                  borderColor: colors.$24,
                   color: chartScale === 'month' ? colors.$1 : colors.$3,
                 }}
               >
@@ -417,7 +417,7 @@ export function Totals() {
             className="col-span-10 xl:col-span-3 shadow-sm"
             headerClassName="px-3 sm:px-4 py-3 sm:py-4"
             withoutBodyPadding
-            style={{ borderColor: colors.$20 }}
+            style={{ borderColor: colors.$24 }}
             headerStyle={{ borderColor: colors.$20 }}
             withoutHeaderPadding
           >
@@ -514,7 +514,7 @@ export function Totals() {
                 <Badge
                   variant="transparent"
                   className="border"
-                  style={{ borderColor: colors.$20 }}
+                  style={{ borderColor: colors.$21 }}
                 >
                   <span className="mx-2 text-base font-mono">
                     {totalsData[currency]?.outstanding?.outstanding_count || 0}
@@ -531,7 +531,7 @@ export function Totals() {
             className="col-span-10 xl:col-span-7 shadow-sm"
             headerClassName="px-3 sm:px-4 py-3 sm:py-4"
             childrenClassName="px-4"
-            style={{ borderColor: colors.$20 }}
+            style={{ borderColor: colors.$24 }}
             headerStyle={{ borderColor: colors.$20 }}
             withoutHeaderPadding
           >

--- a/src/pages/dashboard/components/UpcomingInvoices.tsx
+++ b/src/pages/dashboard/components/UpcomingInvoices.tsx
@@ -99,7 +99,7 @@ export function UpcomingInvoices() {
       className="h-96 relative shadow-sm"
       headerClassName="px-3 sm:px-4 py-3 sm:py-4"
       withoutBodyPadding
-      style={{ borderColor: colors.$20 }}
+      style={{ borderColor: colors.$24 }}
       headerStyle={{ borderColor: colors.$20 }}
       withoutHeaderPadding
     >

--- a/src/pages/dashboard/components/UpcomingInvoices.tsx
+++ b/src/pages/dashboard/components/UpcomingInvoices.tsx
@@ -99,8 +99,8 @@ export function UpcomingInvoices() {
       className="h-96 relative shadow-sm"
       headerClassName="px-3 sm:px-4 py-3 sm:py-4"
       withoutBodyPadding
-      style={{ borderColor: colors.$5 }}
-      headerStyle={{ borderColor: colors.$5 }}
+      style={{ borderColor: colors.$20 }}
+      headerStyle={{ borderColor: colors.$20 }}
       withoutHeaderPadding
     >
       <div className="px-4 pt-4">
@@ -114,7 +114,6 @@ export function UpcomingInvoices() {
           withoutPadding
           withoutPerPageAsPreference
           styleOptions={{
-            addRowSeparator: true,
             withoutBottomBorder: true,
             withoutTopBorder: true,
             withoutLeftBorder: true,
@@ -129,9 +128,8 @@ export function UpcomingInvoices() {
             tBodyStyle: { border: 0 },
             thTextSize: 'small',
             thStyle: {
-              borderBottom: `1px solid ${colors.$5}`,
+              borderBottom: `1px solid ${colors.$20}`,
             },
-            rowSeparatorColor: colors.$5,
             ascIcon: <ArrowUp size="1.1rem" color="#6b7280" />,
             descIcon: <ArrowDown size="1.1rem" color="#6b7280" />,
           }}

--- a/src/pages/dashboard/components/UpcomingQuotes.tsx
+++ b/src/pages/dashboard/components/UpcomingQuotes.tsx
@@ -88,7 +88,7 @@ export function UpcomingQuotes() {
       className="h-96 relative shadow-sm"
       headerClassName="px-3 sm:px-4 py-3 sm:py-4"
       withoutBodyPadding
-      style={{ borderColor: colors.$20 }}
+      style={{ borderColor: colors.$24 }}
       headerStyle={{ borderColor: colors.$20 }}
       withoutHeaderPadding
     >

--- a/src/pages/dashboard/components/UpcomingQuotes.tsx
+++ b/src/pages/dashboard/components/UpcomingQuotes.tsx
@@ -88,8 +88,8 @@ export function UpcomingQuotes() {
       className="h-96 relative shadow-sm"
       headerClassName="px-3 sm:px-4 py-3 sm:py-4"
       withoutBodyPadding
-      style={{ borderColor: colors.$5 }}
-      headerStyle={{ borderColor: colors.$5 }}
+      style={{ borderColor: colors.$20 }}
+      headerStyle={{ borderColor: colors.$20 }}
       withoutHeaderPadding
     >
       <div className="px-4 pt-4">
@@ -103,7 +103,6 @@ export function UpcomingQuotes() {
           withoutPadding
           withoutPerPageAsPreference
           styleOptions={{
-            addRowSeparator: true,
             withoutBottomBorder: true,
             withoutTopBorder: true,
             withoutLeftBorder: true,
@@ -118,9 +117,8 @@ export function UpcomingQuotes() {
             tBodyStyle: { border: 0 },
             thTextSize: 'small',
             thStyle: {
-              borderBottom: `1px solid ${colors.$5}`,
+              borderBottom: `1px solid ${colors.$20}`,
             },
-            rowSeparatorColor: colors.$5,
             ascIcon: <ArrowUp size="1.1rem" color="#6b7280" />,
             descIcon: <ArrowDown size="1.1rem" color="#6b7280" />,
           }}

--- a/src/pages/dashboard/components/UpcomingRecurringInvoices.tsx
+++ b/src/pages/dashboard/components/UpcomingRecurringInvoices.tsx
@@ -107,7 +107,7 @@ export function UpcomingRecurringInvoices() {
       className="h-96 relative shadow-sm"
       headerClassName="px-3 sm:px-4 py-3 sm:py-4"
       withoutBodyPadding
-      style={{ borderColor: colors.$20 }}
+      style={{ borderColor: colors.$24 }}
       headerStyle={{ borderColor: colors.$20 }}
       withoutHeaderPadding
     >

--- a/src/pages/dashboard/components/UpcomingRecurringInvoices.tsx
+++ b/src/pages/dashboard/components/UpcomingRecurringInvoices.tsx
@@ -107,8 +107,8 @@ export function UpcomingRecurringInvoices() {
       className="h-96 relative shadow-sm"
       headerClassName="px-3 sm:px-4 py-3 sm:py-4"
       withoutBodyPadding
-      style={{ borderColor: colors.$5 }}
-      headerStyle={{ borderColor: colors.$5 }}
+      style={{ borderColor: colors.$20 }}
+      headerStyle={{ borderColor: colors.$20 }}
       withoutHeaderPadding
     >
       <div className="px-4 pt-4">
@@ -122,7 +122,6 @@ export function UpcomingRecurringInvoices() {
           withoutPadding
           withoutPerPageAsPreference
           styleOptions={{
-            addRowSeparator: true,
             withoutBottomBorder: true,
             withoutTopBorder: true,
             withoutLeftBorder: true,
@@ -137,9 +136,8 @@ export function UpcomingRecurringInvoices() {
             tBodyStyle: { border: 0 },
             thTextSize: 'small',
             thStyle: {
-              borderBottom: `1px solid ${colors.$5}`,
+              borderBottom: `1px solid ${colors.$20}`,
             },
-            rowSeparatorColor: colors.$5,
             ascIcon: <ArrowUp size="1.1rem" color="#6b7280" />,
             descIcon: <ArrowDown size="1.1rem" color="#6b7280" />,
           }}

--- a/src/pages/dashboard/hooks/useGenerateActivityElement.tsx
+++ b/src/pages/dashboard/hooks/useGenerateActivityElement.tsx
@@ -232,7 +232,7 @@ export function useGenerateActivityElement() {
   return (activity: ActivityRecord) => (
     <div
       className="flex flex-col py-2.5 border border-t-0 border-x-0 last:border-b-0 border-dashed"
-      style={{ borderColor: colors.$5 }}
+      style={{ borderColor: colors.$21 }}
     >
       <div className="flex flex-col space-y-1">
         <span className="text-sm">{generate(activity)}</span>

--- a/src/pages/settings/tax-settings/components/calculate-taxes/components/EURegions.tsx
+++ b/src/pages/settings/tax-settings/components/calculate-taxes/components/EURegions.tsx
@@ -48,8 +48,6 @@ export function EURegions() {
   };
 
   const divClickIntercept = (id: string) => {
-    console.log(id);
-
     const checkbox = document.getElementById(id.replace('.apply_tax', ''));
     checkbox?.click();
   };

--- a/src/pages/settings/tax-settings/components/calculate-taxes/components/UKRegions.tsx
+++ b/src/pages/settings/tax-settings/components/calculate-taxes/components/UKRegions.tsx
@@ -48,8 +48,6 @@ export function UKRegions() {
   };
 
   const divClickIntercept = (id: string) => {
-    console.log(id);
-
     const checkbox = document.getElementById(id.replace('.apply_tax', ''));
     checkbox?.click();
   };
@@ -116,7 +114,9 @@ export function UKRegions() {
                 value={`tax_data.regions.UK.subregions.${value[0]}.apply_tax`}
                 checked={value[1].apply_tax ? true : false}
                 className="flex justify-end h-6 w-6 rounded-half shadow"
-                disabled={companyChanges?.tax_data?.regions?.UK?.tax_all_subregions}
+                disabled={
+                  companyChanges?.tax_data?.regions?.UK?.tax_all_subregions
+                }
                 onValueChange={(value, checked) => handleChange(value, checked)}
               ></Checkbox>
 
@@ -141,7 +141,9 @@ export function UKRegions() {
                 type="primary"
                 className=""
                 disableWithoutIcon={true}
-                disabled={companyChanges?.tax_data.regions?.UK?.tax_all_subregions}
+                disabled={
+                  companyChanges?.tax_data.regions?.UK?.tax_all_subregions
+                }
                 onClick={(e: ChangeEvent<HTMLInputElement>) => {
                   e.preventDefault();
                   setTaxSetting(value[1]);


### PR DESCRIPTION
@beganovich @turbo124 The PR includes final styling of the data table along with adjusting the border color on the dashboard to match Figma. Screenshots:

![Screenshot 2025-04-01 at 19 18 22](https://github.com/user-attachments/assets/259ec32f-b5f5-44ed-ab42-ac84b41fe83f)

![Screenshot 2025-04-01 at 19 19 04](https://github.com/user-attachments/assets/79c93ddb-5cf7-442b-8610-fac4ee1787ac)

Let me know your thoughts.