### PR TITLE
[Cleanup] Redesign E-Invoicing | Email Settings | Templates & Reminders

### DIFF
--- a/src/components/e-invoice/PaymentMeans.tsx
+++ b/src/components/e-invoice/PaymentMeans.tsx
@@ -31,6 +31,7 @@ import { useFormik } from 'formik';
 import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { get } from 'lodash';
 import { useRefreshCompanyUsers } from '$app/common/hooks/useRefreshCompanyUsers';
+import { useColorScheme } from '$app/common/colors';
 
 type Entity = 'company' | 'invoice' | 'client';
 
@@ -316,6 +317,7 @@ const PAYMENT_MEANS_FORM_ELEMENTS = {
 
 export const PaymentMeans = forwardRef<PaymentMeansFormComponent, Props>(
   (props, ref) => {
+    const colors = useColorScheme();
     const company = useCurrentCompany();
 
     const [t] = useTranslation();
@@ -454,7 +456,12 @@ export const PaymentMeans = forwardRef<PaymentMeansFormComponent, Props>(
     }, [company.e_invoice]);
 
     return (
-      <Card title={t('payment_means')}>
+      <Card
+        title={t('payment_means')}
+        className="shadow-sm"
+        style={{ borderColor: colors.$24 }}
+        headerStyle={{ borderColor: colors.$20 }}
+      >
         <Element leftSide="Code">
           <SelectField
             value={form.values.payment_means[0].code}

--- a/src/pages/settings/e-invoice/EInvoice.tsx
+++ b/src/pages/settings/e-invoice/EInvoice.tsx
@@ -215,7 +215,12 @@ export function EInvoice() {
       <PEPPOLPlanBanner />
 
       {Boolean(!company?.legal_entity_id) && (
-        <Card title={t('e_invoicing')}>
+        <Card
+          title={t('e_invoicing')}
+          className="shadow-sm"
+          style={{ borderColor: colors.$24 }}
+          headerStyle={{ borderColor: colors.$20 }}
+        >
           <Element
             leftSide={
               <PropertyCheckbox
@@ -377,6 +382,8 @@ export function EInvoice() {
                         handleChange('settings.e_quote_type', value)
                       }
                       disabled={disableSettingsField('e_quote_type')}
+                      dismissable={false}
+                      customSelector
                     >
                       <option value="OrderX_Comfort">OrderX_Comfort</option>
                       <option value="OrderX_Basic">OrderX_Basic</option>

--- a/src/pages/settings/e-invoice/common/components/EUTaxDetails.tsx
+++ b/src/pages/settings/e-invoice/common/components/EUTaxDetails.tsx
@@ -27,11 +27,14 @@ import { AxiosError } from 'axios';
 import { toast } from '$app/common/helpers/toast/toast';
 import { Country } from '$app/common/interfaces/country';
 import { X } from 'react-feather';
+import { useColorScheme } from '$app/common/colors';
 
 export function EUTaxDetails() {
   const [t] = useTranslation();
 
+  const colors = useColorScheme();
   const company = useCurrentCompany();
+
   const resolveCountry = useResolveCountry();
 
   const displayCountryOption = (countryId: string) => {
@@ -52,6 +55,9 @@ export function EUTaxDetails() {
     <Card
       title={t('additional_tax_identifiers')}
       description={t('additional_tax_identifiers_help').toString()}
+      className="shadow-sm"
+      style={{ borderColor: colors.$24 }}
+      headerStyle={{ borderColor: colors.$20 }}
     >
       <Element leftSide={t('new_identifier')}>
         <Configure />

--- a/src/pages/settings/e-invoice/peppol/Preferences.tsx
+++ b/src/pages/settings/e-invoice/peppol/Preferences.tsx
@@ -28,14 +28,17 @@ import { useQuery, useQueryClient } from 'react-query';
 import { AxiosError, AxiosResponse } from 'axios';
 import { ValidationBag } from '$app/common/interfaces/validation-bag';
 import { get } from 'lodash';
+import { useColorScheme } from '$app/common/colors';
 
 export function Preferences() {
   const { t } = useTranslation();
-  const company = useCurrentCompany();
   const refresh = useRefreshCompanyUsers();
+
+  const colors = useColorScheme();
+  const statics = useStaticsQuery();
+  const company = useCurrentCompany();
   const account = useCurrentAccount();
   const accentColor = useAccentColor();
-  const statics = useStaticsQuery();
 
   const form = useFormik({
     initialValues: {
@@ -128,7 +131,12 @@ export function Preferences() {
         </div>
       </Modal>
 
-      <Card title={`PEPPOL: ${t('preferences')}`}>
+      <Card
+        title={`PEPPOL: ${t('preferences')}`}
+        className="shadow-sm"
+        style={{ borderColor: colors.$24 }}
+        headerStyle={{ borderColor: colors.$20 }}
+      >
         <Element leftSide={t('status')}>
           <div className="flex flex-col">
             <p>

--- a/src/pages/settings/email-settings/EmailSettings.tsx
+++ b/src/pages/settings/email-settings/EmailSettings.tsx
@@ -39,6 +39,7 @@ import reactStringReplace from 'react-string-replace';
 import { useState } from 'react';
 import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { SendTimeModal } from './common/components/SendTimeModal';
+import { useColorScheme } from '$app/common/colors';
 
 export function EmailSettings() {
   useTitle('email_settings');
@@ -50,6 +51,7 @@ export function EmailSettings() {
     { name: t('email_settings'), href: '/settings/email_settings' },
   ];
 
+  const colors = useColorScheme();
   const company = useInjectCompanyChanges();
   const currentCompany = useCurrentCompany();
   const emailProviders = useEmailProviders();
@@ -88,7 +90,12 @@ export function EmailSettings() {
       >
         <AdvancedSettingsPlanAlert />
 
-        <Card title={t('settings')}>
+        <Card
+          title={t('settings')}
+          className="shadow-sm"
+          style={{ borderColor: colors.$24 }}
+          headerStyle={{ borderColor: colors.$20 }}
+        >
           <Element
             leftSide={
               <PropertyCheckbox
@@ -170,7 +177,13 @@ export function EmailSettings() {
             />
           </Element>
 
-          <Divider />
+          <div className="px-4 sm:px-6 py-4">
+            <Divider
+              className="border-dashed"
+              withoutPadding
+              style={{ borderColor: colors.$20 }}
+            />
+          </div>
 
           <Element
             leftSide={
@@ -191,6 +204,8 @@ export function EmailSettings() {
                 (!proPlan() && !enterprisePlan())
               }
               errorMessage={errors?.errors['settings.email_sending_method']}
+              customSelector
+              dismissable={false}
             >
               {emailProviders.map(
                 ({ value, label, enabled }) =>
@@ -311,6 +326,8 @@ export function EmailSettings() {
                   }
                   disabled={disableSettingsField('mailgun_endpoint')}
                   errorMessage={errors?.errors['settings.mailgun_endpoint']}
+                  customSelector
+                  dismissable={false}
                 >
                   <option value="api.mailgun.net" defaultChecked>
                     api.mailgun.net
@@ -453,7 +470,7 @@ export function EmailSettings() {
               }
             >
               <SelectField
-                value={company?.settings.entity_send_time || ''}
+                value={company?.settings.entity_send_time?.toString() || ''}
                 onValueChange={(value) =>
                   handleChange(
                     'settings.entity_send_time',
@@ -463,9 +480,10 @@ export function EmailSettings() {
                 withBlank
                 disabled={disableSettingsField('entity_send_time')}
                 errorMessage={errors?.errors['settings.entity_send_time']}
+                customSelector
               >
                 {[...Array(24).keys()].map((number, index) => (
-                  <option key={index} value={number + 1}>
+                  <option key={index} value={(number + 1).toString()}>
                     {dayjs()
                       .startOf('day')
                       .add(number + 1, 'hour')
@@ -480,7 +498,13 @@ export function EmailSettings() {
             <SMTPMailDriver />
           )}
 
-          <Divider />
+          <div className="px-4 sm:px-6 py-4">
+            <Divider
+              className="border-dashed"
+              withoutPadding
+              style={{ borderColor: colors.$20 }}
+            />
+          </div>
 
           <Element
             leftSide={
@@ -498,6 +522,8 @@ export function EmailSettings() {
               }
               disabled={disableSettingsField('email_style')}
               errorMessage={errors?.errors['settings.email_style']}
+              customSelector
+              dismissable={false}
             >
               <option value="plain">{t('plain')}</option>
               <option value="light">{t('light')}</option>

--- a/src/pages/settings/email-settings/EmailSettings.tsx
+++ b/src/pages/settings/email-settings/EmailSettings.tsx
@@ -91,7 +91,7 @@ export function EmailSettings() {
         <AdvancedSettingsPlanAlert />
 
         <Card
-          title={t('settings')}
+          title={t('email_settings')}
           className="shadow-sm"
           style={{ borderColor: colors.$24 }}
           headerStyle={{ borderColor: colors.$20 }}

--- a/src/pages/settings/email-settings/common/components/SMTPMailDriver.tsx
+++ b/src/pages/settings/email-settings/common/components/SMTPMailDriver.tsx
@@ -72,6 +72,7 @@ export function SMTPMailDriver() {
           onValueChange={(value) => handleChange('smtp_encryption', value)}
           withBlank
           disabled={isFormBusy}
+          customSelector
         >
           <option value="tls">STARTTLS</option>
           <option value="ssl">SSL/TLS</option>
@@ -94,7 +95,10 @@ export function SMTPMailDriver() {
         />
       </Element>
 
-      <Element leftSide={t('local_domain')} leftSideHelp={t('local_domain_help')}>
+      <Element
+        leftSide={t('local_domain')}
+        leftSideHelp={t('local_domain_help')}
+      >
         <InputField
           value={company?.smtp_local_domain || ''}
           onValueChange={(value) => handleChange('smtp_local_domain', value)}
@@ -114,7 +118,7 @@ export function SMTPMailDriver() {
 
       <Element leftSide={t('send_time')}>
         <SelectField
-          value={company?.settings.entity_send_time || ''}
+          value={company?.settings.entity_send_time?.toString() || ''}
           onValueChange={(value) =>
             handleChange(
               'settings.entity_send_time',
@@ -122,9 +126,10 @@ export function SMTPMailDriver() {
             )
           }
           withBlank
+          customSelector
         >
           {[...Array(24).keys()].map((number, index) => (
-            <option key={index} value={number + 1}>
+            <option key={index} value={(number + 1).toString()}>
               {dayjs()
                 .startOf('day')
                 .add(number + 1, 'hour')

--- a/src/pages/settings/templates-and-reminders/TemplatesAndReminders.tsx
+++ b/src/pages/settings/templates-and-reminders/TemplatesAndReminders.tsx
@@ -344,7 +344,7 @@ export function TemplatesAndReminders() {
       <AdvancedSettingsPlanAlert />
 
       <Card
-        title={t('edit')}
+        title={t('templates_and_reminders')}
         className="shadow-sm"
         style={{ borderColor: colors.$24 }}
         headerStyle={{ borderColor: colors.$20 }}

--- a/src/pages/settings/templates-and-reminders/TemplatesAndReminders.tsx
+++ b/src/pages/settings/templates-and-reminders/TemplatesAndReminders.tsx
@@ -14,7 +14,6 @@ import { freePlan } from '$app/common/guards/guards/free-plan';
 import { endpoint, isHosted, isSelfHosted } from '$app/common/helpers';
 import { generateEmailPreview } from '$app/common/helpers/emails/generate-email-preview';
 import { request } from '$app/common/helpers/request';
-import { useCurrentUser } from '$app/common/hooks/useCurrentUser';
 import { useInjectCompanyChanges } from '$app/common/hooks/useInjectCompanyChanges';
 import { useShouldDisableAdvanceSettings } from '$app/common/hooks/useShouldDisableAdvanceSettings';
 import { useTitle } from '$app/common/hooks/useTitle';
@@ -43,6 +42,7 @@ import { Spinner } from '$app/components/Spinner';
 import { NumberInputField } from '$app/components/forms/NumberInputField';
 import { EmailTemplate } from '$app/pages/invoices/email/components/Mailer';
 import { route } from '$app/common/helpers/route';
+import { useColorScheme } from '$app/common/colors';
 
 const REMINDERS = ['reminder1', 'reminder2', 'reminder3'];
 
@@ -59,11 +59,11 @@ export function TemplatesAndReminders() {
     },
   ];
 
+  const colors = useColorScheme();
   const company = useInjectCompanyChanges();
   const handleChange = useHandleCurrentCompanyChangeProperty();
   const handleSave = useHandleCompanySave();
   const onCancel = useDiscardChanges();
-  const user = useCurrentUser();
 
   const disableSettingsField = useDisableSettingsField();
 
@@ -343,7 +343,12 @@ export function TemplatesAndReminders() {
     >
       <AdvancedSettingsPlanAlert />
 
-      <Card title={t('edit')}>
+      <Card
+        title={t('edit')}
+        className="shadow-sm"
+        style={{ borderColor: colors.$24 }}
+        headerStyle={{ borderColor: colors.$20 }}
+      >
         <Element
           leftSide={
             <PropertyCheckbox
@@ -440,7 +445,7 @@ export function TemplatesAndReminders() {
         templateId === 'reminder_endless' ||
         templateId === 'quote_reminder1') &&
         !disableSettingsField(emailTemplateKey) && (
-          <Card>
+          <Card className="shadow-sm" style={{ borderColor: colors.$24 }}>
             {REMINDERS.includes(templateId) ||
             templateId === 'quote_reminder1' ? (
               <>
@@ -474,6 +479,8 @@ export function TemplatesAndReminders() {
                         value
                       )
                     }
+                    customSelector
+                    dismissable={false}
                   >
                     <option value="disabled" defaultChecked>
                       {t('disabled')}
@@ -582,6 +589,7 @@ export function TemplatesAndReminders() {
                       )
                     }
                     withBlank
+                    customSelector
                   >
                     {Object.keys(frequencies).map((frequency, index) => (
                       <option key={index} value={frequency}>
@@ -596,7 +604,12 @@ export function TemplatesAndReminders() {
         )}
 
       {preview && (
-        <Card className="scale-y-100" title={preview.subject}>
+        <Card
+          className="scale-y-100 shadow-sm"
+          style={{ borderColor: colors.$24 }}
+          headerStyle={{ borderColor: colors.$20 }}
+          title={preview.subject}
+        >
           {!isLoadingPdf ? (
             <iframe
               srcDoc={generateEmailPreview(preview.body, preview.wrapper)}
@@ -615,7 +628,12 @@ export function TemplatesAndReminders() {
         </Card>
       )}
 
-      <Card title={t('variables')}>
+      <Card
+        title={t('variables')}
+        className="shadow-sm"
+        style={{ borderColor: colors.$24 }}
+        headerStyle={{ borderColor: colors.$20 }}
+      >
         <Element leftSide={t('invoice')} className="flex-wrap">
           <div className="flex flex-wrap">
             {variables.invoice.map((variable, index) => (


### PR DESCRIPTION
@beganovich @turbo124 The PR includes a redesign of E-Invoicing, Email Settings, and Templates & Reminders pages according to the Figma design. Screenshots:

![Screenshot 2025-05-31 at 18 09 10](https://github.com/user-attachments/assets/09bcc523-ce8a-4d4e-b0ac-e9ac48ff290d)

![Screenshot 2025-05-31 at 18 09 46](https://github.com/user-attachments/assets/60119826-c366-457f-820e-50c17a2d4fa7)

![Screenshot 2025-05-31 at 18 10 07](https://github.com/user-attachments/assets/4176a34d-58a1-4c6c-aa65-46427e1bdcde)

Let me know your thoughts.