### PR TITLE
[Cleanup] Adding Include Drafts Preference Field

### DIFF
--- a/src/common/hooks/useReactSettings.ts
+++ b/src/common/hooks/useReactSettings.ts
@@ -35,6 +35,7 @@ export interface Preferences {
     default_view: 'day' | 'week' | 'month';
     range: string;
     currency: number;
+    include_drafts: boolean;
   };
   datatables: {
     clients: {
@@ -97,6 +98,7 @@ export const preferencesDefaults: Preferences = {
     default_view: 'month',
     currency: 1,
     range: 'this_month',
+    include_drafts: false,
   },
   datatables: {
     clients: {

--- a/src/pages/dashboard/components/Totals.tsx
+++ b/src/pages/dashboard/components/Totals.tsx
@@ -32,6 +32,7 @@ import { useQuery } from 'react-query';
 import dayjs from 'dayjs';
 import styled from 'styled-components';
 import { useCurrentUser } from '$app/common/hooks/useCurrentUser';
+import Toggle from '$app/components/forms/Toggle';
 
 interface TotalsRecord {
   revenue: { paid_to_date: string; code: string };
@@ -146,6 +147,8 @@ export function Totals() {
   const currency = settings?.preferences?.dashboard_charts?.currency || 1;
   const dateRange =
     settings?.preferences?.dashboard_charts?.range || 'this_month';
+  const includeDrafts =
+    settings?.preferences?.dashboard_charts?.include_drafts || false;
 
   const [dates, setDates] = useState<{ start_date: string; end_date: string }>({
     start_date: GLOBAL_DATE_RANGES[dateRange]?.start || '',
@@ -187,20 +190,31 @@ export function Totals() {
   };
 
   const totals = useQuery({
-    queryKey: ['/api/v1/charts/totals_v2', body],
+    queryKey: ['/api/v1/charts/totals_v2', body, includeDrafts],
     queryFn: () =>
-      request('POST', endpoint('/api/v1/charts/totals_v2'), body).then(
-        (response) => response.data
-      ),
+      request(
+        'POST',
+        endpoint('/api/v1/charts/totals_v2?include_drafts=:includeDrafts', {
+          includeDrafts,
+        }),
+        body
+      ).then((response) => response.data),
     staleTime: Infinity,
   });
 
   const chart = useQuery({
-    queryKey: ['/api/v1/charts/chart_summary_v2', body],
+    queryKey: ['/api/v1/charts/chart_summary_v2', body, includeDrafts],
     queryFn: () =>
-      request('POST', endpoint('/api/v1/charts/chart_summary_v2'), body).then(
-        (response) => response.data
-      ),
+      request(
+        'POST',
+        endpoint(
+          '/api/v1/charts/chart_summary_v2?include_drafts=:includeDrafts',
+          {
+            includeDrafts,
+          }
+        ),
+        body
+      ).then((response) => response.data),
     staleTime: Infinity,
   });
 
@@ -404,6 +418,14 @@ export function Totals() {
                 <option value="last_year">{t('last_year')}</option>
                 <option value={'last365_days'}>{`${t('last365_days')}`}</option>
               </SelectField>
+
+              <Toggle
+                label={t('include_drafts')}
+                checked={includeDrafts}
+                onValueChange={(value) =>
+                  update('preferences.dashboard_charts.include_drafts', value)
+                }
+              />
             </Preferences>
           </div>
         </div>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adding an additional preference, `include_drafts`, for dashboard queries (`/api/v1/charts/totals_v2` and `/api/v1/charts/chart_summary_v2`). It has been added to the preference modal. Screenshot:

<img width="327" height="356" alt="Screenshot 2025-12-11 at 13 20 13" src="https://github.com/user-attachments/assets/e1b75cf8-8554-4d3e-a9e8-697e3f0c8470" />

Let me know your thoughts.