### PR TITLE
[Bugfix] Tiptap Empty Text Value

### DIFF
--- a/src/components/TipTapEditor.tsx
+++ b/src/components/TipTapEditor.tsx
@@ -944,7 +944,7 @@ export function TipTapEditor({
   useDebounce(
     () => {
       if (typeof currentValue === 'string') {
-        onValueChange(currentValue);
+        onValueChange(editor?.getText() ? currentValue : '');
       }
     },
     500,


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes to avoid having an empty <p> tag when no text is entered, ensuring an empty string is used as the value instead. Let me know your thoughts.