### PR TITLE
[Cleanup] Discount Selectors

### DIFF
--- a/src/components/forms/SelectField.tsx
+++ b/src/components/forms/SelectField.tsx
@@ -36,6 +36,9 @@ export interface SelectProps extends CommonProps {
   controlStyle?: CSSProperties;
   applyCustomDropdownIndicator?: boolean;
   dropdownIndicatorClassName?: string;
+  withoutDropdownIndicatorPadding?: boolean;
+  withoutControlPadding?: boolean;
+  controlClassName?: string;
 }
 
 export function SelectField(props: SelectProps) {
@@ -58,6 +61,9 @@ export function SelectField(props: SelectProps) {
     controlIcon,
     controlStyle,
     dropdownIndicatorClassName,
+    withoutDropdownIndicatorPadding = false,
+    withoutControlPadding = false,
+    controlClassName,
   } = props;
 
   const blankEntry: ReactNode = (
@@ -203,9 +209,10 @@ export function SelectField(props: SelectProps) {
                   className={classNames(
                     'flex items-center rounded-md border cursor-pointer',
                     {
-                      'pl-2': controlIcon,
-                      'pl-1': !controlIcon,
-                    }
+                      'pl-2': controlIcon && !withoutControlPadding,
+                      'pl-1': !controlIcon && !withoutControlPadding,
+                    },
+                    controlClassName
                   )}
                   style={{
                     height: '2.5rem',
@@ -224,7 +231,8 @@ export function SelectField(props: SelectProps) {
             DropdownIndicator: () => (
               <div
                 className={classNames(
-                  'flex items-center justify-center px-3 hover:opacity-75 h-full w-full',
+                  'flex items-center justify-center hover:opacity-75 h-full w-full',
+                  { 'px-3': !withoutDropdownIndicatorPadding },
                   dropdownIndicatorClassName
                 )}
                 style={{ color: colors.$3 }}

--- a/src/pages/credits/common/components/CreditDetails.tsx
+++ b/src/pages/credits/common/components/CreditDetails.tsx
@@ -130,6 +130,7 @@ export function CreditDetails(props: Props) {
           <div className="flex space-x-2">
             <div className="w-full lg:w-1/2">
               <SelectField
+                dropdownIndicatorClassName="pr-3"
                 onValueChange={(value) =>
                   handleChange('is_amount_discount', JSON.parse(value))
                 }
@@ -137,6 +138,9 @@ export function CreditDetails(props: Props) {
                 errorMessage={errors?.errors.is_amount_discount}
                 customSelector
                 dismissable={false}
+                searchable={false}
+                withoutControlPadding
+                withoutDropdownIndicatorPadding
               >
                 <option value="false">{t('percent')}</option>
                 <option value="true">{t('amount')}</option>

--- a/src/pages/invoices/common/components/InvoiceDetails.tsx
+++ b/src/pages/invoices/common/components/InvoiceDetails.tsx
@@ -128,7 +128,7 @@ export function InvoiceDetails(props: Props) {
           <div className="flex space-x-2">
             <div className="w-full lg:w-1/2">
               <SelectField
-                className="shadow-sm"
+                dropdownIndicatorClassName="pr-3"
                 onValueChange={(value) =>
                   handleChange('is_amount_discount', JSON.parse(value))
                 }
@@ -136,6 +136,9 @@ export function InvoiceDetails(props: Props) {
                 errorMessage={props.errors?.errors.is_amount_discount}
                 customSelector
                 dismissable={false}
+                searchable={false}
+                withoutDropdownIndicatorPadding
+                withoutControlPadding
               >
                 <option value="false">{t('percent')}</option>
                 <option value="true">{t('amount')}</option>

--- a/src/pages/purchase-orders/edit/components/Details.tsx
+++ b/src/pages/purchase-orders/edit/components/Details.tsx
@@ -124,6 +124,7 @@ export function Details(props: PurchaseOrderCardProps) {
           <Inline>
             <div className="w-full lg:w-1/2">
               <SelectField
+                dropdownIndicatorClassName="pr-3"
                 value={purchaseOrder.is_amount_discount.toString()}
                 onValueChange={(value) =>
                   handleChange('is_amount_discount', JSON.parse(value))
@@ -131,6 +132,9 @@ export function Details(props: PurchaseOrderCardProps) {
                 errorMessage={errors?.errors.is_amount_discount}
                 customSelector
                 dismissable={false}
+                searchable={false}
+                withoutControlPadding
+                withoutDropdownIndicatorPadding
               >
                 <option value="false">{t('percent')}</option>
                 <option value="true">{t('amount')}</option>

--- a/src/pages/quotes/common/components/QuoteDetails.tsx
+++ b/src/pages/quotes/common/components/QuoteDetails.tsx
@@ -130,6 +130,7 @@ export function QuoteDetails(props: Props) {
           <div className="flex space-x-2">
             <div className="w-full lg:w-1/2">
               <SelectField
+                dropdownIndicatorClassName="pr-3"
                 value={quote?.is_amount_discount.toString()}
                 onValueChange={(value) =>
                   handleChange('is_amount_discount', JSON.parse(value))
@@ -137,6 +138,9 @@ export function QuoteDetails(props: Props) {
                 errorMessage={errors?.errors.is_amount_discount}
                 customSelector
                 dismissable={false}
+                searchable={false}
+                withoutControlPadding
+                withoutDropdownIndicatorPadding
               >
                 <option value="false">{t('percent')}</option>
                 <option value="true">{t('amount')}</option>

--- a/src/pages/recurring-invoices/common/components/InvoiceDetails.tsx
+++ b/src/pages/recurring-invoices/common/components/InvoiceDetails.tsx
@@ -156,6 +156,7 @@ export function InvoiceDetails(props: Props) {
           <div className="flex space-x-2">
             <div className="w-full lg:w-1/2">
               <SelectField
+                dropdownIndicatorClassName="pr-3"
                 onValueChange={(value) =>
                   handleChange('is_amount_discount', JSON.parse(value))
                 }
@@ -163,6 +164,9 @@ export function InvoiceDetails(props: Props) {
                 errorMessage={props.errors?.errors.is_amount_discount}
                 customSelector
                 dismissable={false}
+                searchable={false}
+                withoutControlPadding
+                withoutDropdownIndicatorPadding
               >
                 <option value="false">{t('percent')}</option>
                 <option value="true">{t('amount')}</option>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes a UI improvement for "Discount" selectors to make more text visible. Screenshot:

<img width="423" height="436" alt="Screenshot 2025-11-18 at 19 55 14" src="https://github.com/user-attachments/assets/1d4acf27-4837-4862-ab3f-615cd04f7c0f" />

Let me know your thoughts.