### PR TITLE
[Bugfix] Preventing Dropdown Z-Index Issue | Custom Lables

### DIFF
--- a/src/pages/settings/localization/components/CustomLabels.tsx
+++ b/src/pages/settings/localization/components/CustomLabels.tsx
@@ -188,7 +188,7 @@ export function CustomLabels() {
         <Button
           behavior="button"
           type="secondary"
-          onClick={() => setIsCustomModalOpen(true)}
+          onClick={() => setTimeout(() => setIsCustomModalOpen(true), 100)}
         >
           {t('add_custom')}
         </Button>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes preventing a dropdown z-index issue when it is active and after the "add_custom" button is clicked on the "Custom Labels" tab. I cannot recreate the issue that is mentioned in the ticket, but I did implement this prevention. Let me know your thoughts.