### PR TITLE
[Feature] Filtering In Email History Section

### DIFF
--- a/src/pages/clients/show/pages/HistoryAndActivities.tsx
+++ b/src/pages/clients/show/pages/HistoryAndActivities.tsx
@@ -150,7 +150,7 @@ export default function HistoryAndActivities() {
                     className="border-transparent focus:border-transparent focus:ring-0 border-0 w-full px-0"
                     value={filter}
                     onValueChange={(value) => setFilter(value)}
-                    placeholder={t('search_emails')}
+                    placeholder={t('search')}
                     changeOverride
                     style={{ backgroundColor: colors.$1, color: colors.$3 }}
                   />

--- a/src/pages/clients/show/pages/HistoryAndActivities.tsx
+++ b/src/pages/clients/show/pages/HistoryAndActivities.tsx
@@ -9,7 +9,7 @@
  */
 
 import { useOutletContext, useParams } from 'react-router-dom';
-import { endpoint } from '$app/common/helpers';
+import { date, endpoint } from '$app/common/helpers';
 import { request } from '$app/common/helpers/request';
 import { useQuery } from 'react-query';
 import { Card } from '$app/components/cards';
@@ -30,12 +30,14 @@ import { EmailRecord as EmailRecordType } from '$app/common/interfaces/email-his
 import { Spinner } from '$app/components/Spinner';
 import { InputField } from '$app/components/forms';
 import { Search as SearchIcon } from '$app/components/icons/Search';
+import { useCurrentCompanyDateFormats } from '$app/common/hooks/useCurrentCompanyDateFormats';
 
 export default function HistoryAndActivities() {
   const [t] = useTranslation();
 
   const { id } = useParams();
   const colors = useColorScheme();
+  const { dateFormat } = useCurrentCompanyDateFormats();
 
   const activityElement = useGenerateActivityElement();
 
@@ -75,6 +77,33 @@ export default function HistoryAndActivities() {
     staleTime: Infinity,
   });
 
+  const checkEmailRecord = (emailRecord: EmailRecordType) => {
+    const doesSubjectContains = emailRecord.subject
+      .toLowerCase()
+      .includes(filter.toLowerCase());
+
+    const doesRecipientsContains = emailRecord.recipients
+      .toLowerCase()
+      .includes(filter.toLowerCase());
+
+    const doesEntityContains = emailRecord.entity
+      .toLowerCase()
+      .includes(filter.toLowerCase());
+
+    const doesEventDateContains = emailRecord.events.some((event) => {
+      const formattedDate = date(event.date, dateFormat);
+
+      return formattedDate.includes(filter);
+    });
+
+    return (
+      doesSubjectContains ||
+      doesRecipientsContains ||
+      doesEntityContains ||
+      doesEventDateContains
+    );
+  };
+
   useEffect(() => {
     if (emailRecords) {
       setFilteredEmailRecords(emailRecords);
@@ -85,16 +114,7 @@ export default function HistoryAndActivities() {
     if (emailRecords) {
       if (filter) {
         setFilteredEmailRecords(
-          emailRecords.filter(
-            (emailRecord) =>
-              emailRecord.subject
-                .toLowerCase()
-                .includes(filter.toLowerCase()) ||
-              emailRecord.recipients
-                .toLowerCase()
-                .includes(filter.toLowerCase()) ||
-              emailRecord.entity.toLowerCase().includes(filter.toLowerCase())
-          )
+          emailRecords.filter((emailRecord) => checkEmailRecord(emailRecord))
         );
       } else {
         setFilteredEmailRecords(emailRecords || []);
@@ -114,47 +134,51 @@ export default function HistoryAndActivities() {
         headerStyle={{ borderColor: colors.$20 }}
       >
         <div className="px-4 sm:px-6 pb-6 pt-4">
-          {isLoadingEmailRecords && <Spinner />}
-
-          <div className="flex items-center space-x-1.5 py-2 px-4 flex-1 border-b mb-4">
-            {isLoadingEmailRecords ? (
+          {isLoadingEmailRecords && (
+            <div className="flex justify-center items-center py-8">
               <Spinner />
-            ) : (
-              <SearchIcon color={colors.$5} size="1.6rem" />
-            )}
-
-            <div className="flex-1">
-              <InputField
-                className="border-transparent focus:border-transparent focus:ring-0 border-0 w-full px-0"
-                value={filter}
-                onValueChange={(value) => setFilter(value)}
-                placeholder={t('search_emails')}
-                changeOverride
-                style={{ backgroundColor: colors.$1, color: colors.$3 }}
-              />
             </div>
-          </div>
+          )}
 
-          <div className="flex flex-col overflow-y-auto max-h-96 space-y-4">
-            {filteredEmailRecords?.map(
-              (emailRecord, index) =>
-                emailRecord && (
-                  <EmailRecord
-                    key={index}
-                    emailRecord={emailRecord}
-                    index={index}
-                    withAllBorders
-                    withEntityNavigationIcon
+          {!isLoadingEmailRecords && (
+            <>
+              <div className="flex items-center space-x-1.5 py-2 px-4 flex-1 border-b mb-4">
+                <SearchIcon color={colors.$5} size="1.6rem" />
+
+                <div className="flex-1">
+                  <InputField
+                    className="border-transparent focus:border-transparent focus:ring-0 border-0 w-full px-0"
+                    value={filter}
+                    onValueChange={(value) => setFilter(value)}
+                    placeholder={t('search_emails')}
+                    changeOverride
+                    style={{ backgroundColor: colors.$1, color: colors.$3 }}
                   />
-                )
-            )}
-
-            {filteredEmailRecords.length === 0 && (
-              <div className="text-center text-sm font-medium pt-6 pb-4">
-                {t('no_records_found')}.
+                </div>
               </div>
-            )}
-          </div>
+
+              <div className="flex flex-col overflow-y-auto max-h-96 space-y-4">
+                {filteredEmailRecords?.map(
+                  (emailRecord, index) =>
+                    emailRecord && (
+                      <EmailRecord
+                        key={index}
+                        emailRecord={emailRecord}
+                        index={index}
+                        withAllBorders
+                        withEntityNavigationIcon
+                      />
+                    )
+                )}
+
+                {filteredEmailRecords.length === 0 && (
+                  <div className="text-center text-sm font-medium pt-6 pb-4">
+                    {t('no_records_found')}.
+                  </div>
+                )}
+              </div>
+            </>
+          )}
         </div>
       </Card>
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adding filtering to the "Email History" card/section on the Client overview page. Currently, I implemented React filtering without calling the API, as the API always returns all emails. To filter emails, I check if the filter is contained in the `subject`, `recipients`, or `entity`, or if a date is entered, I check the dates in the events array to see if it includes any of those dates.

`Note`: I used "search_emails" translation keyword, so if you agree please just add it into files.

Let me know your thoughts.