### PR TITLE
[Bugfix] Money Formatting Payments | Invoice Slider

### DIFF
--- a/src/pages/invoices/common/components/InvoiceSlider.tsx
+++ b/src/pages/invoices/common/components/InvoiceSlider.tsx
@@ -571,8 +571,8 @@ export function InvoiceSlider() {
                           <span>
                             {formatMoney(
                               paymentable.amount,
-                              payment.client?.country_id,
-                              payment.client?.settings.currency_id
+                              invoice?.client?.country_id,
+                              invoice?.client?.settings.currency_id
                             )}
                           </span>
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for money formatting on the invoice slider for payments. Previously, the details for money formatting were taken from the payment object, but now we use details from the invoice object, and it will match the currency for the entire invoice slider. Screenshot:

<img width="607" height="939" alt="Screenshot 2025-09-07 at 00 26 59" src="https://github.com/user-attachments/assets/f029f074-f165-4070-9eba-2ce0501060b0" />

Closes #2698 

Let me know your thoughts.