### PR TITLE
[Cleanup] Redesign Credit Cards & Banks | Group Settings | Payment Links

### DIFF
--- a/src/components/PropertyCheckbox.tsx
+++ b/src/components/PropertyCheckbox.tsx
@@ -77,7 +77,7 @@ export function PropertyCheckbox(props: Props) {
   }, [props.checked]);
 
   return (
-    <div className="flex items-center">
+    <div className="flex items-center space-x-2">
       {!isCompanySettingsActive && (
         <Checkbox
           checked={checked}

--- a/src/components/layouts/Settings.tsx
+++ b/src/components/layouts/Settings.tsx
@@ -20,7 +20,7 @@ import { companySettingsErrorsAtom } from '../../pages/settings/common/atoms';
 import { ValidationAlert } from '$app/components/ValidationAlert';
 import { useSettingsRoutes } from './common/hooks';
 import { Icon } from '../icons/Icon';
-import { MdClose, MdGroup } from 'react-icons/md';
+import { MdGroup } from 'react-icons/md';
 import { FaObjectGroup } from 'react-icons/fa';
 import { useActiveSettingsDetails } from '$app/common/hooks/useActiveSettingsDetails';
 import { useSwitchToCompanySettings } from '$app/common/hooks/useSwitchToCompanySettings';
@@ -28,6 +28,7 @@ import { useCurrentSettingsLevel } from '$app/common/hooks/useCurrentSettingsLev
 import { useColorScheme } from '$app/common/colors';
 import { styled } from 'styled-components';
 import { Sparkle } from '../icons/Sparkle';
+import { XMark } from '../icons/XMark';
 
 interface Props {
   title: string;
@@ -90,10 +91,10 @@ export function Settings(props: Props) {
         <div className="col-span-12 lg:col-span-3">
           {(isGroupSettingsActive || isClientSettingsActive) && (
             <div
-              className="flex items-center justify-between border py-3 rounded space-x-3 px-2"
+              className="flex items-center justify-between border py-3 space-x-3 px-3 rounded-md shadow-sm"
               style={{
                 backgroundColor: colors.$1,
-                borderColor: colors.$5,
+                borderColor: colors.$24,
               }}
             >
               <div className="flex items-center space-x-2 flex-1 min-w-0">
@@ -113,7 +114,7 @@ export function Settings(props: Props) {
               </div>
 
               <div
-                className="cursor-pointer"
+                className="cursor-pointer hover:opacity-75"
                 onClick={() => {
                   switchToCompanySettings();
 
@@ -121,7 +122,7 @@ export function Settings(props: Props) {
                   isClientSettingsActive && navigate('/clients');
                 }}
               >
-                <Icon element={MdClose} size={20} />
+                <XMark color={colors.$3} size="1rem" />
               </div>
             </div>
           )}

--- a/src/pages/settings/bank-accounts/common/components/ConnectAccounts.tsx
+++ b/src/pages/settings/bank-accounts/common/components/ConnectAccounts.tsx
@@ -106,7 +106,7 @@ export function ConnectAccounts() {
             <div
               className="flex flex-col cursor-pointer border-4"
               style={{
-                borderColor: account === 'yodlee' ? accentColor : colors.$5,
+                borderColor: account === 'yodlee' ? accentColor : colors.$24,
                 height: '10.25rem',
               }}
               onClick={() => setAccount('yodlee')}
@@ -135,7 +135,7 @@ export function ConnectAccounts() {
               data-cy="nordigenBox"
               className="flex flex-col items-center cursor-pointer border-4"
               style={{
-                borderColor: account === 'nordigen' ? accentColor : colors.$5,
+                borderColor: account === 'nordigen' ? accentColor : colors.$24,
                 height: '10.25rem',
               }}
               onClick={() => setAccount('nordigen')}
@@ -162,6 +162,7 @@ export function ConnectAccounts() {
           )}
 
           <Button
+            behavior="button"
             onClick={handleConnectAccount}
             disableWithoutIcon
             disabled={!account}

--- a/src/pages/settings/bank-accounts/components/Details.tsx
+++ b/src/pages/settings/bank-accounts/components/Details.tsx
@@ -14,6 +14,7 @@ import { BankAccount } from '$app/common/interfaces/bank-accounts';
 import { useTranslation } from 'react-i18next';
 import { Card, Element } from '../../../../components/cards';
 import { useResolveCurrency } from '$app/common/hooks/useResolveCurrency';
+import { useColorScheme } from '$app/common/colors';
 
 interface Props {
   accountDetails?: BankAccount;
@@ -30,19 +31,27 @@ export function Details(props: Props) {
 
   const [t] = useTranslation();
 
+  const colors = useColorScheme();
   const company = useCurrentCompany();
 
   const formatMoney = useFormatMoney();
   const resolveCurrency = useResolveCurrency({ resolveBy: 'code' });
 
   return (
-    <Card title={t('details')}>
+    <Card
+      title={t('details')}
+      className="shadow-sm"
+      style={{ borderColor: colors.$24 }}
+      headerStyle={{ borderColor: colors.$20 }}
+    >
       <Element leftSide={t('balance')}>
-        {formatMoney(
-          balance || 0,
-          company.settings.country_id,
-          resolveCurrency(currency)?.id
-        )}
+        <span className="font-mono">
+          {formatMoney(
+            balance || 0,
+            company.settings.country_id,
+            resolveCurrency(currency)?.id
+          )}
+        </span>
       </Element>
       <Element leftSide={t('type')}>{bankAccountType}</Element>
       <Element leftSide={t('provider')}>{providerName}</Element>

--- a/src/pages/settings/bank-accounts/components/transaction-rules/components/RuleModal.tsx
+++ b/src/pages/settings/bank-accounts/components/transaction-rules/components/RuleModal.tsx
@@ -113,12 +113,15 @@ export function RuleModal(props: Props) {
       title={ruleIndex > -1 ? t('edit_rule') : t('add_rule')}
       visible={visible}
       onClose={() => setVisible(false)}
+      overflowVisible
     >
       <SelectField
         required
         label={t('field')}
         value={rule?.search_key}
         onValueChange={(value) => handleChangeRuleField(value)}
+        customSelector
+        dismissable={false}
       >
         <option defaultChecked value="description">
           {t('description')}
@@ -131,6 +134,8 @@ export function RuleModal(props: Props) {
         label={t('operator')}
         value={rule?.operator}
         onValueChange={(value) => handleChangeRule('operator', value)}
+        customSelector
+        dismissable={false}
       >
         {rule?.search_key &&
           OPERATORS[rule.search_key as keyof typeof OPERATORS].map(

--- a/src/pages/settings/bank-accounts/components/transaction-rules/components/TransactionRuleForm.tsx
+++ b/src/pages/settings/bank-accounts/components/transaction-rules/components/TransactionRuleForm.tsx
@@ -60,10 +60,12 @@ export function TransactionRuleForm(props: Props) {
             ? t('new_transaction_rule')
             : t('edit_transaction_rule')
         }
+        className="shadow-sm"
+        style={{ borderColor: colors.$24 }}
+        headerStyle={{ borderColor: colors.$20 }}
       >
         <Element leftSide={t('name')} required>
           <InputField
-            style={{ color: colors.$3, colorScheme: colors.$0, backgroundColor: colors.$1, borderColor: colors.$4 }}
             required
             value={transactionRule.name}
             onValueChange={(value) => handleChange('name', value)}
@@ -76,7 +78,6 @@ export function TransactionRuleForm(props: Props) {
           leftSideHelp={t('match_all_rules_help')}
         >
           <Toggle
-            style={{ color: colors.$3, colorScheme: colors.$0, backgroundColor: colors.$1, borderColor: colors.$4 }}
             checked={transactionRule.matches_on_all || false}
             onValueChange={(value) => handleChange('matches_on_all', value)}
           />
@@ -87,8 +88,6 @@ export function TransactionRuleForm(props: Props) {
           leftSideHelp={t('auto_convert_help')}
         >
           <Toggle
-            style={{ color: colors.$3, colorScheme: colors.$0, backgroundColor: colors.$1, borderColor: colors.$4 }}
-
             checked={transactionRule.auto_convert || false}
             onValueChange={(value) => handleChange('auto_convert', value)}
           />
@@ -125,15 +124,23 @@ export function TransactionRuleForm(props: Props) {
         <Tbody>
           {transactionRule.rules?.map((rule, index) => (
             <Tr key={index} className="py-2">
-              <Td width="30%" style={{ backgroundColor: colors.$2, color: colors.$3, colorScheme: colors.$0 }}>{t(rule.search_key)}</Td>
+              <Td width="30%">{t(rule.search_key)}</Td>
 
-              <Td width="30%" style={{ color: colors.$3, colorScheme: colors.$0, backgroundColor: colors.$1, borderColor: colors.$4 }}>{t(rule.operator)}</Td>
+              <Td width="30%">{t(rule.operator)}</Td>
 
-              <Td width="40%" style={{ color: colors.$3, colorScheme: colors.$0, backgroundColor: colors.$1, borderColor: colors.$4 }}>
+              <Td width="40%">
                 <div className="flex justify-between">
                   <span>{rule.value}</span>
 
-                  <div className="flex space-x-8" style={{ color: colors.$3, colorScheme: colors.$0, backgroundColor: colors.$1, borderColor: colors.$4 }}>
+                  <div
+                    className="flex space-x-8"
+                    style={{
+                      color: colors.$3,
+                      colorScheme: colors.$0,
+                      backgroundColor: colors.$1,
+                      borderColor: colors.$4,
+                    }}
+                  >
                     <MdEdit
                       className="cursor-pointer"
                       color={accentColor}
@@ -156,10 +163,9 @@ export function TransactionRuleForm(props: Props) {
             </Tr>
           ))}
 
-          <Tr style={{ color: colors.$3, colorScheme: colors.$0, backgroundColor: colors.$1, borderColor: colors.$4 }}>
-            <Td colSpan={100} style={{ color: colors.$3, colorScheme: colors.$0, backgroundColor: colors.$1, borderColor: colors.$4 }}>
+          <Tr>
+            <Td colSpan={100}>
               <button
-                style={{ color: colors.$3, colorScheme: colors.$0, backgroundColor: colors.$1, borderColor: colors.$4 }}
                 onClick={() => {
                   setRuleIndex(-1);
                   setIsRuleModalOpen(true);

--- a/src/pages/settings/bank-accounts/components/transaction-rules/components/TransactionRuleForm.tsx
+++ b/src/pages/settings/bank-accounts/components/transaction-rules/components/TransactionRuleForm.tsx
@@ -19,10 +19,13 @@ import Toggle from '$app/components/forms/Toggle';
 import { VendorSelector } from '$app/components/vendors/VendorSelector';
 import { Dispatch, SetStateAction, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { MdAdd, MdDelete, MdEdit } from 'react-icons/md';
 import { useHandleChange } from '../hooks/useHandleChange';
 import { RuleModal } from './RuleModal';
 import { useColorScheme } from '$app/common/colors';
+import styled from 'styled-components';
+import { Plus } from '$app/components/icons/Plus';
+import { Pencil } from '$app/components/icons/Pencil';
+import { Trash } from '$app/components/icons/Trash';
 
 interface Props {
   transactionRule: TransactionRule;
@@ -31,6 +34,14 @@ interface Props {
   setErrors: Dispatch<SetStateAction<ValidationBag | undefined>>;
   page?: 'create' | 'edit';
 }
+
+const AddRuleButton = styled.div`
+  background-color: ${({ theme }) => theme.backgroundColor};
+
+  &:hover {
+    background-color: ${({ theme }) => theme.hoverBackgroundColor};
+  }
+`;
 
 export function TransactionRuleForm(props: Props) {
   const [t] = useTranslation();
@@ -123,7 +134,13 @@ export function TransactionRuleForm(props: Props) {
 
         <Tbody>
           {transactionRule.rules?.map((rule, index) => (
-            <Tr key={index} className="py-2">
+            <Tr
+              key={index}
+              className="py-2 border-b"
+              style={{
+                borderColor: colors.$20,
+              }}
+            >
               <Td width="30%">{t(rule.search_key)}</Td>
 
               <Td width="30%">{t(rule.operator)}</Td>
@@ -132,31 +149,23 @@ export function TransactionRuleForm(props: Props) {
                 <div className="flex justify-between">
                   <span>{rule.value}</span>
 
-                  <div
-                    className="flex space-x-8"
-                    style={{
-                      color: colors.$3,
-                      colorScheme: colors.$0,
-                      backgroundColor: colors.$1,
-                      borderColor: colors.$4,
-                    }}
-                  >
-                    <MdEdit
-                      className="cursor-pointer"
-                      color={accentColor}
-                      fontSize={22}
+                  <div className="flex space-x-6">
+                    <div
+                      className="cursor-pointer hover:opacity-75"
                       onClick={() => {
                         setRuleIndex(index);
                         setIsRuleModalOpen(true);
                       }}
-                    />
+                    >
+                      <Pencil color="#2176FF" size="1.2rem" />
+                    </div>
 
-                    <MdDelete
-                      className="cursor-pointer"
-                      color={accentColor}
-                      fontSize={22}
+                    <div
+                      className="cursor-pointer hover:opacity-75"
                       onClick={() => handleRemoveRule(index)}
-                    />
+                    >
+                      <Trash color="#ef4444" size="1.2rem" />
+                    </div>
                   </div>
                 </div>
               </Td>
@@ -164,22 +173,22 @@ export function TransactionRuleForm(props: Props) {
           ))}
 
           <Tr>
-            <Td colSpan={100}>
-              <button
+            <Td colSpan={100} className="p-1" withoutPadding>
+              <AddRuleButton
+                className="w-full py-2 inline-flex justify-center items-center space-x-2 rounded-[0.1875rem] cursor-pointer"
                 onClick={() => {
                   setRuleIndex(-1);
                   setIsRuleModalOpen(true);
                 }}
-                className="w-full py-1 inline-flex justify-center items-center space-x-2"
+                theme={{
+                  backgroundColor: colors.$1,
+                  hoverBackgroundColor: colors.$20,
+                }}
               >
-                <MdAdd
-                  className="cursor-pointer"
-                  color={accentColor}
-                  fontSize={18}
-                />
+                <Plus color={colors.$3} size="1rem" />
 
                 <span>{t('add_rule')}</span>
-              </button>
+              </AddRuleButton>
             </Td>
           </Tr>
         </Tbody>

--- a/src/pages/settings/bank-accounts/create/Create.tsx
+++ b/src/pages/settings/bank-accounts/create/Create.tsx
@@ -21,11 +21,14 @@ import { Settings } from '../../../../components/layouts/Settings';
 import { useBlankBankAccountQuery } from '../common/queries';
 import { useHandleCreate } from './hooks/useHandleCreate';
 import { BankAccountsPlanAlert } from '../common/components/BankAccountsPlanAlert';
+import { useColorScheme } from '$app/common/colors';
 
 export function Create() {
   const [t] = useTranslation();
 
   useTitle('new_bank_account');
+
+  const colors = useColorScheme();
 
   const { data } = useBlankBankAccountQuery();
 
@@ -73,7 +76,13 @@ export function Create() {
     >
       {!enterprisePlan() && isHosted() && <BankAccountsPlanAlert />}
 
-      <Card onFormSubmit={handleSave} title={t('new_bank_account')}>
+      <Card
+        onFormSubmit={handleSave}
+        title={t('new_bank_account')}
+        className="shadow-sm"
+        style={{ borderColor: colors.$24 }}
+        headerStyle={{ borderColor: colors.$20 }}
+      >
         <Element leftSide={t('account_name')}>
           <InputField
             value={bankAccount?.bank_account_name}

--- a/src/pages/settings/bank-accounts/edit/Edit.tsx
+++ b/src/pages/settings/bank-accounts/edit/Edit.tsx
@@ -25,11 +25,14 @@ import Toggle from '$app/components/forms/Toggle';
 import { useBankAccountQuery } from '$app/pages/settings/bank-accounts/common/queries';
 import { Settings } from '$app/components/layouts/Settings';
 import { $refetch } from '$app/common/hooks/useRefetch';
+import { useColorScheme } from '$app/common/colors';
 
 export function Edit() {
   useTitle('edit_bank_account');
 
   const [t] = useTranslation();
+
+  const colors = useColorScheme();
 
   const navigate = useNavigate();
 
@@ -104,7 +107,13 @@ export function Edit() {
       docsLink="en/basic-settings/#edit_bank_account"
       onSaveClick={handleSave}
     >
-      <Card onFormSubmit={handleSave} title={t('edit_bank_account')}>
+      <Card
+        onFormSubmit={handleSave}
+        title={t('edit_bank_account')}
+        className="shadow-sm"
+        style={{ borderColor: colors.$24 }}
+        headerStyle={{ borderColor: colors.$20 }}
+      >
         <Element leftSide={t('account_name')}>
           <InputField
             value={accountDetails?.bank_account_name}

--- a/src/pages/settings/group-settings/create/Create.tsx
+++ b/src/pages/settings/group-settings/create/Create.tsx
@@ -23,12 +23,14 @@ import { useHandleCreate } from '../common/hooks/useHandleCreate';
 import { Card } from '$app/components/cards';
 import { useShouldDisableAdvanceSettings } from '$app/common/hooks/useShouldDisableAdvanceSettings';
 import { AdvancedSettingsPlanAlert } from '$app/components/AdvancedSettingsPlanAlert';
+import { useColorScheme } from '$app/common/colors';
 
 export function Create() {
   const [t] = useTranslation();
 
   const { documentTitle } = useTitle('new_group');
 
+  const colors = useColorScheme();
   const showPlanAlert = useShouldDisableAdvanceSettings();
 
   const pages = [
@@ -68,7 +70,12 @@ export function Create() {
       <AdvancedSettingsPlanAlert />
 
       {groupSettings && (
-        <Card title={t('new_group')}>
+        <Card
+          title={t('new_group')}
+          className="shadow-sm"
+          style={{ borderColor: colors.$24 }}
+          headerStyle={{ borderColor: colors.$20 }}
+        >
           <GroupSettingsForm
             groupSettings={groupSettings}
             handleChange={handleChange}

--- a/src/pages/settings/group-settings/edit/Edit.tsx
+++ b/src/pages/settings/group-settings/edit/Edit.tsx
@@ -109,7 +109,7 @@ export function Edit() {
         headerStyle={{ borderColor: colors.$20 }}
         headerClassName={classNames('px-4 sm:px-6', {
           'pt-4': currentTabIndex === 0,
-          'pt-[1.4rem] pb-[0.425rem]': currentTabIndex !== 0,
+          'pt-[1.45rem] pb-[0.46rem]': currentTabIndex !== 0,
         })}
         topRight={
           <>

--- a/src/pages/settings/group-settings/edit/components/Clients.tsx
+++ b/src/pages/settings/group-settings/edit/components/Clients.tsx
@@ -23,7 +23,7 @@ export function Clients() {
   const customBulkActions = useCustomBulkActions();
 
   return (
-    <div className="mt-8">
+    <div className="px-4 sm:px-6 pt-3">
       <DataTable
         resource="client"
         endpoint={route(

--- a/src/pages/settings/subscriptions/common/components/MultipleProductSelector.tsx
+++ b/src/pages/settings/subscriptions/common/components/MultipleProductSelector.tsx
@@ -11,13 +11,14 @@
 import { Product } from '$app/common/interfaces/product';
 import { Subscription } from '$app/common/interfaces/subscription';
 import { Link, SelectField } from '$app/components/forms';
-import { MdClose } from 'react-icons/md';
 import { useEffect, useState } from 'react';
 import { useFormatMoney } from '$app/common/hooks/money/useFormatMoney';
 import { useAccentColor } from '$app/common/hooks/useAccentColor';
 import { route } from '$app/common/helpers/route';
 import { BsBox } from 'react-icons/bs';
 import { useNavigate } from 'react-router-dom';
+import { CircleXMark } from '$app/components/icons/CircleXMark';
+import { useColorScheme } from '$app/common/colors';
 
 interface Props {
   type:
@@ -34,6 +35,7 @@ interface Props {
 }
 
 export function MultipleProductSelector(props: Props) {
+  const colors = useColorScheme();
   const accentColor = useAccentColor();
 
   const navigate = useNavigate();
@@ -51,7 +53,7 @@ export function MultipleProductSelector(props: Props) {
 
     if (productIndex > -1) {
       const updatedSelectedProducts = selectedProducts.filter(
-        (product, index) => index !== productIndex
+        (_, index) => index !== productIndex
       );
 
       setSelectedProducts(updatedSelectedProducts);
@@ -153,14 +155,14 @@ export function MultipleProductSelector(props: Props) {
                   </span>
 
                   <div className="flex min-w-0 flex-1 justify-between space-x-4 pt-1.5">
-                    <div className="flex flex-1 justify-between space-x-5">
+                    <div className="flex items-center flex-1 justify-between space-x-5">
                       <Link
                         to={route(`/products/:id/edit`, { id: product.id })}
                       >
                         {product.product_key}
                       </Link>
 
-                      <span>
+                      <span className="font-mono">
                         {formatMoney(
                           product.price,
                           product.company?.settings.country_id,
@@ -169,12 +171,16 @@ export function MultipleProductSelector(props: Props) {
                       </span>
                     </div>
 
-                    <div className="whitespace-nowrap text-right text-sm text-gray-500">
-                      <MdClose
-                        className="cursor-pointer ml-10 xl:ml-20"
-                        color={accentColor}
-                        fontSize={19}
-                        onClick={() => handleRemoveProduct(product.id)}
+                    <div
+                      className="whitespace-nowrap text-right cursor-pointer"
+                      onClick={() => handleRemoveProduct(product.id)}
+                    >
+                      <CircleXMark
+                        color={colors.$16}
+                        hoverColor={colors.$3}
+                        borderColor={colors.$5}
+                        hoverBorderColor={colors.$17}
+                        size="1.4rem"
                       />
                     </div>
                   </div>

--- a/src/pages/settings/subscriptions/common/components/MultipleProductSelector.tsx
+++ b/src/pages/settings/subscriptions/common/components/MultipleProductSelector.tsx
@@ -112,9 +112,10 @@ export function MultipleProductSelector(props: Props) {
     <>
       {props.products && (
         <SelectField
-          onValueChange={(value) => setSelectedProductId(value)}
           value={selectedProductId}
+          onValueChange={(value) => setSelectedProductId(value)}
           withBlank
+          customSelector
         >
           {props.products.map((product, index) => (
             <option key={index} value={product.id}>

--- a/src/pages/settings/subscriptions/common/components/Overview.tsx
+++ b/src/pages/settings/subscriptions/common/components/Overview.tsx
@@ -8,7 +8,7 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
-import { Card, Element } from '$app/components/cards';
+import { Element } from '$app/components/cards';
 import { InputField } from '$app/components/forms';
 import { GroupSettings } from '$app/common/interfaces/group-settings';
 import { Product } from '$app/common/interfaces/product';
@@ -41,7 +41,7 @@ export function Overview(props: OverviewSubscriptionProps) {
   const { subscription, handleChange, errors, products, page } = props;
 
   return (
-    <Card title={t('overview')}>
+    <>
       <Element leftSide={t('name')} required>
         <InputField
           value={subscription.name}
@@ -123,6 +123,6 @@ export function Overview(props: OverviewSubscriptionProps) {
           />
         </Element>
       )}
-    </Card>
+    </>
   );
 }

--- a/src/pages/settings/subscriptions/common/components/Settings.tsx
+++ b/src/pages/settings/subscriptions/common/components/Settings.tsx
@@ -77,7 +77,7 @@ export function Settings(props: SubscriptionProps) {
           errorMessage={errors?.errors.auto_bill}
           customSelector
         >
-          <option defaultChecked></option>
+          <option defaultChecked value=""></option>
           <option value="always">{t('enabled')}</option>
           <option value="optout">{t('optout')}</option>
           <option value="optin">{t('optin')}</option>

--- a/src/pages/settings/subscriptions/common/components/Settings.tsx
+++ b/src/pages/settings/subscriptions/common/components/Settings.tsx
@@ -8,7 +8,7 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
-import { Card, Element } from '$app/components/cards';
+import { Element } from '$app/components/cards';
 import { useTranslation } from 'react-i18next';
 import { SubscriptionProps } from './Overview';
 import frequencies from '$app/common/constants/frequency';
@@ -36,12 +36,14 @@ export function Settings(props: SubscriptionProps) {
   }, [subscription.trial_enabled, subscription.allow_cancellation]);
 
   return (
-    <Card title={t('settings')}>
+    <>
       <Element leftSide={t('frequency')}>
         <SelectField
           value={subscription.frequency_id}
           errorMessage={errors?.errors.frequency_id}
           onValueChange={(value) => handleChange('frequency_id', value)}
+          customSelector
+          dismissable={false}
         >
           <option value="">{t('once')}</option>
           {Object.keys(frequencies).map((frequency, index) => (
@@ -52,30 +54,28 @@ export function Settings(props: SubscriptionProps) {
         </SelectField>
       </Element>
 
-
       <Element leftSide={t('remaining_cycles')}>
         <SelectField
-          value={subscription?.remaining_cycles}
+          value={subscription?.remaining_cycles.toString()}
           onValueChange={(value) => handleChange('remaining_cycles', value)}
           errorMessage={errors?.errors.remaining_cycles}
+          customSelector
         >
           <option value="-1">{t('endless')}</option>
           {[...Array(37).keys()].map((number, index) => (
-            <option value={number} key={index}>
+            <option value={number.toString()} key={index}>
               {number}
             </option>
           ))}
         </SelectField>
       </Element>
 
-
-
-
       <Element leftSide={t('auto_bill')}>
         <SelectField
-          value={subscription.auto_bill}
+          value={subscription.auto_bill || ''}
           onValueChange={(value) => handleChange('auto_bill', value)}
           errorMessage={errors?.errors.auto_bill}
+          customSelector
         >
           <option defaultChecked></option>
           <option value="always">{t('enabled')}</option>
@@ -96,6 +96,21 @@ export function Settings(props: SubscriptionProps) {
       <Element leftSide={t('promo_discount')}>
         <Inline>
           <div className="w-full lg:w-1/2">
+            <SelectField
+              value={subscription.is_amount_discount.toString()}
+              onValueChange={(value) =>
+                handleChange('is_amount_discount', JSON.parse(value))
+              }
+              errorMessage={errors?.errors.is_amount_discount}
+              customSelector
+              dismissable={false}
+            >
+              <option value="true">{t('amount')}</option>
+              <option value="false">{t('percent')}</option>
+            </SelectField>
+          </div>
+
+          <div className="w-full lg:w-1/2">
             <NumberInputField
               value={subscription.promo_discount || ''}
               onValueChange={(value) =>
@@ -103,19 +118,6 @@ export function Settings(props: SubscriptionProps) {
               }
               errorMessage={errors?.errors.promo_discount}
             />
-          </div>
-
-          <div className="w-full lg:w-1/2">
-            <SelectField
-              value={subscription.is_amount_discount.toString()}
-              onValueChange={(value) =>
-                handleChange('is_amount_discount', JSON.parse(value))
-              }
-              errorMessage={errors?.errors.is_amount_discount}
-            >
-              <option value="true">{t('amount')}</option>
-              <option value="false">{t('percent')}</option>
-            </SelectField>
           </div>
         </Inline>
       </Element>
@@ -264,6 +266,6 @@ export function Settings(props: SubscriptionProps) {
           />
         </Element>
       )}
-    </Card>
+    </>
   );
 }

--- a/src/pages/settings/subscriptions/common/components/Steps.tsx
+++ b/src/pages/settings/subscriptions/common/components/Steps.tsx
@@ -1,10 +1,8 @@
 import { useTranslation } from 'react-i18next';
 import { SubscriptionProps } from './Overview';
-import { Card, Element } from '$app/components/cards';
+import { Element } from '$app/components/cards';
 import { SelectField } from '$app/components/forms';
 import { useEffect, useState } from 'react';
-import { Icon } from '$app/components/icons/Icon';
-import { MdClose, MdDragHandle } from 'react-icons/md';
 import {
   DragDropContext,
   Draggable,
@@ -16,6 +14,9 @@ import { request } from '$app/common/helpers/request';
 import { endpoint } from '$app/common/helpers';
 import { AxiosError, AxiosResponse } from 'axios';
 import { ValidationBag } from '$app/common/interfaces/validation-bag';
+import { GridDotsVertical } from '$app/components/icons/GridDotsVertical';
+import { useColorScheme } from '$app/common/colors';
+import { CircleXMark } from '$app/components/icons/CircleXMark';
 
 export type Steps = Record<
   string,
@@ -28,6 +29,8 @@ export function Steps({
   errors,
 }: SubscriptionProps) {
   const { t } = useTranslation();
+
+  const colors = useColorScheme();
 
   const steps = subscription.steps ? subscription.steps.split(',') : [];
 
@@ -94,7 +97,7 @@ export function Steps({
     });
 
   return (
-    <Card title={t('steps')}>
+    <>
       <Element leftSide={t('authentication')}>
         <SelectField
           value=""
@@ -102,6 +105,7 @@ export function Steps({
             handleChange('steps', [...steps, value].join(','));
           }}
           withBlank
+          customSelector
         >
           {auth.map((column, index) => (
             <option key={index} value={column.id}>
@@ -118,6 +122,7 @@ export function Steps({
             handleChange('steps', [...steps, value].join(','));
           }}
           withBlank
+          customSelector
         >
           {filtered
             .filter((step) => !step.id.startsWith('auth.'))
@@ -147,18 +152,27 @@ export function Steps({
                         className="flex items-center justify-between py-2"
                       >
                         <div className="flex space-x-2 items-center">
-                          <Icon
-                            className="cursor-pointer"
-                            element={MdClose}
-                            size={20}
-                            onClick={() => handleDelete(step)}
-                          />
+                          <div {...provided.dragHandleProps}>
+                            <GridDotsVertical
+                              size="1.2rem"
+                              color={colors.$17}
+                            />
+                          </div>
 
                           <p>{t(step)}</p>
                         </div>
 
-                        <div {...provided.dragHandleProps}>
-                          <Icon element={MdDragHandle} size={23} />
+                        <div
+                          className="cursor-pointer"
+                          onClick={() => handleDelete(step)}
+                        >
+                          <CircleXMark
+                            color={colors.$16}
+                            hoverColor={colors.$3}
+                            borderColor={colors.$5}
+                            hoverBorderColor={colors.$17}
+                            size="1.6rem"
+                          />
                         </div>
                       </div>
                     )}
@@ -181,6 +195,6 @@ export function Steps({
           </div>
         ) : null}
       </Element>
-    </Card>
+    </>
   );
 }

--- a/src/pages/settings/subscriptions/common/components/Webhook.tsx
+++ b/src/pages/settings/subscriptions/common/components/Webhook.tsx
@@ -93,7 +93,7 @@ export function Webhook(props: SubscriptionProps) {
           }
           customSelector
         >
-          <option defaultChecked></option>
+          <option defaultChecked value=""></option>
           <option value="post">{t('post')}</option>
           <option value="put">{t('put')}</option>
         </SelectField>

--- a/src/pages/settings/subscriptions/common/components/Webhook.tsx
+++ b/src/pages/settings/subscriptions/common/components/Webhook.tsx
@@ -8,19 +8,21 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
-import { Card, Element } from '$app/components/cards';
+import { Element } from '$app/components/cards';
 import { InputField, SelectField } from '$app/components/forms';
 import { useAccentColor } from '$app/common/hooks/useAccentColor';
 import { Subscription } from '$app/common/interfaces/subscription';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { BiPlusCircle } from 'react-icons/bi';
-import { MdClose } from 'react-icons/md';
 import { SubscriptionProps } from './Overview';
+import { Plus } from '$app/components/icons/Plus';
+import { useColorScheme } from '$app/common/colors';
+import { CircleXMark } from '$app/components/icons/CircleXMark';
 
 export function Webhook(props: SubscriptionProps) {
   const [t] = useTranslation();
 
+  const colors = useColorScheme();
   const accentColor = useAccentColor();
 
   const { subscription, handleChange, errors } = props;
@@ -61,7 +63,7 @@ export function Webhook(props: SubscriptionProps) {
   };
 
   return (
-    <Card title={t('webhook')}>
+    <>
       <Element leftSide={t('webhook_url')}>
         <InputField
           value={subscription.webhook_configuration.post_purchase_url}
@@ -89,6 +91,7 @@ export function Webhook(props: SubscriptionProps) {
           errorMessage={
             errors?.errors['webhook_configuration.post_purchase_rest_method']
           }
+          customSelector
         >
           <option defaultChecked></option>
           <option value="post">{t('post')}</option>
@@ -111,11 +114,12 @@ export function Webhook(props: SubscriptionProps) {
               onValueChange={(value) => setHeaderValue(value)}
             />
 
-            <BiPlusCircle
-              className="mt-7 text-gray-800 cursor-pointer"
-              fontSize={25}
+            <div
+              className="mt-7 cursor-pointer hover:opacity-75"
               onClick={() => headerKey && headerValue && handleAddHeader()}
-            />
+            >
+              <Plus color={colors.$3} size="1.3rem" />
+            </div>
           </div>
 
           {headers?.map(([key, value], index) => (
@@ -127,12 +131,18 @@ export function Webhook(props: SubscriptionProps) {
 
               <span className="flex-1 text-start">{value}</span>
 
-              <MdClose
+              <div
                 className="cursor-pointer"
-                color={accentColor}
-                fontSize={22}
                 onClick={() => handleRemoveHeader(key)}
-              />
+              >
+                <CircleXMark
+                  color={colors.$16}
+                  hoverColor={colors.$3}
+                  borderColor={colors.$5}
+                  hoverBorderColor={colors.$17}
+                  size="1.6rem"
+                />
+              </div>
             </div>
           ))}
 
@@ -143,6 +153,6 @@ export function Webhook(props: SubscriptionProps) {
           )}
         </div>
       </Element>
-    </Card>
+    </>
   );
 }

--- a/src/pages/settings/subscriptions/create/Create.tsx
+++ b/src/pages/settings/subscriptions/create/Create.tsx
@@ -34,6 +34,8 @@ import { useBlankSubscriptionQuery } from '$app/common/queries/subscriptions';
 import { useTitle } from '$app/common/hooks/useTitle';
 import { $refetch } from '$app/common/hooks/useRefetch';
 import { Steps } from '../common/components/Steps';
+import { Card } from '$app/components/cards';
+import { useColorScheme } from '$app/common/colors';
 
 export function Create() {
   const { documentTitle } = useTitle('new_payment_link');
@@ -49,6 +51,7 @@ export function Create() {
     status: ['active'],
   });
 
+  const colors = useColorScheme();
   const showPlanAlert = useShouldDisableAdvanceSettings();
 
   const pages = [
@@ -59,11 +62,9 @@ export function Create() {
 
   const tabs = [t('overview'), t('settings'), t('webhook'), t('steps')];
 
-  const [subscription, setSubscription] = useState<Subscription>();
-
-  const [products, setProducts] = useState<Product[]>();
-
   const [errors, setErrors] = useState<ValidationBag>();
+  const [products, setProducts] = useState<Product[]>();
+  const [subscription, setSubscription] = useState<Subscription>();
 
   const handleChange = useHandleChange({
     setErrors,
@@ -129,49 +130,64 @@ export function Create() {
     >
       <AdvancedSettingsPlanAlert />
 
-      <TabGroup tabs={tabs}>
-        <div>
-          {subscription && (
-            <Overview
-              subscription={subscription}
-              handleChange={handleChange}
-              errors={errors}
-              products={products}
-              page="create"
-            />
-          )}
-        </div>
+      <Card
+        title={t('new_payment_link')}
+        className="shadow-sm"
+        childrenClassName="pb-4"
+        style={{ borderColor: colors.$24 }}
+        headerStyle={{ borderColor: colors.$20 }}
+        withoutHeaderBorder
+        withoutBodyPadding
+      >
+        <TabGroup
+          tabs={tabs}
+          withHorizontalPadding
+          fullRightPadding
+          horizontalPaddingWidth="1.5rem"
+        >
+          <div>
+            {subscription && (
+              <Overview
+                subscription={subscription}
+                handleChange={handleChange}
+                errors={errors}
+                products={products}
+                page="create"
+              />
+            )}
+          </div>
 
-        <div>
-          {subscription && (
-            <SubscriptionSettings
-              subscription={subscription}
-              handleChange={handleChange}
-              errors={errors}
-            />
-          )}
-        </div>
+          <div>
+            {subscription && (
+              <SubscriptionSettings
+                subscription={subscription}
+                handleChange={handleChange}
+                errors={errors}
+              />
+            )}
+          </div>
 
-        <div>
-          {subscription && (
-            <Webhook
-              subscription={subscription}
-              handleChange={handleChange}
-              errors={errors}
-            />
-          )}
-        </div>
+          <div>
+            {subscription && (
+              <Webhook
+                subscription={subscription}
+                handleChange={handleChange}
+                errors={errors}
+              />
+            )}
+          </div>
 
-        <div>
-          {subscription && (
-            <Steps
-              subscription={subscription}
-              handleChange={handleChange}
-              errors={errors}
-            />
-          )}
-        </div>
-      </TabGroup>
+          <div>
+            {subscription && (
+              <Steps
+                subscription={subscription}
+                handleChange={handleChange}
+                errors={errors}
+              />
+            )}
+          </div>
+        </TabGroup>
+      </Card>
     </Settings>
   );
 }

--- a/src/pages/settings/subscriptions/edit/Edit.tsx
+++ b/src/pages/settings/subscriptions/edit/Edit.tsx
@@ -33,12 +33,15 @@ import { $refetch } from '$app/common/hooks/useRefetch';
 import { useActions } from '../common/hooks/useActions';
 import { ResourceActions } from '$app/components/ResourceActions';
 import { Steps } from '../common/components/Steps';
+import { Card } from '$app/components/cards';
+import { useColorScheme } from '$app/common/colors';
 
 export function Edit() {
   const { documentTitle } = useTitle('edit_payment_link');
   const [t] = useTranslation();
 
   const actions = useActions();
+  const colors = useColorScheme();
 
   const { id } = useParams();
   const { data } = useSubscriptionQuery({ id });
@@ -142,48 +145,63 @@ export function Edit() {
         )
       }
     >
-      <TabGroup tabs={tabs}>
-        <div>
-          {subscription && (
-            <Overview
-              subscription={subscription}
-              handleChange={handleChange}
-              errors={errors}
-              products={products}
-            />
-          )}
-        </div>
+      <Card
+        title={t('edit_payment_link')}
+        className="shadow-sm"
+        childrenClassName="pb-4"
+        style={{ borderColor: colors.$24 }}
+        headerStyle={{ borderColor: colors.$20 }}
+        withoutHeaderBorder
+        withoutBodyPadding
+      >
+        <TabGroup
+          tabs={tabs}
+          withHorizontalPadding
+          fullRightPadding
+          horizontalPaddingWidth="1.5rem"
+        >
+          <div>
+            {subscription && (
+              <Overview
+                subscription={subscription}
+                handleChange={handleChange}
+                errors={errors}
+                products={products}
+              />
+            )}
+          </div>
 
-        <div>
-          {subscription && (
-            <SubscriptionSettings
-              subscription={subscription}
-              handleChange={handleChange}
-              errors={errors}
-            />
-          )}
-        </div>
+          <div>
+            {subscription && (
+              <SubscriptionSettings
+                subscription={subscription}
+                handleChange={handleChange}
+                errors={errors}
+              />
+            )}
+          </div>
 
-        <div>
-          {subscription && (
-            <Webhook
-              subscription={subscription}
-              handleChange={handleChange}
-              errors={errors}
-            />
-          )}
-        </div>
+          <div>
+            {subscription && (
+              <Webhook
+                subscription={subscription}
+                handleChange={handleChange}
+                errors={errors}
+              />
+            )}
+          </div>
 
-        <div>
-          {subscription && (
-            <Steps
-              subscription={subscription}
-              handleChange={handleChange}
-              errors={errors}
-            />
-          )}
-        </div>
-      </TabGroup>
+          <div>
+            {subscription && (
+              <Steps
+                subscription={subscription}
+                handleChange={handleChange}
+                errors={errors}
+              />
+            )}
+          </div>
+        </TabGroup>
+      </Card>
     </Settings>
   );
 }


### PR DESCRIPTION
@beganovich @turbo124 This PR redesigns Credit Cards & Banks, Group Settings, and Payment Links according to the Figma design. Screenshot:

<img width="1261" alt="Screenshot 2025-06-02 at 18 27 11" src="https://github.com/user-attachments/assets/48ec30d5-44f7-4529-b89f-28f7d9362fa2" />

<img width="1259" alt="Screenshot 2025-06-02 at 18 27 26" src="https://github.com/user-attachments/assets/2342d487-ad04-4ebd-a7a3-7de022144ad1" />

<img width="1261" alt="Screenshot 2025-06-02 at 18 27 48" src="https://github.com/user-attachments/assets/1f797484-0c2b-4778-b1b4-28d132245a43" />

Let me know your thoughts.