### PR TITLE
[Bugfix] User Selector Read Only | Projects

### DIFF
--- a/src/pages/projects/edit/Edit.tsx
+++ b/src/pages/projects/edit/Edit.tsx
@@ -95,7 +95,6 @@ export default function Edit() {
           onChange={(user) => handleChange('assigned_user_id', user.id)}
           onClearButtonClick={() => handleChange('assigned_user_id', '')}
           errorMessage={errors?.errors.assigned_user_id}
-          readonly
         />
       </Element>
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for removing the `readOnly` prop from the user selector on the project edit page. Screenshot:

<img width="675" height="789" alt="Screenshot 2025-08-14 at 01 54 17" src="https://github.com/user-attachments/assets/d4e7c49d-c111-4bde-84fd-e304fa661abc" />

Let me know your thoughts.