### PR TITLE
[Feature] Next Send Date Column Range Picker

### DIFF
--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -328,14 +328,12 @@ export function DataTable<T extends object>(props: Props<T>) {
 
     apiEndpoint.searchParams.set('status', status as unknown as string);
 
-    if (dateRangeColumns.length && dateRangeQueryParameter) {
-      const startDate = dateRange?.split(',')[0];
-      const endDate = dateRange?.split(',')[1];
-
-      apiEndpoint.searchParams.set(
-        dateRangeQueryParameter,
-        startDate && endDate ? dateRange : ''
-      );
+    if (
+      dateRangeColumns.length &&
+      dateRangeQueryParameter &&
+      dateRange?.split(',').every((date) => date.length > 1)
+    ) {
+      apiEndpoint.searchParams.set(dateRangeQueryParameter, dateRange);
     }
 
     setApiEndpoint(apiEndpoint);
@@ -398,8 +396,13 @@ export function DataTable<T extends object>(props: Props<T>) {
       sort,
       status,
       customFilter,
-      dateRange,
-      dateRangeQueryParameter,
+      ...(dateRange?.split(',').every((date) => date.length > 1)
+        ? [dateRange]
+        : []),
+      ...(dateRange?.split(',').every((date) => date.length > 1) &&
+      dateRangeQueryParameter
+        ? [dateRangeQueryParameter]
+        : []),
     ],
     () => request(methodType, apiEndpoint.href),
     {

--- a/src/pages/recurring-invoices/index/RecurringInvoices.tsx
+++ b/src/pages/recurring-invoices/index/RecurringInvoices.tsx
@@ -142,6 +142,12 @@ export default function RecurringInvoices() {
           setRecurringInvoiceSliderVisibility(true);
         }}
         enableSavingFilterPreference
+        dateRangeColumns={[
+          {
+            column: 'next_send_datetime',
+            queryParameterKey: 'next_send_between',
+          },
+        ]}
       />
 
       {!disableNavigation('recurring_invoice', recurringInvoiceSlider) && (


### PR DESCRIPTION
@beganovich @turbo124 The PR includes implementing a range picker for the next send date column using `next_send_between` as a query parameter. Screenshot:

<img width="1037" height="236" alt="Screenshot 2025-09-17 at 11 15 08" src="https://github.com/user-attachments/assets/1582573e-6a47-4a0b-a4d2-d4d32d5d4c40" />

Let me know your thoughts.