### PR TITLE
[Cleanup] Implementing Confirmation Modal When Bulk Deleting Invoices

### DIFF
--- a/src/common/queries/invoices.ts
+++ b/src/common/queries/invoices.ts
@@ -115,7 +115,8 @@ export function useBulk(params?: Params) {
       | 'mark_paid'
       | 'download'
       | 'cancel'
-      | 'auto_bill',
+      | 'auto_bill'
+      | 'delete',
     emailType?: EmailType
   ) => {
     toast.processing();

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -384,7 +384,7 @@ export function DataTable<T extends object>(props: Props<T>) {
     };
   }, []);
 
-  const { data, isLoading, isFetching, isError, isPlaceholderData } = useQuery(
+  const { data, isLoading, isFetching, isError } = useQuery(
     [
       ...(queryIdentificator ? [queryIdentificator] : []),
       apiEndpoint.pathname,
@@ -666,53 +666,54 @@ export function DataTable<T extends object>(props: Props<T>) {
               )}
 
               {!props.withoutDefaultBulkActions && (
-                <>
+                <DropdownElement
+                  onClick={() => {
+                    if (onBulkActionCall) {
+                      onBulkActionCall(selected, 'archive');
+                    } else {
+                      bulk('archive');
+                    }
+                  }}
+                  icon={<Icon element={MdArchive} />}
+                >
+                  {t('archive')}
+                </DropdownElement>
+              )}
+
+              {!props.withoutDefaultBulkActions && (
+                <DropdownElement
+                  onClick={() => {
+                    if (onDeleteBulkAction) {
+                      onDeleteBulkAction(selected);
+                    } else if (onBulkActionCall) {
+                      onBulkActionCall(selected, 'delete');
+                    } else {
+                      bulk('delete');
+                    }
+                  }}
+                  icon={<Icon element={MdDelete} />}
+                >
+                  {t('delete')}
+                </DropdownElement>
+              )}
+
+              {!props.withoutDefaultBulkActions &&
+                (showRestoreBulk
+                  ? showRestoreBulk(selectedResources)
+                  : showRestoreBulkAction()) && (
                   <DropdownElement
                     onClick={() => {
                       if (onBulkActionCall) {
-                        onBulkActionCall(selected, 'archive');
+                        onBulkActionCall(selected, 'restore');
                       } else {
-                        bulk('archive');
+                        bulk('restore');
                       }
                     }}
-                    icon={<Icon element={MdArchive} />}
+                    icon={<Icon element={MdRestore} />}
                   >
-                    {t('archive')}
+                    {t('restore')}
                   </DropdownElement>
-
-                  <DropdownElement
-                    onClick={() => {
-                      if (onDeleteBulkAction) {
-                        onDeleteBulkAction(selected);
-                      } else if (onBulkActionCall) {
-                        onBulkActionCall(selected, 'delete');
-                      } else {
-                        bulk('delete');
-                      }
-                    }}
-                    icon={<Icon element={MdDelete} />}
-                  >
-                    {t('delete')}
-                  </DropdownElement>
-
-                  {(showRestoreBulk
-                    ? showRestoreBulk(selectedResources)
-                    : showRestoreBulkAction()) && (
-                    <DropdownElement
-                      onClick={() => {
-                        if (onBulkActionCall) {
-                          onBulkActionCall(selected, 'restore');
-                        } else {
-                          bulk('restore');
-                        }
-                      }}
-                      icon={<Icon element={MdRestore} />}
-                    >
-                      {t('restore')}
-                    </DropdownElement>
-                  )}
-                </>
-              )}
+                )}
             </Dropdown>
           )}
         </Actions>

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -161,6 +161,7 @@ interface Props<T> extends CommonProps {
   showRestoreBulk?: (selectedResources: T[]) => boolean;
   enableSavingFilterPreference?: boolean;
   applyManualHeight?: boolean;
+  onDeleteBulkAction?: (selectedIds: string[]) => void;
 }
 
 export type ResourceAction<T> = (resource: T) => ReactElement;
@@ -228,6 +229,7 @@ export function DataTable<T extends object>(props: Props<T>) {
     withoutSortQueryParameter = false,
     showRestoreBulk,
     enableSavingFilterPreference = false,
+    onDeleteBulkAction,
   } = props;
 
   const companyUpdateTimeOut = useRef<NodeJS.Timeout | undefined>(undefined);
