### PR TITLE
[Cleanup] Invoice Footer Section Redesign && Markdown Editor Dark/Light Mode Fixes

### DIFF
--- a/src/components/TabGroup.tsx
+++ b/src/components/TabGroup.tsx
@@ -27,6 +27,7 @@ interface Props {
   withoutVerticalMargin?: boolean;
   withHorizontalPadding?: boolean;
   horizontalPaddingWidth?: string;
+  fullRightPadding?: boolean;
 }
 
 const StyledButton = styled.button`
@@ -45,6 +46,7 @@ export function TabGroup(props: Props) {
     withoutVerticalMargin,
     withHorizontalPadding = false,
     horizontalPaddingWidth = '7rem',
+    fullRightPadding = false,
   } = props;
 
   const [currentIndex, setCurrentIndex] = useState(props.defaultTabIndex || 0);
@@ -60,7 +62,12 @@ export function TabGroup(props: Props) {
   }, [props.defaultTabIndex]);
 
   return (
-    <div className={props.className} data-cy="tabs">
+    <div
+      className={classNames(props.className, {
+        'w-full': props.width === 'full',
+      })}
+      data-cy="tabs"
+    >
       <div className="flex justify-between relative">
         <div className="flex flex-1 overflow-x-auto relative">
           {withHorizontalPadding && (
@@ -74,19 +81,9 @@ export function TabGroup(props: Props) {
           )}
 
           {props.tabs.map((tab, index) => (
-            <div
-              key={index}
-              className={classNames({
-                'w-full': props.width === 'full',
-              })}
-            >
+            <div key={index}>
               <StyledButton
-                className={classNames(
-                  'whitespace-nowrap font-medium text-sm py-3 px-4',
-                  {
-                    'w-full': props.width === 'full',
-                  }
-                )}
+                className="whitespace-nowrap font-medium text-sm py-3 px-4"
                 type="button"
                 onClick={() => handleTabChange(index)}
                 theme={{
@@ -107,10 +104,10 @@ export function TabGroup(props: Props) {
 
           <div
             className={classNames({
-              'flex-1': !withHorizontalPadding,
+              'flex-1': !withHorizontalPadding || fullRightPadding,
             })}
             style={{
-              ...(withHorizontalPadding && {
+              ...(Boolean(withHorizontalPadding && !fullRightPadding) && {
                 width: horizontalPaddingWidth,
               }),
               height: '100%',

--- a/src/components/TabGroup.tsx
+++ b/src/components/TabGroup.tsx
@@ -81,9 +81,19 @@ export function TabGroup(props: Props) {
           )}
 
           {props.tabs.map((tab, index) => (
-            <div key={index}>
+            <div
+              key={index}
+              className={classNames({
+                'flex-1': props.width === 'full',
+              })}
+            >
               <StyledButton
-                className="whitespace-nowrap font-medium text-sm py-3 px-4"
+                className={classNames(
+                  'whitespace-nowrap font-medium text-sm py-3 px-4',
+                  {
+                    'w-full': props.width === 'full',
+                  }
+                )}
                 type="button"
                 onClick={() => handleTabChange(index)}
                 theme={{

--- a/src/pages/invoices/common/components/AddUninvoicedItemsButton.tsx
+++ b/src/pages/invoices/common/components/AddUninvoicedItemsButton.tsx
@@ -175,7 +175,7 @@ export function AddUninvoicedItemsButton(props: Props) {
           tabs={[t('products'), t('tasks'), t('expenses')]}
           width="full"
           withHorizontalPadding
-          horizontalPaddingWidth="3.5rem"
+          horizontalPaddingWidth="1.5rem"
           onTabChange={(tab) => setCurrentTabIndex(tab)}
         >
           <div className="flex flex-col space-y-4 pt-1 px-4">

--- a/src/pages/invoices/common/components/InvoiceFooter.tsx
+++ b/src/pages/invoices/common/components/InvoiceFooter.tsx
@@ -65,7 +65,6 @@ export function InvoiceFooter(props: Props) {
         withoutVerticalMargin
         withHorizontalPadding
         horizontalPaddingWidth="1.5rem"
-        width="full"
         fullRightPadding
       >
         <div className="mb-4 px-6">

--- a/src/pages/invoices/common/components/InvoiceFooter.tsx
+++ b/src/pages/invoices/common/components/InvoiceFooter.tsx
@@ -19,6 +19,7 @@ import { ChangeHandler } from '$app/pages/invoices/create/Create';
 import { ValidationBag } from '$app/common/interfaces/validation-bag';
 import { useAdmin } from '$app/common/hooks/permissions/useHasPermission';
 import { Dispatch, SetStateAction } from 'react';
+import { useColorScheme } from '$app/common/colors';
 
 interface Props {
   invoice?: Invoice;
@@ -31,7 +32,9 @@ interface Props {
 }
 
 export function InvoiceFooter(props: Props) {
-  const { t } = useTranslation();
+  const [t] = useTranslation();
+
+  const colors = useColorScheme();
 
   const { isAdmin, isOwner } = useAdmin();
 
@@ -53,23 +56,33 @@ export function InvoiceFooter(props: Props) {
   ];
 
   return (
-    <Card className="col-span-12 xl:col-span-8 h-max px-6">
-      <TabGroup tabs={tabs} withoutVerticalMargin>
-        <div className="mb-4">
+    <Card
+      className="col-span-12 xl:col-span-8 shadow-sm h-max"
+      style={{ borderColor: colors.$24 }}
+    >
+      <TabGroup
+        tabs={tabs}
+        withoutVerticalMargin
+        withHorizontalPadding
+        horizontalPaddingWidth="1.5rem"
+        width="full"
+        fullRightPadding
+      >
+        <div className="mb-4 px-6">
           <MarkdownEditor
             value={invoice?.public_notes || ''}
             onChange={(value) => handleChange('public_notes', value)}
           />
         </div>
 
-        <div className="mb-4">
+        <div className="mb-4 px-6">
           <MarkdownEditor
             value={invoice?.private_notes || ''}
             onChange={(value) => handleChange('private_notes', value)}
           />
         </div>
 
-        <div>
+        <div className="px-6">
           <MarkdownEditor
             value={invoice?.terms || ''}
             onChange={(value) => handleChange('terms', value)}
@@ -90,7 +103,7 @@ export function InvoiceFooter(props: Props) {
           </Element>
         </div>
 
-        <div>
+        <div className="px-6">
           <MarkdownEditor
             value={invoice?.footer || ''}
             onChange={(value) => handleChange('footer', value)}
@@ -111,7 +124,7 @@ export function InvoiceFooter(props: Props) {
           </Element>
         </div>
 
-        <div className="my-4">
+        <div className="my-4 px-6">
           <span className="text-sm">{t('custom_fields')} &nbsp;</span>
           <Link to="/settings/custom_fields/invoices" className="capitalize">
             {t('click_here')}

--- a/src/pages/invoices/common/components/InvoiceSlider.tsx
+++ b/src/pages/invoices/common/components/InvoiceSlider.tsx
@@ -294,6 +294,7 @@ export function InvoiceSlider() {
         tabs={[t('overview'), t('history'), t('activity'), t('email_history')]}
         width="full"
         withHorizontalPadding
+        horizontalPaddingWidth="1.5rem"
       >
         <div className="space-y-2">
           <div className="px-6">

--- a/src/pages/payments/common/components/PaymentSlider.tsx
+++ b/src/pages/payments/common/components/PaymentSlider.tsx
@@ -176,7 +176,7 @@ export function PaymentSlider() {
         tabs={[t('overview'), t('activity')]}
         width="full"
         withHorizontalPadding
-        horizontalPaddingWidth="3.5rem"
+        horizontalPaddingWidth="1.5rem"
       >
         <div className="space-y-2">
           <div className="px-6">

--- a/src/pages/quotes/common/components/QuoteSlider.tsx
+++ b/src/pages/quotes/common/components/QuoteSlider.tsx
@@ -238,6 +238,7 @@ export function QuoteSlider() {
         tabs={[t('overview'), t('history'), t('activity'), t('email_history')]}
         width="full"
         withHorizontalPadding
+        horizontalPaddingWidth="1.5rem"
       >
         <div className="space-y-2">
           <div className="px-6">

--- a/src/pages/recurring-invoices/common/components/RecurringInvoiceSlider.tsx
+++ b/src/pages/recurring-invoices/common/components/RecurringInvoiceSlider.tsx
@@ -208,6 +208,7 @@ export const RecurringInvoiceSlider = () => {
         tabs={[t('overview'), t('history'), t('schedule'), t('activity')]}
         width="full"
         withHorizontalPadding
+        horizontalPaddingWidth="1.5rem"
       >
         <div className="space-y-2">
           <div className="px-6">

--- a/src/pages/tasks/common/components/TaskSlider.tsx
+++ b/src/pages/tasks/common/components/TaskSlider.tsx
@@ -169,7 +169,7 @@ export function TaskSlider() {
         tabs={[t('overview'), t('activity')]}
         width="full"
         withHorizontalPadding
-        horizontalPaddingWidth="3.5rem"
+        horizontalPaddingWidth="1.5rem"
       >
         <div className="space-y-2">
           <div className="px-6">


### PR DESCRIPTION
@beganovich @turbo124 The PR includes Invoice Footer section redesign along with fixes for dark/light mode for markdown editors in general. Screenshot:

![Screenshot 2025-04-23 at 00 18 12](https://github.com/user-attachments/assets/424eb7f2-b65f-40b9-abaa-e9a0b1b10628)

Let me know your thoughts.