### PR TITLE
[Cleanup] Number Placeholders

### DIFF
--- a/src/pages/credits/common/components/CreditDetails.tsx
+++ b/src/pages/credits/common/components/CreditDetails.tsx
@@ -111,6 +111,7 @@ export function CreditDetails(props: Props) {
         <Element leftSide={t('credit_number')}>
           <InputField
             id="number"
+            placeholder={t('auto_generate')}
             onValueChange={(value) => handleChange('number', value)}
             value={credit?.number || ''}
             errorMessage={errors?.errors.number}

--- a/src/pages/invoices/common/components/InvoiceDetails.tsx
+++ b/src/pages/invoices/common/components/InvoiceDetails.tsx
@@ -109,6 +109,7 @@ export function InvoiceDetails(props: Props) {
         <Element leftSide={t('invoice_number_short')}>
           <InputField
             id="number"
+            placeholder={t('auto_generate')}
             onValueChange={(value) => handleChange('number', value)}
             value={invoice?.number || ''}
             errorMessage={props.errors?.errors.number}

--- a/src/pages/purchase-orders/edit/components/Details.tsx
+++ b/src/pages/purchase-orders/edit/components/Details.tsx
@@ -114,6 +114,7 @@ export function Details(props: PurchaseOrderCardProps) {
       >
         <Element leftSide={t('po_number')}>
           <InputField
+            placeholder={t('auto_generate')}
             value={purchaseOrder.number}
             onValueChange={(value) => handleChange('number', value)}
             errorMessage={errors?.errors.number}

--- a/src/pages/quotes/common/components/QuoteDetails.tsx
+++ b/src/pages/quotes/common/components/QuoteDetails.tsx
@@ -111,6 +111,7 @@ export function QuoteDetails(props: Props) {
         <Element leftSide={t('quote_number_short')}>
           <InputField
             id="number"
+            placeholder={t('auto_generate')}
             onValueChange={(value) => handleChange('number', value)}
             value={quote?.number || ''}
             errorMessage={errors?.errors.number}

--- a/src/pages/recurring-invoices/common/components/InvoiceDetails.tsx
+++ b/src/pages/recurring-invoices/common/components/InvoiceDetails.tsx
@@ -137,6 +137,7 @@ export function InvoiceDetails(props: Props) {
         <Element leftSide={t('invoice_number_short')}>
           <InputField
             id="number"
+            placeholder={t('auto_generate')}
             onValueChange={(value) => handleChange('number', value)}
             value={recurringInvoice?.number || ''}
             errorMessage={props.errors?.errors.number}


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adding number placeholders for invoices, recurring invoices, credits, quotes, and purchase orders. Screenshot:

<img width="1063" height="476" alt="Screenshot 2025-12-24 at 07 50 58" src="https://github.com/user-attachments/assets/f7edb4bc-d2c7-465b-8914-12d92c39ec32" />

`Note`: We're missing the "auto_generate" translation keyword, so if you agree, please add it to the files.

Let me know your thoughts.