### PR TITLE
[Feature] Implementing Update Modal

### DIFF
--- a/src/components/CompanySwitcher.tsx
+++ b/src/components/CompanySwitcher.tsx
@@ -35,8 +35,6 @@ import { useCurrentUser } from '$app/common/hooks/useCurrentUser';
 import { useInjectUserChanges } from '$app/common/hooks/useInjectUserChanges';
 import { useColorScheme } from '$app/common/colors';
 import companySettings from '$app/common/constants/company-settings';
-import { CompanyUpdateModal } from './CompanyUpdateModal';
-import { Button } from './forms';
 
 const SwitcherDiv = styled.div`
   &:hover {
@@ -75,8 +73,6 @@ export function CompanySwitcher() {
   const [shouldShowAddCompany, setShouldShowAddCompany] =
     useState<boolean>(false);
   const [isCompanyCreateModalOpened, setIsCompanyCreateModalOpened] =
-    useState<boolean>(false);
-  const [isCompanyUpdateModalVisible, setIsCompanyUpdateModalVisible] =
     useState<boolean>(false);
 
   const switchCompany = (index: number) => {
@@ -142,11 +138,6 @@ export function CompanySwitcher() {
         setIsModalOpen={setIsCompanyCreateModalOpened}
       />
 
-      <CompanyUpdateModal
-        visible={isCompanyUpdateModalVisible}
-        setVisible={setIsCompanyUpdateModalVisible}
-      />
-
       <Menu
         as="div"
         className="relative inline-block text-left w-full"
@@ -200,21 +191,6 @@ export function CompanySwitcher() {
                 </div>
               </Menu.Item>
             </div>
-
-            {(isAdmin || isOwner) && (
-              <Menu.Item>
-                <div className="border-b py-2 px-2">
-                  <Button
-                    type="minimal"
-                    behavior="button"
-                    className="w-full py-1"
-                    onClick={() => setIsCompanyUpdateModalVisible(true)}
-                  >
-                    {t('update_company')}
-                  </Button>
-                </div>
-              </Menu.Item>
-            )}
 
             <div
               className="flex flex-col pb-1 pt-2 border-b"


### PR DESCRIPTION
@beganovich @turbo124 The PR includes implementation of an update company modal that will allow users to update "Details" and "Address" company details using a modal available in the company switcher popup at any point in the app. Screenshots:

<img width="220" height="486" alt="Screenshot 2025-11-30 at 19 30 33" src="https://github.com/user-attachments/assets/cd86f23f-9dfc-48a8-921b-67a07f2072ef" />

<img width="334" height="534" alt="Screenshot 2025-11-30 at 19 30 43" src="https://github.com/user-attachments/assets/2758fdb1-874a-4fda-92cc-5b98296463e7" />

Let me know your thoughts.