### PR TITLE
Unlist TinyMCE plugin

### DIFF
--- a/src/components/forms/MarkdownEditor.tsx
+++ b/src/components/forms/MarkdownEditor.tsx
@@ -130,7 +130,7 @@ export function MarkdownEditor(props: Props) {
             'preview',
             'help',
             'wordcount',
-            'mceCodeEditor',
+            // 'mceCodeEditor': https://github.com/invoiceninja/invoiceninja/issues/11060
             'emoticons',
           ],
           toolbar: [


### PR DESCRIPTION
We're missing plugin files for this, so I assume we don't use it anyways. Safe to comment to get rid of that error.

https://github.com/invoiceninja/invoiceninja/issues/11060
