### PR TITLE
[Cleanup] Expense Pages Redesign

### DIFF
--- a/src/components/forms/Toggle.tsx
+++ b/src/components/forms/Toggle.tsx
@@ -52,7 +52,7 @@ export default function Toggle(props: Props) {
         theme={{
           ringColor: colors.$5,
           borderColor: colors.$5,
-          backgroundColor: checked ? accentColor : colors.$5,
+          backgroundColor: checked ? colors.$3 : colors.$5,
         }}
         className={classNames(
           'relative inline-flex items-center flex-shrink-0 h-6 w-11 rounded-full transition-colors ease-in-out duration-200',

--- a/src/components/payment-types/PaymentTypeSelector.tsx
+++ b/src/components/payment-types/PaymentTypeSelector.tsx
@@ -21,6 +21,7 @@ export function PaymentTypeSelector(props: GenericSelectorProps) {
       onValueChange={props.onChange}
       withBlank
       errorMessage={props.errorMessage}
+      customSelector
     >
       {statics.data?.payment_types
         .sort((a, b) => a.name.localeCompare(b.name))

--- a/src/components/resizable-panels/PanelResizeHandle.tsx
+++ b/src/components/resizable-panels/PanelResizeHandle.tsx
@@ -31,7 +31,7 @@ export function PanelResizeHandle(props: Props) {
   return renderBasePanelResizeHandler ? (
     <PanelResizeHandleBaseStyled
       className="flex items-center"
-      theme={{ hoverColor: '#3366CC', backgroundColor: colors.$5 }}
+      theme={{ hoverColor: '#3366CC', backgroundColor: colors.$21 }}
       style={{ width: '2.5px' }}
     />
   ) : (

--- a/src/pages/expenses/Expense.tsx
+++ b/src/pages/expenses/Expense.tsx
@@ -141,7 +141,7 @@ export default function Expense() {
               <Divider
                 className="pt-4"
                 withoutPadding
-                borderColor={colors.$5}
+                borderColor={colors.$21}
               />
             )}
 

--- a/src/pages/expenses/common/components/DocumentPreview.tsx
+++ b/src/pages/expenses/common/components/DocumentPreview.tsx
@@ -8,32 +8,42 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
+import { useColorScheme } from '$app/common/colors';
 import { endpoint } from '$app/common/helpers';
 import { request } from '$app/common/helpers/request';
 import { Document } from '$app/common/interfaces/document.interface';
 import { defaultHeaders } from '$app/common/queries/common/headers';
 import { FileIcon } from '$app/components/FileIcon';
 import { Spinner } from '$app/components/Spinner';
-import { Icon } from '$app/components/icons/Icon';
+import { ChevronLeft } from '$app/components/icons/ChevronLeft';
+import { ChevronRight } from '$app/components/icons/ChevronRight';
+import { DoubleChevronLeft } from '$app/components/icons/DoubleChevronLeft';
+import { DoubleChevronRight } from '$app/components/icons/DoubleChevronRight';
 import { android } from '$app/pages/invoices/common/components/InvoiceViewer';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  MdFirstPage,
-  MdLastPage,
-  MdNavigateBefore,
-  MdNavigateNext,
-} from 'react-icons/md';
 import { useQueryClient } from 'react-query';
+import styled from 'styled-components';
+
+const Button = styled.div`
+  background-color: ${(props) => props.theme.backgroundColor};
+  border-color: ${(props) => props.theme.borderColor};
+
+  &:hover {
+    background-color: ${(props) => props.theme.hoverColor};
+  }
+`;
 
 interface Props {
   documents: Document[];
 }
 export function DocumentPreview(props: Props) {
   const [t] = useTranslation();
-  const queryClient = useQueryClient();
 
   const { documents } = props;
+
+  const colors = useColorScheme();
+  const queryClient = useQueryClient();
 
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
@@ -115,38 +125,60 @@ export function DocumentPreview(props: Props) {
       {documents.length ? (
         <div className="flex flex-col">
           {!isFormBusy && (
-            <div className="flex self-end pb-1">
-              <Icon
-                className="cursor-pointer"
-                element={MdFirstPage}
-                size={25}
+            <div className="flex self-end pb-2">
+              <Button
+                className="p-2 border rounded-l-md shadow-sm cursor-pointer"
+                theme={{
+                  hoverColor: colors.$4,
+                  backgroundColor: colors.$1,
+                  borderColor: colors.$24,
+                }}
                 onClick={() => setDocumentIndex(0)}
-              />
-              <Icon
-                className="cursor-pointer"
-                element={MdNavigateBefore}
-                size={25}
+              >
+                <DoubleChevronLeft size="0.85rem" color={colors.$3} />
+              </Button>
+
+              <Button
+                className="p-2 border-b border-t border-r rounded-r-md shadow-sm cursor-pointer"
+                theme={{
+                  hoverColor: colors.$4,
+                  backgroundColor: colors.$1,
+                  borderColor: colors.$24,
+                }}
                 onClick={() =>
                   documentIndex !== 0 &&
                   setDocumentIndex((current) => current - 1)
                 }
-              />
+              >
+                <ChevronLeft size="0.85rem" color={colors.$3} />
+              </Button>
 
-              <Icon
-                className="cursor-pointer"
-                element={MdNavigateNext}
-                size={25}
+              <Button
+                className="p-2 border-t border-b border-l rounded-l-md shadow-sm cursor-pointer ml-2"
+                theme={{
+                  hoverColor: colors.$4,
+                  backgroundColor: colors.$1,
+                  borderColor: colors.$24,
+                }}
                 onClick={() =>
                   documentIndex !== documents.length - 1 &&
                   setDocumentIndex((current) => current + 1)
                 }
-              />
-              <Icon
-                className="cursor-pointer"
-                element={MdLastPage}
-                size={25}
+              >
+                <ChevronRight size="0.85rem" color={colors.$3} />
+              </Button>
+
+              <Button
+                className="p-2 border rounded-r-md shadow-sm cursor-pointer"
+                theme={{
+                  hoverColor: colors.$4,
+                  backgroundColor: colors.$1,
+                  borderColor: colors.$24,
+                }}
                 onClick={() => setDocumentIndex(documents.length - 1)}
-              />
+              >
+                <DoubleChevronRight size="0.85rem" color={colors.$3} />
+              </Button>
             </div>
           )}
 

--- a/src/pages/expenses/create/components/AdditionalInfo.tsx
+++ b/src/pages/expenses/create/components/AdditionalInfo.tsx
@@ -23,11 +23,13 @@ import { useTranslation } from 'react-i18next';
 import { useReactSettings } from '$app/common/hooks/useReactSettings';
 import { ExpenseCardProps } from './Details';
 import { NumberInputField } from '$app/components/forms/NumberInputField';
+import { useColorScheme } from '$app/common/colors';
 
 export function AdditionalInfo(props: ExpenseCardProps) {
   const [t] = useTranslation();
   const { expense, handleChange, errors } = props;
 
+  const colors = useColorScheme();
   const company = useCurrentCompany();
   const reactSettings = useReactSettings();
 
@@ -141,7 +143,13 @@ export function AdditionalInfo(props: ExpenseCardProps) {
   }, [expense]);
 
   return (
-    <Card title={t('additional_info')} isLoading={!expense}>
+    <Card
+      title={t('additional_info')}
+      className="shadow-sm"
+      style={{ borderColor: colors.$24 }}
+      headerStyle={{ borderColor: colors.$20 }}
+      isLoading={!expense}
+    >
       {expense && (
         <Element
           leftSide={t('should_be_invoiced')}

--- a/src/pages/expenses/create/components/Details.tsx
+++ b/src/pages/expenses/create/components/Details.tsx
@@ -26,7 +26,7 @@ import { CustomField } from '$app/components/CustomField';
 import { useCalculateExpenseAmount } from '../../common/hooks/useCalculateExpenseAmount';
 import { useFormatMoney } from '$app/common/hooks/money/useFormatMoney';
 import { Icon } from '$app/components/icons/Icon';
-import { MdLaunch, MdWarning } from 'react-icons/md';
+import { MdWarning } from 'react-icons/md';
 import { route } from '$app/common/helpers/route';
 import { Link } from 'react-router-dom';
 import { Link as LinkBase } from '$app/components/forms';
@@ -36,6 +36,8 @@ import reactStringReplace from 'react-string-replace';
 import { useTaxRatesQuery } from '$app/common/queries/tax-rates';
 import { TaxRate } from '$app/common/interfaces/tax-rate';
 import { getTaxRateComboValue } from '$app/common/helpers/tax-rates/tax-rates-combo';
+import { useColorScheme } from '$app/common/colors';
+import { ExternalLink } from '$app/components/icons/ExternalLink';
 
 export interface ExpenseCardProps {
   expense: Expense | undefined;
@@ -58,6 +60,7 @@ export function Details(props: Props) {
 
   const { expense, handleChange, taxInputType, pageType, errors } = props;
 
+  const colors = useColorScheme();
   const company = useCurrentCompany();
 
   const { data: taxes } = useTaxRatesQuery({ status: ['active'] });
@@ -106,7 +109,7 @@ export function Details(props: Props) {
   return (
     <div className="flex flex-col space-y-4">
       {expense && (
-        <Card>
+        <Card className="shadow-sm" style={{ borderColor: colors.$24 }}>
           <Element leftSide={t('expense_total')} withoutWrappingLeftSide>
             {formatMoney(
               calculateExpenseAmount(expense),
@@ -117,14 +120,20 @@ export function Details(props: Props) {
         </Card>
       )}
 
-      <Card title={t('details')} isLoading={!expense}>
+      <Card
+        title={t('details')}
+        className="shadow-sm"
+        style={{ borderColor: colors.$24 }}
+        headerStyle={{ borderColor: colors.$20 }}
+        isLoading={!expense}
+      >
         {expense && pageType === 'edit' && (
           <>
             <Element leftSide={t('status')}>
               <ExpenseStatus entity={expense} />
             </Element>
 
-            <Element leftSide={t('expense_number')}>
+            <Element leftSide={t('number')}>
               <InputField
                 id="number"
                 value={expense.number}
@@ -148,7 +157,9 @@ export function Details(props: Props) {
                     })}
                     target="_blank"
                   >
-                    <Icon element={MdLaunch} size={18} />
+                    <div>
+                      <ExternalLink color="#0062FF" size="1.1rem" />
+                    </div>
                   </Link>
                 )}
               </div>
@@ -194,7 +205,9 @@ export function Details(props: Props) {
                     })}
                     target="_blank"
                   >
-                    <Icon element={MdLaunch} size={18} />
+                    <div>
+                      <ExternalLink color="#0062FF" size="1.1rem" />
+                    </div>
                   </Link>
                 )}
               </div>

--- a/src/pages/expenses/create/components/Notes.tsx
+++ b/src/pages/expenses/create/components/Notes.tsx
@@ -12,13 +12,23 @@ import { Card } from '$app/components/cards';
 import { InputField } from '$app/components/forms';
 import { useTranslation } from 'react-i18next';
 import { ExpenseCardProps } from './Details';
+import { useColorScheme } from '$app/common/colors';
 
 export function Notes(props: ExpenseCardProps) {
   const [t] = useTranslation();
   const { expense, handleChange, errors } = props;
 
+  const colors = useColorScheme();
+
   return (
-    <Card title={t('notes')} isLoading={!expense} withContainer>
+    <Card
+      title={t('notes')}
+      className="shadow-sm"
+      style={{ borderColor: colors.$24 }}
+      headerStyle={{ borderColor: colors.$20 }}
+      isLoading={!expense}
+      withContainer
+    >
       {expense && (
         <InputField
           value={expense.public_notes}

--- a/src/pages/expenses/create/components/Taxes.tsx
+++ b/src/pages/expenses/create/components/Taxes.tsx
@@ -16,6 +16,7 @@ import { useTranslation } from 'react-i18next';
 import { ExpenseCardProps } from './Details';
 import { DynamicLink } from '$app/components/DynamicLink';
 import { useAdmin } from '$app/common/hooks/permissions/useHasPermission';
+import { useColorScheme } from '$app/common/colors';
 
 interface Props extends ExpenseCardProps {
   taxInputType: 'by_rate' | 'by_amount';
@@ -29,6 +30,7 @@ export function TaxSettings(props: Props) {
 
   const { expense, handleChange, taxInputType, setTaxInputType } = props;
 
+  const colors = useColorScheme();
   const company = useCurrentCompany();
 
   const handleResetTaxValues = (value: 'by_rate' | 'by_amount') => {
@@ -54,7 +56,13 @@ export function TaxSettings(props: Props) {
   };
 
   return (
-    <Card title={t('taxes')} isLoading={!expense}>
+    <Card
+      title={t('taxes')}
+      className="shadow-sm"
+      style={{ borderColor: colors.$24 }}
+      headerStyle={{ borderColor: colors.$20 }}
+      isLoading={!expense}
+    >
       {company?.enabled_expense_tax_rates === 0 && (
         <Element leftSide={t('expense_tax_help')}>
           <DynamicLink

--- a/src/pages/expenses/documents/Documents.tsx
+++ b/src/pages/expenses/documents/Documents.tsx
@@ -16,12 +16,18 @@ import { Context } from '../edit/Edit';
 import { $refetch } from '$app/common/hooks/useRefetch';
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
+import { useTranslation } from 'react-i18next';
+import { Card } from '$app/components/cards';
+import { useColorScheme } from '$app/common/colors';
 import classNames from 'classnames';
 
 export default function Documents() {
-  const context: Context = useOutletContext();
+  const [t] = useTranslation();
 
+  const context: Context = useOutletContext();
   const { expense, isPreviewMode } = context;
+
+  const colors = useColorScheme();
 
   const hasPermission = useHasPermission();
   const entityAssigned = useEntityAssigned();
@@ -31,28 +37,44 @@ export default function Documents() {
   };
 
   return (
-    <div
-      className={classNames({
-        'w-2/3': !isPreviewMode,
-        'w-full': isPreviewMode,
-      })}
+    <Card
+      title={t('documents')}
+      className="shadow-sm"
+      style={{ borderColor: colors.$24 }}
+      headerStyle={{ borderColor: colors.$20 }}
     >
-      <Upload
-        widgetOnly
-        endpoint={endpoint('/api/v1/expenses/:id/upload', { id: expense.id })}
-        onSuccess={invalidateCache}
-        disableUpload={
-          !hasPermission('edit_expense') && !entityAssigned(expense)
-        }
-      />
+      <div className="flex flex-col items-center w-full px-6 py-2">
+        <div
+          className={classNames('w-full', {
+            'lg:w-2/3': !isPreviewMode,
+          })}
+        >
+          <Upload
+            widgetOnly
+            endpoint={endpoint('/api/v1/expenses/:id/upload', {
+              id: expense.id,
+            })}
+            onSuccess={invalidateCache}
+            disableUpload={
+              !hasPermission('edit_expense') && !entityAssigned(expense)
+            }
+          />
+        </div>
 
-      <DocumentsTable
-        documents={expense?.documents || []}
-        onDocumentDelete={invalidateCache}
-        disableEditableOptions={
-          !entityAssigned(expense, true) && !hasPermission('edit_expense')
-        }
-      />
-    </div>
+        <div
+          className={classNames('w-full', {
+            'lg:w-2/3': !isPreviewMode,
+          })}
+        >
+          <DocumentsTable
+            documents={expense?.documents || []}
+            onDocumentDelete={invalidateCache}
+            disableEditableOptions={
+              !entityAssigned(expense, true) && !hasPermission('edit_expense')
+            }
+          />
+        </div>
+      </div>
+    </Card>
   );
 }


### PR DESCRIPTION
@beganovich @turbo124 The PR includes redesign of Expense pages according to Figma design. Screenshot:

<img width="1261" alt="Screenshot 2025-05-15 at 13 35 00" src="https://github.com/user-attachments/assets/7cb55905-0ebd-404d-9b8b-6cf8a36055bf" />

Let me know your thoughts.