### PR TITLE
[Cleanup] "Paused" Recurring Invoices Helper

### DIFF
--- a/src/pages/recurring-invoices/common/hooks.tsx
+++ b/src/pages/recurring-invoices/common/hooks.tsx
@@ -50,6 +50,7 @@ import {
   MdControlPointDuplicate,
   MdDelete,
   MdEdit,
+  MdInfo,
   MdNotStarted,
   MdPictureAsPdf,
   MdRestore,
@@ -697,7 +698,20 @@ export function useRecurringInvoiceColumns() {
       id: 'status_id',
       label: t('status'),
       format: (value, recurringInvoice) => (
-        <RecurringInvoiceStatusBadge entity={recurringInvoice} />
+        <div className="flex items-center space-x-1">
+          <RecurringInvoiceStatusBadge entity={recurringInvoice} />
+
+          {recurringInvoice.status_id === RecurringInvoiceStatus.PAUSED && (
+            <Tooltip
+              placement="top"
+              message={t('paused_recurring_invoice_helper') as string}
+              withoutArrow
+              width="auto"
+            >
+              <Icon element={MdInfo} size={20} />
+            </Tooltip>
+          )}
+        </div>
       ),
     },
     {

--- a/src/pages/recurring-invoices/edit/Edit.tsx
+++ b/src/pages/recurring-invoices/edit/Edit.tsx
@@ -30,6 +30,10 @@ import { useTaskColumns } from '$app/pages/invoices/common/hooks/useTaskColumns'
 import { useColorScheme } from '$app/common/colors';
 import { RecurringInvoiceContext } from '../create/Create';
 import { TasksTabLabel } from '$app/pages/invoices/common/components/TasksTabLabel';
+import { RecurringInvoiceStatus } from '$app/common/enums/recurring-invoice-status';
+import { Tooltip } from '$app/components/Tooltip';
+import { Icon } from '$app/components/icons/Icon';
+import { MdInfo } from 'react-icons/md';
 
 export default function Edit() {
   const [t] = useTranslation();
@@ -73,8 +77,20 @@ export default function Edit() {
                   {t('status')}
                 </span>
 
-                <div>
+                <div className="flex items-center space-x-1">
                   <RecurringInvoiceStatusBadge entity={recurringInvoice} />
+
+                  {recurringInvoice.status_id ===
+                    RecurringInvoiceStatus.PAUSED && (
+                    <Tooltip
+                      placement="top"
+                      message={t('paused_recurring_invoice_helper') as string}
+                      withoutArrow
+                      width="auto"
+                    >
+                      <Icon element={MdInfo} size={20} />
+                    </Tooltip>
+                  )}
                 </div>
               </div>
             )}


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adding an "Info" icon with a tooltip for "Paused" recurring invoices. Screenshots:

<img width="1034" height="210" alt="Screenshot 2025-11-19 at 20 43 28" src="https://github.com/user-attachments/assets/fac7ae77-6541-4c76-aa3e-9db372a78083" />

<img width="654" height="420" alt="Screenshot 2025-11-19 at 20 43 41" src="https://github.com/user-attachments/assets/5fde50be-607a-4e1a-a8b6-65da5250b92a" />

Let me know your thoughts.