### PR TITLE
[Feature] Adding HTML Code Option For Lexical Editor

### DIFF
--- a/src/components/lexical/plugins/ToolbarPlugin/htmlCode.tsx
+++ b/src/components/lexical/plugins/ToolbarPlugin/htmlCode.tsx
@@ -1,0 +1,96 @@
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { $generateHtmlFromNodes, $generateNodesFromDOM } from '@lexical/html';
+import { $getRoot, $insertNodes } from 'lexical';
+import { useState } from 'react';
+import { Modal } from '$app/components/Modal';
+import { Button, InputField } from '$app/components/forms';
+import { useTranslation } from 'react-i18next';
+import { Icon } from '$app/components/icons/Icon';
+import { BiCodeAlt } from 'react-icons/bi';
+import classNames from 'classnames';
+
+interface Props {
+  disabled: boolean;
+}
+
+export default function HtmlCode({ disabled }: Props) {
+  const [t] = useTranslation();
+
+  const [editor] = useLexicalComposerContext();
+
+  const [sourceCode, setSourceCode] = useState<string>('');
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+
+  const openSourceCode = () => {
+    editor.getEditorState().read(() => {
+      const htmlString = $generateHtmlFromNodes(editor, null);
+      setSourceCode(htmlString);
+      setIsModalOpen(true);
+    });
+  };
+
+  const handleSave = () => {
+    editor.update(() => {
+      const parser = new DOMParser();
+      const dom = parser.parseFromString(sourceCode, 'text/html');
+      const nodes = $generateNodesFromDOM(editor, dom);
+
+      // Clear existing content
+      const root = $getRoot();
+      root.clear();
+
+      // Insert new nodes
+      root.select();
+      $insertNodes(nodes);
+    });
+
+    setIsModalOpen(false);
+  };
+
+  const handleCancel = () => {
+    setIsModalOpen(false);
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        className={classNames('toolbar-item', {
+          'cursor-not-allowed': disabled,
+        })}
+        onClick={() => {
+          if (disabled) return;
+          openSourceCode();
+        }}
+      >
+        <Icon element={BiCodeAlt} style={{ color: 'gray' }} />
+      </button>
+
+      <Modal
+        title={t('source_code')}
+        visible={isModalOpen}
+        onClose={handleCancel}
+        size="regular"
+      >
+        <div className="flex flex-col space-y-4">
+          <InputField
+            element="textarea"
+            value={sourceCode}
+            onValueChange={(value) => setSourceCode(value)}
+            style={{
+              width: '100%',
+              minHeight: '400px',
+              fontFamily: 'monospace',
+            }}
+          />
+
+          <div className="flex w-full justify-end">
+            <Button behavior="button" type="primary" onClick={handleSave}>
+              {t('save')}
+            </Button>
+          </div>
+        </div>
+      </Modal>
+    </>
+  );
+}

--- a/src/components/lexical/plugins/ToolbarPlugin/htmlCode.tsx
+++ b/src/components/lexical/plugins/ToolbarPlugin/htmlCode.tsx
@@ -35,11 +35,9 @@ export default function HtmlCode({ disabled }: Props) {
       const dom = parser.parseFromString(sourceCode, 'text/html');
       const nodes = $generateNodesFromDOM(editor, dom);
 
-      // Clear existing content
       const root = $getRoot();
       root.clear();
 
-      // Insert new nodes
       root.select();
       $insertNodes(nodes);
     });

--- a/src/components/lexical/plugins/ToolbarPlugin/index.tsx
+++ b/src/components/lexical/plugins/ToolbarPlugin/index.tsx
@@ -84,6 +84,7 @@ import { useColorScheme } from '$app/common/colors';
 import { useTranslation } from 'react-i18next';
 import { useReactSettings } from '$app/common/hooks/useReactSettings';
 import classNames from 'classnames';
+import HtmlCode from './htmlCode';
 
 const rootTypeToRootName = {
   root: 'Root',
@@ -886,9 +887,6 @@ export default function ToolbarPlugin({
     [activeEditor, selectedElementKey]
   );
 
-  const canViewerSeeInsertDropdown = !toolbarState.isImageCaption;
-  const canViewerSeeInsertCodeButton = !toolbarState.isImageCaption;
-
   return (
     <div
       className={classNames('toolbar', {
@@ -1082,22 +1080,21 @@ export default function ToolbarPlugin({
           >
             <i className="format underline" />
           </button>
-          {canViewerSeeInsertCodeButton && (
-            <button
-              disabled={!isEditable}
-              onClick={() => {
-                activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'code');
-              }}
-              className={
-                'toolbar-item spaced ' + (toolbarState.isCode ? 'active' : '')
-              }
-              title={`Insert code block (${SHORTCUTS.INSERT_CODE_BLOCK})`}
-              type="button"
-              aria-label="Insert code block"
-            >
-              <i className="format code" />
-            </button>
-          )}
+          <button
+            disabled={!isEditable}
+            onClick={() => {
+              activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'code');
+            }}
+            className={
+              'toolbar-item spaced ' + (toolbarState.isCode ? 'active' : '')
+            }
+            title={`Insert code block (${SHORTCUTS.INSERT_CODE_BLOCK})`}
+            type="button"
+            aria-label="Insert code block"
+          >
+            <i className="format code" />
+          </button>
+          <HtmlCode disabled={!isEditable} />
           <button
             disabled={!isEditable}
             onClick={insertLink}


### PR DESCRIPTION
@beganovich @turbo124 This PR adds HTML code editing functionality to the Lexical editor. Screenshot:

<img width="656" height="567" alt="Screenshot 2025-10-05 at 23 55 06" src="https://github.com/user-attachments/assets/c25fb6dd-b067-448e-8cdf-1b2f2f934340" />

Let me know your thoughts.