### PR TITLE
[Bugfix] Invoices/Credits Money Formatting On Payment Slider

### DIFF
--- a/src/pages/payments/common/components/PaymentSlider.tsx
+++ b/src/pages/payments/common/components/PaymentSlider.tsx
@@ -133,7 +133,7 @@ export function PaymentSlider() {
                 ? formatMoney(
                     payment?.amount,
                     payment.client?.country_id,
-                    payment.client?.settings.currency_id
+                    payment.currency_id
                   )
                 : null}
             </Element>
@@ -149,7 +149,7 @@ export function PaymentSlider() {
                 ? formatMoney(
                     payment.applied,
                     payment.client?.country_id,
-                    payment.client?.settings.currency_id
+                    payment.currency_id
                   )
                 : null}
             </Element>
@@ -220,7 +220,7 @@ export function PaymentSlider() {
                     {formatMoney(
                       invoice.amount,
                       payment.client?.country_id,
-                      payment.client?.settings.currency_id
+                      payment.currency_id
                     )}
                   </span>
 
@@ -273,7 +273,7 @@ export function PaymentSlider() {
                     {formatMoney(
                       credit.amount,
                       payment.client?.country_id,
-                      payment.client?.settings.currency_id
+                      payment.currency_id
                     )}
                   </span>
 

--- a/src/pages/payments/common/components/PaymentSlider.tsx
+++ b/src/pages/payments/common/components/PaymentSlider.tsx
@@ -219,8 +219,8 @@ export function PaymentSlider() {
                   <span>
                     {formatMoney(
                       invoice.amount,
-                      invoice.client?.country_id,
-                      invoice.client?.settings.currency_id
+                      payment.client?.country_id,
+                      payment.client?.settings.currency_id
                     )}
                   </span>
 
@@ -272,8 +272,8 @@ export function PaymentSlider() {
                   <span>
                     {formatMoney(
                       credit.amount,
-                      credit.client?.country_id,
-                      credit.client?.settings.currency_id
+                      payment.client?.country_id,
+                      payment.client?.settings.currency_id
                     )}
                   </span>
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for formatting money on the payment slider for invoices and credit cards, where currency_id and country_id from the invoice and credit clients are used instead of those from the payment.

Closes #2633 

Let me know your thoughts.