### PR TITLE
[Bugfix] Date Format for Payment Schedules

### DIFF
--- a/src/pages/settings/schedules/common/components/PaymentSchedule.tsx
+++ b/src/pages/settings/schedules/common/components/PaymentSchedule.tsx
@@ -14,7 +14,7 @@ import { ValidationBag } from '$app/common/interfaces/validation-bag';
 import { atom } from 'jotai';
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { endpoint } from '$app/common/helpers';
+import { date, endpoint } from '$app/common/helpers';
 import { Invoice } from '$app/common/interfaces/invoice';
 import { ComboboxAsync, Entry } from '$app/components/forms/Combobox';
 import { useFormatMoney } from '$app/common/hooks/money/useFormatMoney';
@@ -23,6 +23,7 @@ import { Button } from '$app/components/forms';
 import Toggle from '$app/components/forms/Toggle';
 import { AddScheduleModal } from './AddScheduleModal';
 import { useInvoiceQuery } from '$app/common/queries/invoices';
+import { useCurrentCompanyDateFormats } from '$app/common/hooks/useCurrentCompanyDateFormats';
 
 
 interface Props {
@@ -51,6 +52,8 @@ export function PaymentSchedule(props: Props) {
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [selectedScheduleIndex, setSelectedScheduleIndex] = useState(-1);
     const [selectedInvoice, setSelectedInvoice] = useState<Invoice | null>(null);
+
+    const { dateFormat } = useCurrentCompanyDateFormats();
 
     const { schedule, handleChange, errors, setErrors, page, disableInvoiceSelection } = props;
 
@@ -436,7 +439,7 @@ export function PaymentSchedule(props: Props) {
                                             key={index}
                                             className={`border-b ${isScheduleInPast(schedule.date) ? 'opacity-60' : ''}`}
                                         >
-                                            <Td width="30%">{schedule.date}</Td>
+                                            <Td width="30%">{date(schedule.date, dateFormat)}</Td>
                                             <Td>{formatScheduleAmount(schedule)}</Td>
                                             <Td>
                                                 <div className="">


### PR DESCRIPTION
@beganovich @turbo124 The PR includes date format fixes for payment schedules. Screenshot:

<img width="1197" height="494" alt="Screenshot 2025-10-23 at 19 07 18" src="https://github.com/user-attachments/assets/b9cb613c-2562-4d54-8658-216735ef02ec" />

Let me know your thoughts.