### PR TITLE
[Bugfix] Hiding Page Numbering Alignment Field

### DIFF
--- a/src/pages/settings/invoice-design/pages/general-settings/components/GeneralSettings.tsx
+++ b/src/pages/settings/invoice-design/pages/general-settings/components/GeneralSettings.tsx
@@ -858,8 +858,21 @@ export default function GeneralSettings() {
     );
   };
 
+  const handleScrollToBottom = () => {
+    const pageNumberingAlignment = document.querySelector(
+      '.page-numbering-alignment-select'
+    );
+
+    if (pageNumberingAlignment) {
+      pageNumberingAlignment.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center',
+      });
+    }
+  };
+
   return (
-    <>
+    <div className="flex flex-col pb-24">
       <AdvancedSettingsPlanAlert />
 
       <Card
@@ -1608,7 +1621,15 @@ export default function GeneralSettings() {
           <Toggle
             checked={Boolean(company?.settings?.page_numbering)}
             id="settings.page_numbering"
-            onChange={(value) => handleChange('page_numbering', value)}
+            onChange={(value) => {
+              handleChange('page_numbering', value);
+
+              if (value) {
+                setTimeout(() => {
+                  handleScrollToBottom();
+                }, 25);
+              }
+            }}
             disabled={disableSettingsField('page_numbering')}
           />
         </Element>
@@ -1626,6 +1647,7 @@ export default function GeneralSettings() {
             }
           >
             <SelectField
+              className="page-numbering-alignment-select"
               id="settings.page_numbering_alignment"
               disabled={disableSettingsField('page_numbering_alignment')}
               value={
@@ -1645,6 +1667,6 @@ export default function GeneralSettings() {
           </Element>
         )}
       </Card>
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
@beganovich @turbo124 This PR includes adding logic for hiding the page numbering alignment field when the page numbering toggle is turned off. Screenshot:

<img width="514" height="247" alt="Screenshot 2025-11-17 at 10 57 47" src="https://github.com/user-attachments/assets/f53b7e76-aafa-4a29-8bd1-8e65442fa1bf" />

Let me know your thoughts.