### PR TITLE
[Bugfix] Status Color Scheme

### DIFF
--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -11,6 +11,11 @@
 import classNames from 'classnames';
 import { useAccentColor } from '$app/common/hooks/useAccentColor';
 import CommonProps from '../common/interfaces/common-props.interface';
+import {
+  hexToRGB,
+  isColorLight,
+  useAdjustColorDarkness,
+} from '$app/common/hooks/useAdjustColorDarkness';
 
 interface Props extends CommonProps {
   variant?:
@@ -38,6 +43,8 @@ export function Badge(props: Props) {
 
   const accentColor = useAccentColor();
 
+  const adjustColorDarkness = useAdjustColorDarkness();
+
   const styles: React.CSSProperties = { ...props.style };
 
   if (props.variant === 'primary') {
@@ -45,9 +52,26 @@ export function Badge(props: Props) {
     styles.color = 'white';
   }
 
+  const getTextContrastColor = (color: string) => {
+    if (color.length === 7) {
+      const { red, green, blue, hex } = hexToRGB(color);
+
+      const darknessAmount = isColorLight(red, green, blue) ? -220 : 220;
+
+      return adjustColorDarkness(hex, darknessAmount);
+    }
+
+    return undefined;
+  };
+
   return (
     <span
-      style={styles}
+      style={{
+        ...styles,
+        color: styles.backgroundColor
+          ? getTextContrastColor(styles.backgroundColor)
+          : undefined,
+      }}
       className={classNames(
         'text-xs px-2 py-1 rounded font-medium',
         {

--- a/src/pages/settings/user/components/StatusColorTheme.tsx
+++ b/src/pages/settings/user/components/StatusColorTheme.tsx
@@ -102,7 +102,7 @@ interface Theme {
 }
 const COLOR_THEMES: Record<ThemeKey, Theme> = {
   light: {
-    palette: ['#58a6e4', '#324ea1', '#4c9a1d', '#cd8900', '#b83700'],
+    palette: ['#93C5FD26', '#1D4ED826', '#22C55E26', '#EAB30826', '#EF444426'],
   },
   dark: {
     palette: ['#298aaa', '#0c45a3', '#407535', '#a87001', '#8b3c40'],
@@ -255,6 +255,8 @@ export function StatusColorTheme() {
     const updatedColorTheme = cloneDeep(reactSettings?.color_theme);
 
     if (updatedColorTheme) {
+      updatedColorTheme.status_color_theme = '';
+
       CUSTOM_COLOR_FIELDS.forEach((fieldKey) => {
         updatedColorTheme[fieldKey] = '';
       });
@@ -272,13 +274,14 @@ export function StatusColorTheme() {
     <>
       <Element leftSide={t('status_color_theme')}>
         <SelectField
-          value={reactSettings?.color_theme?.status_color_theme || 'light'}
+          value={reactSettings?.color_theme?.status_color_theme || ''}
           onValueChange={(value) =>
             handleUserChange(
               'company_user.react_settings.color_theme.status_color_theme',
               value
             )
           }
+          withBlank
           customSelector
         >
           {Object.keys(COLOR_THEMES).map((themeKey, index) => (
@@ -295,7 +298,7 @@ export function StatusColorTheme() {
                     <div
                       key={paletteColor}
                       style={{
-                        backgroundColor: paletteColor,
+                        backgroundColor: paletteColor.slice(0, 7),
                         width: 50,
                         height: 20,
                       }}

--- a/src/pages/settings/user/components/StatusColorTheme.tsx
+++ b/src/pages/settings/user/components/StatusColorTheme.tsx
@@ -255,7 +255,7 @@ export function StatusColorTheme() {
     const updatedColorTheme = cloneDeep(reactSettings?.color_theme);
 
     if (updatedColorTheme) {
-      updatedColorTheme.status_color_theme = '';
+      updatedColorTheme.status_color_theme = 'light';
 
       CUSTOM_COLOR_FIELDS.forEach((fieldKey) => {
         updatedColorTheme[fieldKey] = '';
@@ -274,14 +274,13 @@ export function StatusColorTheme() {
     <>
       <Element leftSide={t('status_color_theme')}>
         <SelectField
-          value={reactSettings?.color_theme?.status_color_theme || ''}
+          value={reactSettings?.color_theme?.status_color_theme || 'light'}
           onValueChange={(value) =>
             handleUserChange(
               'company_user.react_settings.color_theme.status_color_theme',
               value
             )
           }
-          withBlank
           customSelector
         >
           {Object.keys(COLOR_THEMES).map((themeKey, index) => (


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for the "Status Color Scheme". It ensures that the "Clear All" button now sets `status_color_scheme` to light, and the "Light" theme matches the designer's specifications in Figma. I matched those colors and used color calculations to ensure proper text contrast across all other themes except "Light". 

Closes #2577 

Let me know your thoughts.