@@ -680,7 +682,9 @@ export function DataTable<T extends object>(props: Props<T>) {
 
                   <DropdownElement
                     onClick={() => {
-                      if (onBulkActionCall) {
+                      if (onDeleteBulkAction) {
+                        onDeleteBulkAction(selected);
+                      } else if (onBulkActionCall) {
                         onBulkActionCall(selected, 'delete');
                       } else {
                         bulk('delete');

--- a/src/pages/clients/show/pages/Invoices.tsx
+++ b/src/pages/clients/show/pages/Invoices.tsx
@@ -18,26 +18,13 @@ import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission
 import { permission } from '$app/common/guards/guards/permission';
 import { useFooterColumns } from '$app/pages/invoices/common/hooks/useFooterColumns';
 import { useSetAtom } from 'jotai';
-import {
-  ConfirmActionModal,
-  confirmActionModalAtom,
-} from '$app/pages/recurring-invoices/common/components/ConfirmActionModal';
+import { confirmActionModalAtom } from '$app/pages/recurring-invoices/common/components/ConfirmActionModal';
 import { useState } from 'react';
-import { useBulk } from '$app/common/queries/invoices';
-import { useTranslation } from 'react-i18next';
+import { DeleteInvoicesConfirmationModal } from '$app/pages/invoices/common/components/DeleteInvoicesConfirmationModal';
 
 export default function Invoices() {
-  const [t] = useTranslation();
-
   const { id } = useParams();
 
-  const deselectAll = () => {
-    setSelectedInvoiceIds([]);
-  };
-
-  const bulk = useBulk({
-    onSuccess: deselectAll,
-  });
   const hasPermission = useHasPermission();
 
   const actions = useActions();
@@ -73,13 +60,9 @@ export default function Invoices() {
         }}
       />
 
-      <ConfirmActionModal
-        title={t('delete_invoices')}
-        message={t('delete_invoices_confirmation')}
-        disabledButton={selectedInvoiceIds.length === 0}
-        onClick={() => {
-          bulk(selectedInvoiceIds, 'delete');
-        }}
+      <DeleteInvoicesConfirmationModal
+        selectedInvoiceIds={selectedInvoiceIds}
+        setSelectedInvoiceIds={setSelectedInvoiceIds}
       />
     </>
   );

--- a/src/pages/clients/show/pages/Invoices.tsx
+++ b/src/pages/clients/show/pages/Invoices.tsx
@@ -17,35 +17,70 @@ import { useCustomBulkActions } from '$app/pages/invoices/common/hooks/useCustom
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 import { permission } from '$app/common/guards/guards/permission';
 import { useFooterColumns } from '$app/pages/invoices/common/hooks/useFooterColumns';
+import { useSetAtom } from 'jotai';
+import {
+  ConfirmActionModal,
+  confirmActionModalAtom,
+} from '$app/pages/recurring-invoices/common/components/ConfirmActionModal';
+import { useState } from 'react';
+import { useBulk } from '$app/common/queries/invoices';
+import { useTranslation } from 'react-i18next';
 
 export default function Invoices() {
+  const [t] = useTranslation();
+
   const { id } = useParams();
 
+  const deselectAll = () => {
+    setSelectedInvoiceIds([]);
+  };
+
+  const bulk = useBulk({
+    onSuccess: deselectAll,
+  });
   const hasPermission = useHasPermission();
 
   const actions = useActions();
   const columns = useInvoiceColumns();
-  const customBulkActions = useCustomBulkActions();
   const { footerColumns } = useFooterColumns();
+  const customBulkActions = useCustomBulkActions();
+
+  const setIsConfirmActionModalOpen = useSetAtom(confirmActionModalAtom);
+  const [selectedInvoiceIds, setSelectedInvoiceIds] = useState<string[]>([]);
 
   return (
-    <DataTable
-      resource="invoice"
-      endpoint={route(
-        '/api/v1/invoices?include=client.group_settings&client_id=:id&sort=id|desc',
-        { id }
-      )}
-      columns={columns}
-      footerColumns={footerColumns}
-      customActions={actions}
-      customBulkActions={customBulkActions}
-      withResourcefulActions
-      bulkRoute="/api/v1/invoices/bulk"
-      linkToCreate={route('/invoices/create?client=:id', { id })}
-      linkToEdit="/invoices/:id/edit"
-      excludeColumns={['client_id']}
-      linkToCreateGuards={[permission('create_invoice')]}
-      hideEditableOptions={!hasPermission('edit_invoice')}
-    />
+    <>
+      <DataTable
+        resource="invoice"
+        endpoint={route(
+          '/api/v1/invoices?include=client.group_settings&client_id=:id&sort=id|desc',
+          { id }
+        )}
+        columns={columns}
+        footerColumns={footerColumns}
+        customActions={actions}
+        customBulkActions={customBulkActions}
+        withResourcefulActions
+        bulkRoute="/api/v1/invoices/bulk"
+        linkToCreate={route('/invoices/create?client=:id', { id })}
+        linkToEdit="/invoices/:id/edit"
+        excludeColumns={['client_id']}
+        linkToCreateGuards={[permission('create_invoice')]}
+        hideEditableOptions={!hasPermission('edit_invoice')}
+        onDeleteBulkAction={(selected) => {
+          setSelectedInvoiceIds(selected);
+          setIsConfirmActionModalOpen(true);
+        }}
+      />
+
+      <ConfirmActionModal
+        title={t('delete_invoices')}
+        message={t('delete_invoices_confirmation')}
+        disabledButton={selectedInvoiceIds.length === 0}
+        onClick={() => {
+          bulk(selectedInvoiceIds, 'delete');
+        }}
+      />
+    </>
   );
 }

--- a/src/pages/invoices/common/components/DeleteInvoicesConfirmationModal.tsx
+++ b/src/pages/invoices/common/components/DeleteInvoicesConfirmationModal.tsx
@@ -1,0 +1,56 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { emitter } from '$app';
+import { useBulk } from '$app/common/queries/invoices';
+import {
+  ConfirmActionModal,
+  confirmActionModalAtom,
+} from '$app/pages/recurring-invoices/common/components/ConfirmActionModal';
+import { useSetAtom } from 'jotai';
+import { useTranslation } from 'react-i18next';
+
+interface Props {
+  selectedInvoiceIds: string[];
+  setSelectedInvoiceIds: (ids: string[]) => void;
+}
+
+export function DeleteInvoicesConfirmationModal({
+  selectedInvoiceIds,
+  setSelectedInvoiceIds,
+}: Props) {
+  const [t] = useTranslation();
+
+  const setIsConfirmActionModalOpen = useSetAtom(confirmActionModalAtom);
+
+  const deselectAll = () => {
+    setSelectedInvoiceIds([]);
+    emitter.emit('bulk.completed');
+  };
+
+  const bulk = useBulk({
+    onSuccess: deselectAll,
+  });
+
+  return (
+    <ConfirmActionModal
+      title={t('delete')}
+      message={t('delete_invoices_confirmation')}
+      disabledButton={selectedInvoiceIds.length === 0}
+      disableButtonWithoutLoadingIcon
+      onClose={deselectAll}
+      onClick={() => {
+        bulk(selectedInvoiceIds, 'delete');
+        setIsConfirmActionModalOpen(false);
+        deselectAll();
+      }}
+    />
+  );
+}

--- a/src/pages/invoices/common/components/DeleteInvoicesConfirmationModal.tsx
+++ b/src/pages/invoices/common/components/DeleteInvoicesConfirmationModal.tsx
@@ -41,8 +41,8 @@ export function DeleteInvoicesConfirmationModal({
 
   return (
     <ConfirmActionModal
-      title={t('delete')}
-      message={t('delete_invoices_confirmation')}
+      title={t('confirmation')}
+      message={t('are_you_sure')}
       disabledButton={selectedInvoiceIds.length === 0}
       disableButtonWithoutLoadingIcon
       onClose={deselectAll}

--- a/src/pages/invoices/index/Invoices.tsx
+++ b/src/pages/invoices/index/Invoices.tsx
@@ -47,11 +47,8 @@ import { useReactSettings } from '$app/common/hooks/useReactSettings';
 import { useSocketEvent } from '$app/common/queries/sockets';
 import { $refetch } from '$app/common/hooks/useRefetch';
 import { InputLabel } from '$app/components/forms';
-import { useBulk } from '$app/common/queries/invoices';
-import {
-  ConfirmActionModal,
-  confirmActionModalAtom,
-} from '$app/pages/recurring-invoices/common/components/ConfirmActionModal';
+import { confirmActionModalAtom } from '$app/pages/recurring-invoices/common/components/ConfirmActionModal';
+import { DeleteInvoicesConfirmationModal } from '../common/components/DeleteInvoicesConfirmationModal';
 
 export default function Invoices() {
   const { documentTitle } = useTitle('invoices');
@@ -62,10 +59,6 @@ export default function Invoices() {
 
   const hasPermission = useHasPermission();
   const disableNavigation = useDisableNavigation();
-
-  const deselectAll = () => {
-    setSelectedInvoiceIds([]);
-  };
 
   const [sliderInvoiceId, setSliderInvoiceId] = useState<string>('');
   const [invoiceSlider, setInvoiceSlider] = useAtom(invoiceSliderAtom);
@@ -78,9 +71,6 @@ export default function Invoices() {
   const { data: invoiceResponse } = useInvoiceQuery({ id: sliderInvoiceId });
 
   const actions = useActions();
-  const bulk = useBulk({
-    onSuccess: deselectAll,
-  });
 
   const filters = useInvoiceFilters();
   const columns = useInvoiceColumns();
@@ -192,13 +182,9 @@ export default function Invoices() {
         bulkUrl="/api/v1/invoices/bulk"
       />
 
-      <ConfirmActionModal
-        title={t('delete_invoices')}
-        message={t('delete_invoices_confirmation')}
-        disabledButton={selectedInvoiceIds.length === 0}
-        onClick={() => {
-          bulk(selectedInvoiceIds, 'delete');
-        }}
+      <DeleteInvoicesConfirmationModal
+        selectedInvoiceIds={selectedInvoiceIds}
+        setSelectedInvoiceIds={setSelectedInvoiceIds}
       />
     </Default>
   );

--- a/src/pages/invoices/index/Invoices.tsx
+++ b/src/pages/invoices/index/Invoices.tsx
@@ -30,7 +30,7 @@ import {
   invoiceSliderAtom,
   invoiceSliderVisibilityAtom,
 } from '../common/components/InvoiceSlider';
-import { useAtom } from 'jotai';
+import { useAtom, useSetAtom } from 'jotai';
 import { useInvoiceQuery } from '$app/common/queries/invoices';
 import { useEffect, useState } from 'react';
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
@@ -47,6 +47,11 @@ import { useReactSettings } from '$app/common/hooks/useReactSettings';
 import { useSocketEvent } from '$app/common/queries/sockets';
 import { $refetch } from '$app/common/hooks/useRefetch';
 import { InputLabel } from '$app/components/forms';
+import { useBulk } from '$app/common/queries/invoices';
+import {
+  ConfirmActionModal,
+  confirmActionModalAtom,
+} from '$app/pages/recurring-invoices/common/components/ConfirmActionModal';
 
 export default function Invoices() {
   const { documentTitle } = useTitle('invoices');
@@ -58,8 +63,14 @@ export default function Invoices() {
   const hasPermission = useHasPermission();
   const disableNavigation = useDisableNavigation();
 
+  const deselectAll = () => {
+    setSelectedInvoiceIds([]);
+  };
+
   const [sliderInvoiceId, setSliderInvoiceId] = useState<string>('');
   const [invoiceSlider, setInvoiceSlider] = useAtom(invoiceSliderAtom);
+  const setIsConfirmActionModalOpen = useSetAtom(confirmActionModalAtom);
+  const [selectedInvoiceIds, setSelectedInvoiceIds] = useState<string[]>([]);
   const [invoiceSliderVisibility, setInvoiceSliderVisibility] = useAtom(
     invoiceSliderVisibilityAtom
   );
@@ -67,6 +78,10 @@ export default function Invoices() {
   const { data: invoiceResponse } = useInvoiceQuery({ id: sliderInvoiceId });
 
   const actions = useActions();
+  const bulk = useBulk({
+    onSuccess: deselectAll,
+  });
+
   const filters = useInvoiceFilters();
   const columns = useInvoiceColumns();
   const reactSettings = useReactSettings();
@@ -147,6 +162,10 @@ export default function Invoices() {
         }}
         dateRangeColumns={dateRangeColumns}
         enableSavingFilterPreference
+        onDeleteBulkAction={(selected) => {
+          setSelectedInvoiceIds(selected);
+          setIsConfirmActionModalOpen(true);
+        }}
       />
 
       {!disableNavigation('invoice', invoiceSlider) && <InvoiceSlider />}
@@ -171,6 +190,15 @@ export default function Invoices() {
           </div>
         )}
         bulkUrl="/api/v1/invoices/bulk"
+      />
+
+      <ConfirmActionModal
+        title={t('delete_invoices')}
+        message={t('delete_invoices_confirmation')}
+        disabledButton={selectedInvoiceIds.length === 0}
+        onClick={() => {
+          bulk(selectedInvoiceIds, 'delete');
+        }}
       />
     </Default>
   );

--- a/src/pages/recurring-invoices/common/components/ConfirmActionModal.tsx
+++ b/src/pages/recurring-invoices/common/components/ConfirmActionModal.tsx
@@ -22,6 +22,7 @@ interface Props {
   disabledButton?: boolean;
   title?: string | null;
   message?: string | null;
+  disableButtonWithoutLoadingIcon?: boolean;
 }
 
 export function ConfirmActionModal({
@@ -30,6 +31,7 @@ export function ConfirmActionModal({
   disabledButton,
   title,
   message,
+  disableButtonWithoutLoadingIcon,
 }: Props) {
   const [t] = useTranslation();
   const [isModalVisible, setIsModalVisible] = useAtom(confirmActionModalAtom);
@@ -58,6 +60,7 @@ export function ConfirmActionModal({
           behavior="button"
           onClick={() => onClick()}
           disabled={disabledButton}
+          disableWithoutIcon={disableButtonWithoutLoadingIcon}
         >
           {t('continue')}
         </Button>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of a confirmation modal when bulk deleting invoices. Screenshot:

![Screenshot 2025-06-22 at 19 10 31](https://github.com/user-attachments/assets/c7fcf956-8803-4456-9e3d-d1d0457a2133)

`Note`: If you agree with the translation used, please just add the missing "delete_invoices_confirmation" translation keyword to the files.

Closes #2467 

Let me know your thoughts.