### PR TITLE
[Bugfix] Uploading Loader Margins

### DIFF
--- a/src/components/import/UploadCompanyImport.tsx
+++ b/src/components/import/UploadCompanyImport.tsx
@@ -757,7 +757,7 @@ export function UploadCompanyImport(props: Props) {
               style={{ width: `${uploadProgress}%` }}
             ></div>
             <div className="text-sm text-gray-500 mt-1">
-              {Math.round(uploadProgress)}% uploaded
+              {Math.round(uploadProgress)}% {t('uploaded')}
             </div>
           </div>
         </div>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes margin fixes for the loading bar. Screenshot:

<img width="836" height="539" alt="Screenshot 2025-12-29 at 19 09 03" src="https://github.com/user-attachments/assets/ad6b2116-d7ae-4467-9fa0-006a53487819" />

Let me know your thoughts.