### PR TITLE
[Cleanup] Displaying Custom Surcharge Fields

### DIFF
--- a/src/pages/invoices/common/components/InvoiceTotals.tsx
+++ b/src/pages/invoices/common/components/InvoiceTotals.tsx
@@ -227,7 +227,11 @@ export function InvoiceTotals(props: Props) {
 
               {isSurchargeField(variable) && (
                 <>
-                  {Boolean(company && company?.custom_fields?.surcharge1) && (
+                  {Boolean(
+                    company &&
+                      company?.custom_fields?.surcharge1 &&
+                      variable === '$custom_surcharge1'
+                  ) && (
                     <CustomSurchargeField
                       field="surcharge1"
                       type="number"
@@ -245,7 +249,11 @@ export function InvoiceTotals(props: Props) {
                     />
                   )}
 
-                  {Boolean(company && company?.custom_fields?.surcharge2) && (
+                  {Boolean(
+                    company &&
+                      company?.custom_fields?.surcharge2 &&
+                      variable === '$custom_surcharge2'
+                  ) && (
                     <CustomSurchargeField
                       field="surcharge2"
                       type="number"
@@ -263,7 +271,11 @@ export function InvoiceTotals(props: Props) {
                     />
                   )}
 
-                  {Boolean(company && company?.custom_fields?.surcharge3) && (
+                  {Boolean(
+                    company &&
+                      company?.custom_fields?.surcharge3 &&
+                      variable === '$custom_surcharge3'
+                  ) && (
                     <CustomSurchargeField
                       field="surcharge3"
                       type="number"
@@ -281,7 +293,11 @@ export function InvoiceTotals(props: Props) {
                     />
                   )}
 
-                  {Boolean(company && company?.custom_fields?.surcharge4) && (
+                  {Boolean(
+                    company &&
+                      company?.custom_fields?.surcharge4 &&
+                      variable === '$custom_surcharge4'
+                  ) && (
                     <CustomSurchargeField
                       field="surcharge4"
                       type="number"

--- a/src/pages/invoices/common/hooks/useTotalVariables.ts
+++ b/src/pages/invoices/common/hooks/useTotalVariables.ts
@@ -18,7 +18,11 @@ export function useTotalVariables() {
 
   useEffect(() => {
     if (company?.settings.pdf_variables.total_columns.length > 0) {
-      const columns = cloneDeep(company?.settings.pdf_variables.total_columns);
+      let columns = cloneDeep(company?.settings.pdf_variables.total_columns);
+
+      columns = columns.filter(
+        (variable) => !variable.includes('$custom_surcharge')
+      );
 
       if (company?.enabled_tax_rates > 0) {
         columns.push('$tax1');
@@ -30,6 +34,22 @@ export function useTotalVariables() {
         columns.push('$tax3');
       }
 
+      if (company?.custom_fields?.surcharge1) {
+        columns.push('$custom_surcharge1');
+      }
+
+      if (company?.custom_fields?.surcharge2) {
+        columns.push('$custom_surcharge2');
+      }
+
+      if (company?.custom_fields?.surcharge3) {
+        columns.push('$custom_surcharge3');
+      }
+
+      if (company?.custom_fields?.surcharge4) {
+        columns.push('$custom_surcharge4');
+      }
+
       // Replace $line_taxes and $total_taxes with $taxes at their positions
       columns.forEach((column, index) => {
         if (column === '$line_taxes' || column === '$total_taxes') {
@@ -38,8 +58,9 @@ export function useTotalVariables() {
       });
 
       // Remove duplicates of $taxes that might have been created
-      const uniqueColumns = columns.filter((column, index, arr) =>
-        column !== '$taxes' || arr.indexOf(column) === index
+      const uniqueColumns = columns.filter(
+        (column, index, arr) =>
+          column !== '$taxes' || arr.indexOf(column) === index
       );
 
       setColumns(uniqueColumns);
@@ -48,7 +69,7 @@ export function useTotalVariables() {
 
     // We need to clone the product columns to local object,
     // because by default it's frozen.
-    let variables: string[] = ['$subtotal'];
+    const variables: string[] = ['$subtotal'];
     variables.push('$total');
 
     // clone(company?.settings.pdf_variables.total_columns) || [];
@@ -63,28 +84,20 @@ export function useTotalVariables() {
     //   variables = variables.filter((variable) => variable !== '$line_taxes');
     // }
 
-    if (!company?.custom_fields?.surcharge1) {
-      variables = variables.filter(
-        (variable) => variable !== '$custom_surcharge1'
-      );
+    if (company?.custom_fields?.surcharge1) {
+      variables.push('$custom_surcharge1');
     }
 
-    if (!company?.custom_fields?.surcharge2) {
-      variables = variables.filter(
-        (variable) => variable !== '$custom_surcharge2'
-      );
+    if (company?.custom_fields?.surcharge2) {
+      variables.push('$custom_surcharge2');
     }
 
-    if (!company?.custom_fields?.surcharge3) {
-      variables = variables.filter(
-        (variable) => variable !== '$custom_surcharge3'
-      );
+    if (company?.custom_fields?.surcharge3) {
+      variables.push('$custom_surcharge3');
     }
 
-    if (!company?.custom_fields?.surcharge4) {
-      variables = variables.filter(
-        (variable) => variable !== '$custom_surcharge4'
-      );
+    if (company?.custom_fields?.surcharge4) {
+      variables.push('$custom_surcharge4');
     }
 
     variables.push('$discount');


### PR DESCRIPTION
@beganovich @turbo124 The PR includes cleanup logic for custom surcharge fields on invoice pages. So, instead of expecting to display them once labels are entered and they are included in totals, we will only expect labels to be entered to align the logic with the rest of the custom fields. Let me know your thoughts.