### PR TITLE
[Cleanup] Updated At Refresh Endpoint Query Parameter

### DIFF
--- a/src/common/hooks/useAuthenticated.ts
+++ b/src/common/hooks/useAuthenticated.ts
@@ -22,6 +22,7 @@ import { AuthenticationTypes } from '../dtos/authentication';
 import { endpoint } from '../helpers';
 import { authenticate } from '../stores/slices/user';
 import { RootState } from '../stores/store';
+import dayjs from 'dayjs';
 
 export function useAuthenticated(): boolean {
   const user = useSelector((state: RootState) => state.user);
@@ -40,7 +41,12 @@ export function useAuthenticated(): boolean {
   }
 
   queryClient.fetchQuery('/api/v1/refresh', () =>
-    request('POST', endpoint('/api/v1/refresh'))
+    request(
+      'POST',
+      endpoint('/api/v1/refresh?updated_at=:updatedAt', {
+        updatedAt: dayjs().unix(),
+      })
+    )
       .then((response) => {
         let currentIndex = 0;
 
@@ -75,7 +81,7 @@ export function useAuthenticated(): boolean {
         dispatch(changeCurrentIndex(currentIndex));
       })
       .catch((e) => {
-        console.error(e)
+        console.error(e);
 
         localStorage.removeItem('X-NINJA-TOKEN');
 

--- a/src/common/hooks/useRefreshCompanyUsers.ts
+++ b/src/common/hooks/useRefreshCompanyUsers.ts
@@ -15,12 +15,18 @@ import {
   updateCompanyUsers,
 } from '../stores/slices/company-users';
 import { useDispatch } from 'react-redux';
+import dayjs from 'dayjs';
 
 export function useRefreshCompanyUsers() {
   const dispatch = useDispatch();
 
   return async () => {
-    return request('POST', endpoint('/api/v1/refresh')).then((response) => {
+    return request(
+      'POST',
+      endpoint('/api/v1/refresh?updated_at=:updatedAt', {
+        updatedAt: dayjs().unix(),
+      })
+    ).then((response) => {
       dispatch(updateCompanyUsers(response.data.data));
       dispatch(resetChanges('company'));
     });

--- a/src/components/AboutModal.tsx
+++ b/src/components/AboutModal.tsx
@@ -37,6 +37,7 @@ import {
 import { useDispatch } from 'react-redux';
 import { PasswordConfirmation } from './PasswordConfirmation';
 import { useOnWrongPasswordEnter } from '$app/common/hooks/useOnWrongPasswordEnter';
+import dayjs from 'dayjs';
 
 interface SystemInfo {
   system_health: boolean;
@@ -131,7 +132,15 @@ export function AboutModal(props: Props) {
 
       request('GET', endpoint('/api/v1/ping?clear_cache=true'))
         .then(() => {
-          request('POST', endpoint('/api/v1/refresh?current_company=true'))
+          request(
+            'POST',
+            endpoint(
+              '/api/v1/refresh?current_company=true&updated_at=:updatedAt',
+              {
+                updatedAt: dayjs().unix(),
+              }
+            )
+          )
             .then((response) => {
               dispatch(updateCompanyUsers(response.data.data));
               dispatch(resetChanges('company'));

--- a/src/components/HelpSidebarIcons.tsx
+++ b/src/components/HelpSidebarIcons.tsx
@@ -46,6 +46,7 @@ import { CircleWarning } from './icons/CircleWarning';
 import { Message } from './icons/Message';
 import { CircleQuestion } from './icons/CircleQuestion';
 import { CircleInfo } from './icons/CircleInfo';
+import dayjs from 'dayjs';
 
 interface Props {
   docsLink?: string;
@@ -126,7 +127,12 @@ export function HelpSidebarIcons(props: Props) {
   const refreshData = () => {
     setDisabledButton(true);
 
-    request('POST', endpoint('/api/v1/refresh')).then((data) => {
+    request(
+      'POST',
+      endpoint('/api/v1/refresh?updated_at=:updatedAt', {
+        updatedAt: dayjs().unix(),
+      })
+    ).then((data) => {
       dispatch(updateCompanyUsers(data.data.data));
       dispatch(resetChanges('company'));
       setDisabledButton(false);

--- a/src/components/banners/VerifyPhone.tsx
+++ b/src/components/banners/VerifyPhone.tsx
@@ -34,6 +34,7 @@ import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { $refetch } from '$app/common/hooks/useRefetch';
 import { useColorScheme } from '$app/common/colors';
 import { Popover } from '@headlessui/react';
+import dayjs from 'dayjs';
 
 interface VerificationProps {
   visible: boolean;
@@ -66,13 +67,16 @@ function Confirmation({
 
       $refetch(['users', 'company_users']);
 
-      request('POST', endpoint('/api/v1/refresh')).then(
-        (response: GenericSingleResourceResponse<CompanyUser>) => {
-          dispatch(updateCompanyUsers(response.data.data));
-          dispatch(resetChanges('company'));
-          onComplete();
-        }
-      );
+      request(
+        'POST',
+        endpoint('/api/v1/refresh?updated_at=:updatedAt', {
+          updatedAt: dayjs().unix(),
+        })
+      ).then((response: GenericSingleResourceResponse<CompanyUser>) => {
+        dispatch(updateCompanyUsers(response.data.data));
+        dispatch(resetChanges('company'));
+        onComplete();
+      });
     });
   };
 

--- a/src/pages/clients/common/components/MergeClientModal.tsx
+++ b/src/pages/clients/common/components/MergeClientModal.tsx
@@ -28,6 +28,7 @@ import { useNavigate } from 'react-router-dom';
 import { $refetch } from '$app/common/hooks/useRefetch';
 import { useEntityPageIdentifier } from '$app/common/hooks/useEntityPageIdentifier';
 import { useOnWrongPasswordEnter } from '$app/common/hooks/useOnWrongPasswordEnter';
+import dayjs from 'dayjs';
 
 interface Props {
   visible: boolean;
@@ -77,7 +78,12 @@ export function MergeClientModal(props: Props) {
         .then(() => {
           $refetch(['clients']);
 
-          request('POST', endpoint('/api/v1/refresh'))
+          request(
+            'POST',
+            endpoint('/api/v1/refresh?updated_at=:updatedAt', {
+              updatedAt: dayjs().unix(),
+            })
+          )
             .then((response: AxiosResponse) => {
               toast.success('merged_clients');
 

--- a/src/pages/settings/company/create/CompanyCreate.tsx
+++ b/src/pages/settings/company/create/CompanyCreate.tsx
@@ -26,6 +26,7 @@ import { useQueryClient } from 'react-query';
 import { useDispatch } from 'react-redux';
 import { useColorScheme } from '$app/common/colors';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import dayjs from 'dayjs';
 
 interface Props {
   isModalOpen: boolean;
@@ -83,7 +84,12 @@ export function CompanyCreate(props: Props) {
 
       request('POST', endpoint('/api/v1/companies'))
         .then(() => {
-          request('POST', endpoint('/api/v1/refresh'))
+          request(
+            'POST',
+            endpoint('/api/v1/refresh?updated_at=:updatedAt', {
+              updatedAt: dayjs().unix(),
+            })
+          )
             .then((response: AxiosResponse) => {
               const companyUsers = response.data.data;
 

--- a/src/pages/settings/tax-rates/TaxRates.tsx
+++ b/src/pages/settings/tax-rates/TaxRates.tsx
@@ -17,6 +17,7 @@ import {
   resetChanges,
   updateCompanyUsers,
 } from '$app/common/stores/slices/company-users';
+import dayjs from 'dayjs';
 
 export function TaxRates() {
   const dispatch = useDispatch();
@@ -24,7 +25,12 @@ export function TaxRates() {
 
   const onBulkActionsSuccess = (action: 'archive' | 'delete' | 'restore') => {
     if (action === 'archive' || action === 'delete') {
-      request('POST', endpoint('/api/v1/refresh')).then((response) => {
+      request(
+        'POST',
+        endpoint('/api/v1/refresh?updated_at=:updatedAt', {
+          updatedAt: dayjs().unix(),
+        })
+      ).then((response) => {
         dispatch(updateCompanyUsers(response.data.data));
         dispatch(resetChanges('company'));
       });


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adding an `updated_at` query parameter to each `/refresh` endpoint in the app with the current timestamp as the value. Let me know your thoughts.