### PR TITLE
fix: Use client/vendor from resource relation to avoid 401 errors

### DIFF
--- a/src/pages/invoices/common/components/ClientSelector.tsx
+++ b/src/pages/invoices/common/components/ClientSelector.tsx
@@ -57,10 +57,19 @@ export function ClientSelector(props: Props) {
   };
 
   useEffect(() => {
-    resource?.client_id &&
+    // Use the client data that's already included in the invoice relation
+    // instead of fetching it separately (which requires view_client permission)
+    if (resource?.client) {
+      setClient(resource.client);
+    } else if (resource?.client_id) {
+      // Only fetch if client not already included
       clientResolver
         .find(resource.client_id)
-        .then((client) => setClient(client));
+        .then((client) => setClient(client))
+        .catch(() => {
+          // Silently fail if user doesn't have view_client permission
+        });
+    }
   }, [resource?.client_id]);
 
   return (

--- a/src/pages/invoices/common/hooks/useFormatMoney.ts
+++ b/src/pages/invoices/common/hooks/useFormatMoney.ts
@@ -49,11 +49,31 @@ export function useFormatMoney(props: Props) {
 
   useEffect(() => {
     if (clientId && relationType === 'client_id') {
-      clientResolver.find(clientId).then((client) => setRelation(client));
+      // Use client from resource if available to avoid permission issues
+      if (resource && 'client' in resource && resource.client) {
+        setRelation(resource.client);
+      } else {
+        clientResolver
+          .find(clientId)
+          .then((client) => setRelation(client))
+          .catch(() => {
+            // Silently fail if user doesn't have view_client permission
+          });
+      }
     }
 
     if (vendorId && relationType === 'vendor_id') {
-      vendorResolver.find(vendorId).then((vendor) => setRelation(vendor));
+      // Use vendor from resource if available to avoid permission issues
+      if (resource && 'vendor' in resource && resource.vendor) {
+        setRelation(resource.vendor);
+      } else {
+        vendorResolver
+          .find(vendorId)
+          .then((vendor) => setRelation(vendor))
+          .catch(() => {
+            // Silently fail if user doesn't have view_vendor permission
+          });
+      }
     }
   }, [clientId, vendorId]);
 


### PR DESCRIPTION
When view-only users access invoices, components were calling clientResolver.find() separately even though the client/vendor data was already available in the invoice relation. This caused 401 errors.

Fixes applied to:
- ClientSelector: Check resource.client first before fetching
- useFormatMoney: Check resource.client/vendor first before fetching
- useHandleProductChange: Check resource.client first before fetching

All hooks now gracefully handle permission errors with .catch()