### PR TITLE
[Cleanup] Adjusting Max Width For Products Selector

### DIFF
--- a/src/components/products/ProductSelector.tsx
+++ b/src/components/products/ProductSelector.tsx
@@ -64,7 +64,7 @@ export function ProductSelector(props: Props) {
           value: 'id',
           searchable: 'notes',
           dropdownLabelFn: (product) => (
-            <div className="flex flex-col flex-1 max-w-64">
+            <div className="flex flex-col flex-1 max-w-[33rem]">
               <div className="flex space-x-1">
                 <p className="font-medium truncate">{product.product_key}</p>
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adjusting the max width for the product selector. So, if there are long notes, for example, the product selector will be significantly wider than we had it earlier, but if there is no need for that (if there are no long notes), the size will stay as default. Let me know your thoughts.