### PR TITLE
[Bugfix] Refetching Dashboard Queries After Vendor Updates

### DIFF
--- a/src/common/hooks/useRefetch.tsx
+++ b/src/common/hooks/useRefetch.tsx
@@ -129,6 +129,9 @@ export const keys = {
       '/api/v1/recurring_expenses',
       '/api/v1/purchase_orders',
       '/api/v1/activities/entity',
+      '/api/v1/charts/totals_v2',
+      '/api/v1/charts/chart_summary_v2',
+      '/api/v1/activities',
     ],
   },
   users: {


### PR DESCRIPTION
@beganovich @turbo124 The PR includes logic improvements to invalidate dashboard queries after vendors are changed. Let me know your thoughts.