### PR TITLE
[Cleanup] Product Selector Max Width

### DIFF
--- a/src/components/products/ProductSelector.tsx
+++ b/src/components/products/ProductSelector.tsx
@@ -64,9 +64,9 @@ export function ProductSelector(props: Props) {
           value: 'id',
           searchable: 'notes',
           dropdownLabelFn: (product) => (
-            <div>
+            <div className="flex flex-col flex-1 max-w-64">
               <div className="flex space-x-1">
-                <p className="font-medium">{product.product_key}</p>
+                <p className="font-medium truncate">{product.product_key}</p>
 
                 {currentCompany?.track_inventory &&
                   props.displayStockQuantity && (
@@ -84,7 +84,10 @@ export function ProductSelector(props: Props) {
                   )}
               </div>
 
-              <p className="text-xs font-medium" style={{ color: colors.$22 }}>
+              <p
+                className="text-xs font-medium truncate"
+                style={{ color: colors.$22 }}
+              >
                 {product.notes}
               </p>
             </div>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes a quick cleanup for the product selector to set a constraint on width with truncating text values in case notes are too large. Screenshot:

![Screenshot 2025-07-02 at 05 41 33](https://github.com/user-attachments/assets/cc5d77c4-9922-4716-b010-51a74e162fc4)

Let me know your thoughts.