### PR TITLE
[Bugfix] Paypal Gateway Card Reordering

### DIFF
--- a/src/pages/settings/gateways/create/Create.tsx
+++ b/src/pages/settings/gateways/create/Create.tsx
@@ -332,15 +332,15 @@ export function Create() {
   useEffect(() => {
     if (!filteredGateways.length) return;
 
-    const gatewayIndex = filteredGateways.findIndex(
-      (gateway) => gateway.key === 'b9886f9257f0c6ee7c302f1c74475f6c'
+    const gatewayIndex = filteredGateways.findIndex((gateway) =>
+      gateway.name?.toLowerCase().includes('paypal')
     );
 
-    if (gatewayIndex === -1 || gatewayIndex === 2) return;
+    if (gatewayIndex === -1 || gatewayIndex === 1) return;
 
     const updatedGateways = [...filteredGateways];
     const [gateway] = updatedGateways.splice(gatewayIndex, 1);
-    updatedGateways.splice(2, 0, gateway);
+    updatedGateways.splice(1, 0, gateway);
 
     setFilteredGateways(updatedGateways);
   }, [filteredGateways]);


### PR DESCRIPTION
@beganovich @turbo124 The PR includes changes to the logic for PayPal gateway card reordering. Screenshot:

<img width="1512" height="764" alt="Screenshot 2025-08-06 at 12 55 49" src="https://github.com/user-attachments/assets/97c8732c-942d-4910-acaa-3a9f8854a863" />

Let me know your thoughts.