### PR TITLE
[Cleanup] UX Improvement When Selecting Permissions

### DIFF
--- a/src/components/forms/Checkbox.tsx
+++ b/src/components/forms/Checkbox.tsx
@@ -58,7 +58,7 @@ export function Checkbox(props: Props) {
           aria-describedby="comments-description"
           type="checkbox"
           className={classNames(
-            'rounded border cursor-pointer disabled:opacity-50',
+            'rounded border disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed',
             props.className
           )}
           style={{

--- a/src/components/forms/Toggle.tsx
+++ b/src/components/forms/Toggle.tsx
@@ -11,7 +11,6 @@
 import { useState } from 'react';
 import { Switch } from '@headlessui/react';
 import CommonProps from '../../common/interfaces/common-props.interface';
-import { useAccentColor } from '$app/common/hooks/useAccentColor';
 import { useEffect } from 'react';
 import { useColorScheme } from '$app/common/colors';
 import { styled } from 'styled-components';
@@ -36,7 +35,6 @@ const StyledSwitch = styled(Switch)`
 
 export default function Toggle(props: Props) {
   const colors = useColorScheme();
-  const accentColor = useAccentColor();
 
   const [checked, setChecked] = useState<boolean>(false);
   const [disabled, setDisabled] = useState<boolean>(false);
@@ -57,7 +55,7 @@ export default function Toggle(props: Props) {
         className={classNames(
           'relative inline-flex items-center flex-shrink-0 h-6 w-11 rounded-full transition-colors ease-in-out duration-200',
           {
-            'pointer-events-none opacity-75': disabled,
+            'cursor-not-allowed opacity-75': disabled,
             'border cursor-pointer focus:outline-none focus:ring-2 focus:ring-offset-2':
               !disabled,
           }

--- a/src/pages/settings/users/edit/components/Permissions.tsx
+++ b/src/pages/settings/users/edit/components/Permissions.tsx
@@ -46,6 +46,14 @@ export function Permissions(props: Props) {
     'recurring_expense',
   ];
 
+  const isPermissionDisabled = () => {
+    if (user?.company_user?.is_admin) {
+      return true;
+    }
+
+    return false;
+  };
+
   const handleAdministratorToggle = (value: boolean) => {
     setUser(
       (user) =>
@@ -54,12 +62,17 @@ export function Permissions(props: Props) {
           company_user: user.company_user && {
             ...user.company_user,
             is_admin: value,
+            permissions: value ? '' : user.company_user.permissions,
           },
         }
     );
   };
 
   const isPermissionChecked = (permission: PermissionsType) => {
+    if (user?.company_user?.is_admin) {
+      return true;
+    }
+
     const permissions = user?.company_user?.permissions;
     const [type] = permission.split('_');
 
@@ -119,6 +132,28 @@ export function Permissions(props: Props) {
       currentPermissions.push(permission);
     }
 
+    if (!currentPermissions.includes(`${permissionType}_all`)) {
+      const permissionsFromTypeLength = currentPermissions.filter(
+        (currentPermission) =>
+          currentPermission.startsWith(permissionType) &&
+          currentPermission !== 'view_reports' &&
+          currentPermission !== 'view_dashboard' &&
+          currentPermission !== 'disable_emails'
+      ).length;
+
+      if (permissionsFromTypeLength === permissions.length) {
+        currentPermissions = currentPermissions.filter(
+          (currentPermission) =>
+            !currentPermission.startsWith(permissionType) ||
+            currentPermission === 'view_reports' ||
+            currentPermission === 'view_dashboard' ||
+            currentPermission === 'disable_emails'
+        );
+
+        currentPermissions.push(`${permissionType}_all`);
+      }
+    }
+
     if (currentPermissions[0] === '') {
       currentPermissions.shift();
     }
@@ -155,6 +190,7 @@ export function Permissions(props: Props) {
             handlePermissionChange('view_dashboard', value)
           }
           cypressRef="viewDashboard"
+          disabled={isPermissionDisabled()}
         />
       </Element>
 
@@ -168,6 +204,7 @@ export function Permissions(props: Props) {
             handlePermissionChange('view_reports', value)
           }
           cypressRef="viewReports"
+          disabled={isPermissionDisabled()}
         />
       </Element>
 
@@ -180,6 +217,7 @@ export function Permissions(props: Props) {
           onValueChange={(value) =>
             handlePermissionChange('disable_emails', value)
           }
+          disabled={isPermissionDisabled()}
         />
       </Element>
 
@@ -214,6 +252,7 @@ export function Permissions(props: Props) {
                 handlePermissionChange('create_all', event.target.checked)
               }
               cypressRef="create_all"
+              disabled={isPermissionDisabled()}
             />
           </div>
           <div className="col-1">
@@ -223,6 +262,7 @@ export function Permissions(props: Props) {
                 handlePermissionChange('view_all', event.target.checked)
               }
               cypressRef="view_all"
+              disabled={isPermissionDisabled()}
             />
           </div>
           <div className="col-1">
@@ -232,6 +272,7 @@ export function Permissions(props: Props) {
                 handlePermissionChange('edit_all', event.target.checked)
               }
               cypressRef="edit_all"
+              disabled={isPermissionDisabled()}
             />
           </div>
         </div>
@@ -245,13 +286,14 @@ export function Permissions(props: Props) {
                 checked={isPermissionChecked(
                   `create_${permission}` as PermissionsType
                 )}
-                onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+                onValueChange={(_, checked) =>
                   handlePermissionChange(
                     `create_${permission}` as PermissionsType,
-                    event.target.checked
+                    Boolean(checked)
                   )
                 }
                 cypressRef={`create_${permission}`}
+                disabled={isPermissionDisabled()}
               />
             </div>
             <div className="col-1">
@@ -259,13 +301,14 @@ export function Permissions(props: Props) {
                 checked={isPermissionChecked(
                   `view_${permission}` as PermissionsType
                 )}
-                onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+                onValueChange={(_, checked) =>
                   handlePermissionChange(
                     `view_${permission}` as PermissionsType,
-                    event.target.checked
+                    Boolean(checked)
                   )
                 }
                 cypressRef={`view_${permission}`}
+                disabled={isPermissionDisabled()}
               />
             </div>
             <div className="col-1">
@@ -273,13 +316,14 @@ export function Permissions(props: Props) {
                 checked={isPermissionChecked(
                   `edit_${permission}` as PermissionsType
                 )}
-                onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+                onValueChange={(_, checked) =>
                   handlePermissionChange(
                     `edit_${permission}` as PermissionsType,
-                    event.target.checked
+                    Boolean(checked)
                   )
                 }
                 cypressRef={`edit_${permission}`}
+                disabled={isPermissionDisabled()}
               />
             </div>
           </div>

--- a/src/pages/settings/users/edit/components/Permissions.tsx
+++ b/src/pages/settings/users/edit/components/Permissions.tsx
@@ -23,6 +23,12 @@ interface Props {
   setUser: React.Dispatch<React.SetStateAction<User | undefined>>;
 }
 
+const SPECIAL_PERMISSIONS = [
+  'view_reports',
+  'view_dashboard',
+  'disable_emails',
+];
+
 export function Permissions(props: Props) {
   const [t] = useTranslation();
   const { user, setUser } = props;
@@ -107,15 +113,11 @@ export function Permissions(props: Props) {
       currentPermissions = currentPermissions.filter(
         (currentPermission) =>
           !currentPermission.startsWith(permissionType) ||
-          currentPermission === 'view_reports' ||
-          currentPermission === 'view_dashboard' ||
-          currentPermission === 'disable_emails'
+          SPECIAL_PERMISSIONS.includes(currentPermission)
       );
     } else if (
       currentPermissions.includes(`${permissionType}_all`) &&
-      permission !== 'view_reports' &&
-      permission !== 'view_dashboard' &&
-      permission !== 'disable_emails'
+      !SPECIAL_PERMISSIONS.includes(permission)
     ) {
       const permissionsByType = permissions
         .map((currentPermission) => `${permissionType}_${currentPermission}`)
@@ -136,18 +138,14 @@ export function Permissions(props: Props) {
       const permissionsFromTypeLength = currentPermissions.filter(
         (currentPermission) =>
           currentPermission.startsWith(permissionType) &&
-          currentPermission !== 'view_reports' &&
-          currentPermission !== 'view_dashboard' &&
-          currentPermission !== 'disable_emails'
+          !SPECIAL_PERMISSIONS.includes(currentPermission)
       ).length;
 
       if (permissionsFromTypeLength === permissions.length) {
         currentPermissions = currentPermissions.filter(
           (currentPermission) =>
             !currentPermission.startsWith(permissionType) ||
-            currentPermission === 'view_reports' ||
-            currentPermission === 'view_dashboard' ||
-            currentPermission === 'disable_emails'
+            SPECIAL_PERMISSIONS.includes(currentPermission)
         );
 
         currentPermissions.push(`${permissionType}_all`);


### PR DESCRIPTION
@beganovich @turbo124 The PR includes few UX improvements when selecting permissions:

- If the "Admin" permission is selected, all other permissions will appear "checked" and "disabled" without the possibility of unchecking them until the "Admin" permission is unchecked.
- If the "Admin" permission is checked, all permissions will be removed from the array, and only the `is_admin` boolean value will be set to true. The UI will be correctly updated.
- If 13/14 permissions from one type (for example, "View") are checked, and then the last one is checked, it will remove all of them from the array, and only the "view_all" permission will be added along with a proper UI update.

Let me know your thoughts.