### PR TITLE
[Bugfix] Per Page Query Parameter For Bank Integrations Query

### DIFF
--- a/src/pages/settings/bank-accounts/common/queries.ts
+++ b/src/pages/settings/bank-accounts/common/queries.ts
@@ -45,7 +45,7 @@ export function useBankAccountsQuery(params?: Params) {
   const { perPage } = params || {};
 
   return useQuery<BankAccount[]>(
-    ['/api/v1/bank_integrations'],
+    ['/api/v1/bank_integrations', params],
     () =>
       request(
         'GET',

--- a/src/pages/transactions/common/hooks/useTransactionFilters.tsx
+++ b/src/pages/transactions/common/hooks/useTransactionFilters.tsx
@@ -18,7 +18,9 @@ export function useTransactionFilters() {
 
   const statusThemeColors = useStatusThemeColorScheme();
 
-  const { data: bankIntegrations } = useBankAccountsQuery({ perPage: 1000 });
+  const { data: bankIntegrations } = useBankAccountsQuery({
+    perPage: 1000,
+  });
 
   const filters: SelectOption[] = [
     {


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for the `per_page` query parameter for the bank_integrations list on the Transaction list filter. Instead of 20 bank integrations per page, we will now have 1000 bank integrations per page. Let me know your thoughts.