### PR TITLE
[Bugfix] Documents Breadcrumbs + Hidding Plus Icon For Users

### DIFF
--- a/src/components/layouts/Default.tsx
+++ b/src/components/layouts/Default.tsx
@@ -64,6 +64,7 @@ import { CurrencyExchange } from '../icons/CurrencyExchange';
 import { ChartLine } from '../icons/ChartLine';
 import { ArrowsTransaction } from '../icons/ArrowsTransaction';
 import { Gear } from '../icons/Gear';
+import { docuCompanyAccountDetailsAtom } from '$app/pages/documents/Document';
 
 export interface SaveOption {
   label: string;
@@ -99,6 +100,7 @@ export function Default(props: Props) {
   const user = useInjectUserChanges();
   const company = useCurrentCompany();
   const companyUser = useCurrentCompanyUser();
+  const docuCompanyAccountDetails = useAtomValue(docuCompanyAccountDetailsAtom);
 
   const isMiniSidebar = Boolean(
     user?.company_user?.react_settings.show_mini_sidebar
@@ -394,7 +396,9 @@ export function Default(props: Props) {
             icon: Plus,
             to: '/documents/users/create',
             label: t('new_user'),
-            visible: true,
+            visible:
+              (docuCompanyAccountDetails?.account?.num_users || 0) !==
+              (docuCompanyAccountDetails?.account?.users || [])?.length,
           },
         },
       ],

--- a/src/pages/documents/pages/users/Users.tsx
+++ b/src/pages/documents/pages/users/Users.tsx
@@ -31,6 +31,10 @@ export default function Users() {
 
   const pages = [
     {
+      name: t('documents'),
+      href: '/documents',
+    },
+    {
       name: t('users'),
       href: '/documents/users',
     },

--- a/src/pages/documents/pages/users/create/Create.tsx
+++ b/src/pages/documents/pages/users/create/Create.tsx
@@ -41,6 +41,10 @@ export default function Create() {
 
   const pages = [
     {
+      name: t('documents'),
+      href: '/documents',
+    },
+    {
       name: t('users'),
       href: '/documents/users',
     },

--- a/src/pages/documents/pages/users/edit/Edit.tsx
+++ b/src/pages/documents/pages/users/edit/Edit.tsx
@@ -43,6 +43,10 @@ function Create() {
 
   const pages = [
     {
+      name: t('documents'),
+      href: '/documents',
+    },
+    {
       name: t('users'),
       href: '/documents/users',
     },


### PR DESCRIPTION
@beganovich @turbo124 The PR includes two fixes: a fix for breadcrumbs for users under documents on all pages, and also, same as we disabled the new_user button on the list users page, I hid it if the client reached the user limit. Let me know your thoughts.