### PR TITLE
[Bugfix] Automatic Scroll When Live Preview Is Triggered 

### DIFF
--- a/src/pages/credits/create/components/CreatePage.tsx
+++ b/src/pages/credits/create/components/CreatePage.tsx
@@ -135,6 +135,8 @@ export default function CreatePage() {
               entity="credit"
               relationType="client_id"
               endpoint="/api/v1/live_preview?entity=:entity"
+              observable={true}
+              initiallyVisible={false}
             />
           )}
         </div>

--- a/src/pages/credits/edit/Edit.tsx
+++ b/src/pages/credits/edit/Edit.tsx
@@ -151,6 +151,8 @@ export default function Edit() {
               relationType="client_id"
               endpoint="/api/v1/live_preview?entity=:entity"
               withRemoveLogoCTA
+              observable={true}
+              initiallyVisible={false}
             />
           )}
         </div>

--- a/src/pages/invoices/common/components/InvoicePreview.tsx
+++ b/src/pages/invoices/common/components/InvoicePreview.tsx
@@ -92,6 +92,7 @@ export function InvoicePreview(props: Props) {
           })}
           resource={props.resource}
           method="POST"
+          enabled={props.observable ? isIntersecting : true}
         />
       </div>
     );
@@ -114,6 +115,7 @@ export function InvoicePreview(props: Props) {
           )}
           resource={props.resource}
           method="POST"
+          enabled={props.observable ? isIntersecting : true}
         />
 
         {props.withRemoveLogoCTA && <RemoveLogoCTA />}

--- a/src/pages/invoices/common/components/InvoiceViewer.tsx
+++ b/src/pages/invoices/common/components/InvoiceViewer.tsx
@@ -47,9 +47,9 @@ export function InvoiceViewer(props: Props) {
       toast.processing();
     }
 
-    setIsLoading(true);
-
     if (props.enabled !== false) {
+      setIsLoading(true);
+
       queryClient.fetchQuery({
         queryKey: [props.link, JSON.stringify(props.resource)],
         retry: 0,
@@ -127,7 +127,6 @@ export function InvoiceViewer(props: Props) {
         height={isLoading ? 0 : props.height || 1500}
         loading="lazy"
         tabIndex={-1}
-
       />
     </>
   );

--- a/src/pages/purchase-orders/create/components/CreatePage.tsx
+++ b/src/pages/purchase-orders/create/components/CreatePage.tsx
@@ -149,6 +149,8 @@ export default function Create() {
               entity="purchase_order"
               relationType="vendor_id"
               endpoint="/api/v1/live_preview/purchase_order?entity=:entity"
+              observable={true}
+              initiallyVisible={false}
             />
           )}
         </div>

--- a/src/pages/purchase-orders/edit/Edit.tsx
+++ b/src/pages/purchase-orders/edit/Edit.tsx
@@ -169,6 +169,8 @@ export default function Edit() {
               relationType="vendor_id"
               endpoint="/api/v1/live_preview/purchase_order?entity=:entity"
               withRemoveLogoCTA
+              observable={true}
+              initiallyVisible={false}
             />
           )}
         </div>

--- a/src/pages/quotes/create/components/CreatePage.tsx
+++ b/src/pages/quotes/create/components/CreatePage.tsx
@@ -167,6 +167,8 @@ export default function CreatePage() {
               entity="quote"
               relationType="client_id"
               endpoint="/api/v1/live_preview?entity=:entity"
+              observable={true}
+              initiallyVisible={false}
             />
           )}
         </div>

--- a/src/pages/quotes/edit/Edit.tsx
+++ b/src/pages/quotes/edit/Edit.tsx
@@ -184,6 +184,8 @@ export default function Edit() {
               relationType="client_id"
               endpoint="/api/v1/live_preview?entity=:entity"
               withRemoveLogoCTA
+              observable={true}
+              initiallyVisible={false}
             />
           )}
         </div>

--- a/src/pages/recurring-invoices/create/components/CreatePage.tsx
+++ b/src/pages/recurring-invoices/create/components/CreatePage.tsx
@@ -155,6 +155,8 @@ export default function CreatePage() {
             entity="recurring_invoice"
             relationType="client_id"
             endpoint="/api/v1/live_preview?entity=:entity"
+            observable={true}
+            initiallyVisible={false}
           />
         )}
       </div>

--- a/src/pages/recurring-invoices/edit/Edit.tsx
+++ b/src/pages/recurring-invoices/edit/Edit.tsx
@@ -177,6 +177,8 @@ export default function Edit() {
               relationType="client_id"
               endpoint="/api/v1/live_preview?entity=:entity"
               withRemoveLogoCTA
+              observable={true}
+              initiallyVisible={false}
             />
           )}
         </div>


### PR DESCRIPTION
@beganovich @turbo124 The PR improves the logic to not have automatic scrolling when changes are made in an entity and live_preview should be triggered. Let me know your thoughts.