### PR TITLE
[Bugfix] Table Column Preferences Issue

### DIFF
--- a/src/components/DataTableColumnsPicker.tsx
+++ b/src/components/DataTableColumnsPicker.tsx
@@ -85,6 +85,11 @@ export function DataTableColumnsPicker(props: Props) {
   const onSave = () => {
     const user = cloneDeep(currentUser) as User;
 
+    // Fix legacy data issue where react_table_columns was incorrectly stored as an array instead of an object. If you see this in 2 years, feel free to remove it.
+    if (Array.isArray(user.company_user?.react_settings.react_table_columns)) {
+      set(user, 'company_user.react_settings.react_table_columns', {});
+    }
+
     set(
       user,
       `company_user.react_settings.react_table_columns.${table}`,


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for saving table column preferences. In the video that Dave posted in the ticket, I noticed that this property had somehow become an array for this user, which is very weird because we never handle it that way. However, I was able to recreate the issue by manually setting this property to an empty array (as it appeared for the client who experienced the issue) and implemented a fix accordingly. Everything works perfectly fine on my end now. Let me know your thoughts.