### PR TITLE
Add net amount column invoices recurring invoices

### DIFF
--- a/src/pages/invoices/common/hooks/useInvoiceColumns.tsx
+++ b/src/pages/invoices/common/hooks/useInvoiceColumns.tsx
@@ -60,7 +60,6 @@ export const defaultColumns: string[] = [
   'number',
   'client',
   'amount',
-  'net_amount',
   'balance',
   'date',
   'due_date',

--- a/src/pages/recurring-invoices/common/hooks.tsx
+++ b/src/pages/recurring-invoices/common/hooks.tsx
@@ -596,7 +596,6 @@ export const defaultColumns: string[] = [
   'number',
   'client',
   'amount',
-  'net_amount',
   'remaining_cycles',
   'next_send_date',
   'frequency',


### PR DESCRIPTION
- Add net_amount column to default columns in both invoice and recurring invoice views
- Display amount minus taxes for better visibility of net values

This PR is related to this discussion: https://github.com/invoiceninja/invoiceninja/discussions/10954#discussioncomment-13081588