### PR TITLE
Remove fixed height for monaco

### DIFF
--- a/src/pages/settings/invoice-design/pages/custom-designs/pages/create/Create.tsx
+++ b/src/pages/settings/invoice-design/pages/custom-designs/pages/create/Create.tsx
@@ -247,7 +247,7 @@ export default function Create() {
       {type === 'template' ? (
         <Card title={t('import')} withContainer collapsed>
           <Editor
-            height="15rem"
+            height=""
             defaultLanguage="html"
             value={design?.design.body}
             options={{


### PR DESCRIPTION
Removes the default height of 15rem for the monaco editor and allows it to fill the view:

closes #2123