### PR TITLE
[Cleanup] Documents Tab Redesign | Invoices

### DIFF
--- a/src/pages/invoices/edit/components/Documents.tsx
+++ b/src/pages/invoices/edit/components/Documents.tsx
@@ -34,33 +34,38 @@ export default function Documents() {
   const { invoice } = context;
 
   return (
-    <Card title={t('documents')} className="w-full xl:w-2/3">
-      {location.pathname.includes('/create') ? (
-        <div className="text-sm mt-4 px-6">
-          {t('save_to_upload_documents')}.
-        </div>
-      ) : (
-        <div className="px-6">
-          <Upload
-            widgetOnly
-            endpoint={endpoint('/api/v1/invoices/:id/upload', {
-              id,
-            })}
-            onSuccess={() => $refetch(['invoices'])}
-            disableUpload={
-              !hasPermission('edit_invoice') && !entityAssigned(invoice)
-            }
-          />
+    <Card title={t('documents')}>
+      <div className="flex flex-col items-center w-full px-4 sm:px-6 py-2">
+        {location.pathname.includes('/create') ? (
+          <div className="text-sm mt-4">{t('save_to_upload_documents')}.</div>
+        ) : (
+          <>
+            <div className="w-full lg:w-2/3">
+              <Upload
+                widgetOnly
+                endpoint={endpoint('/api/v1/invoices/:id/upload', {
+                  id,
+                })}
+                onSuccess={() => $refetch(['invoices'])}
+                disableUpload={
+                  !hasPermission('edit_invoice') && !entityAssigned(invoice)
+                }
+              />
+            </div>
 
-          <DocumentsTable
-            documents={invoice?.documents || []}
-            onDocumentDelete={() => $refetch(['invoices'])}
-            disableEditableOptions={
-              !entityAssigned(invoice, true) && !hasPermission('edit_invoice')
-            }
-          />
-        </div>
-      )}
+            <div className="w-full lg:w-2/3">
+              <DocumentsTable
+                documents={invoice?.documents || []}
+                onDocumentDelete={() => $refetch(['invoices'])}
+                disableEditableOptions={
+                  !entityAssigned(invoice, true) &&
+                  !hasPermission('edit_invoice')
+                }
+              />
+            </div>
+          </>
+        )}
+      </div>
     </Card>
   );
 }

--- a/src/pages/invoices/edit/components/Documents.tsx
+++ b/src/pages/invoices/edit/components/Documents.tsx
@@ -37,7 +37,9 @@ export default function Documents() {
     <Card title={t('documents')}>
       <div className="flex flex-col items-center w-full px-4 sm:px-6 py-2">
         {location.pathname.includes('/create') ? (
-          <div className="text-sm mt-4">{t('save_to_upload_documents')}.</div>
+          <div className="text-sm self-start">
+            {t('save_to_upload_documents')}.
+          </div>
         ) : (
           <>
             <div className="w-full lg:w-2/3">


### PR DESCRIPTION
@beganovich @turbo124 The PR includes a redesign of the "Documents" tab for invoice according to the Figma design. Screenshot:

<img width="1262" alt="Screenshot 2025-04-24 at 18 40 29" src="https://github.com/user-attachments/assets/5063ecc2-5fef-4123-abb6-1f42d59695d0" />

Let me know your thoughts.