### PR TITLE
fix: Prevent Assigned component from bypassing preCheck permission guard

### DIFF
--- a/src/components/Assigned.tsx
+++ b/src/components/Assigned.tsx
@@ -42,9 +42,14 @@ export function Assigned({
   >();
 
   useEffect(() => {
-    if (user && entityId && !isAssigned) {
-      (async () => {
-        const entityResponse = await queryClient.fetchQuery(
+  // If preCheck is explicitly false, don't make the API call
+  if (preCheck === false) {
+    return;
+  }
+
+  if (user && entityId && !isAssigned) {
+    (async () => {
+      const entityResponse = await queryClient.fetchQuery(
           [cacheEndpoint, entityId],
           () =>
             request('GET', endpoint(apiEndpoint, { id: entityId })).then(


### PR DESCRIPTION
Fixed issue where lesser permissioned users were still attempting to access routes which would result in 401's

Root Cause:
- Components useEffect had inverted logic for preCheck
- When preCheck === false (user lacks permission), the effect would still run and make the API call
- This caused 401 errors and user logouts on quote list page

The Fix:
- Added early return when preCheck === false
- Prevents API call entirely when permission is denied
- Maintains backward compatibility for preCheck === undefined

Impact:
- Users with view_quote but not view_invoice can now access quote list
- No more unauthorized /api/v1/invoices/:id API calls
- No more unexpected 401 logouts

File: src/components/Assigned.tsx
Lines: 45-48 (added early return)

Tested:
- TypeScript compilation: ✓ No errors
- Vite build: ✓ Success
- Logic verification: ✓ Correct behavior for all preCheck values

@beganovich for merge to main please post review.