### PR TITLE
[Feature] Date Range Selector | Expenses

### DIFF
--- a/src/pages/expenses/index/Expenses.tsx
+++ b/src/pages/expenses/index/Expenses.tsx
@@ -26,7 +26,10 @@ import { useCustomBulkActions } from '../common/hooks/useCustomBulkActions';
 import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
 import { Guard } from '$app/common/guards/Guard';
 import { or } from '$app/common/guards/guards/or';
-import { ChangeTemplateModal, useChangeTemplate } from '$app/pages/settings/invoice-design/pages/custom-designs/components/ChangeTemplate';
+import {
+  ChangeTemplateModal,
+  useChangeTemplate,
+} from '$app/pages/settings/invoice-design/pages/custom-designs/components/ChangeTemplate';
 import { Expense } from '$app/common/interfaces/expense';
 import { InputLabel } from '$app/components/forms';
 
@@ -38,14 +41,10 @@ export default function Expenses() {
 
   const pages = [{ name: t('expenses'), href: '/expenses' }];
 
-  const columns = useExpenseColumns();
-
   const actions = useActions();
-
   const filters = useExpenseFilters();
-
+  const columns = useExpenseColumns();
   const expenseColumns = useAllExpenseColumns();
-
   const customBulkActions = useCustomBulkActions();
 
   const {
@@ -88,9 +87,10 @@ export default function Expenses() {
         linkToCreateGuards={[permission('create_expense')]}
         hideEditableOptions={!hasPermission('edit_expense')}
         enableSavingFilterPreference
+        dateRangeColumns={[{ column: 'date', queryParameterKey: 'date_range' }]}
       />
 
-    <ChangeTemplateModal<Expense>
+      <ChangeTemplateModal<Expense>
         entity="expense"
         entities={changeTemplateResources as Expense[]}
         visible={changeTemplateVisible}
@@ -111,7 +111,6 @@ export default function Expenses() {
         )}
         bulkUrl="/api/v1/expenses/bulk"
       />
-      
     </Default>
   );
 }


### PR DESCRIPTION
@beganovich @turbo124 The PR includes implementation of a date range selector for the "date" column on the Expenses main table. Screenshot:

<img width="1260" height="434" alt="Screenshot 2025-11-05 at 17 59 41" src="https://github.com/user-attachments/assets/18dc4246-42cf-436f-8843-a211a583e363" />

Let me know your thoughts.