### PR TITLE
[Bugfix] Handling 401 Error Message For PEPPOL Setup Endpoint

### DIFF
--- a/src/common/helpers/request.ts
+++ b/src/common/helpers/request.ts
@@ -41,6 +41,13 @@ client.interceptors.response.use(
     const url = error.response?.config.url;
 
     if (
+      url?.includes('einvoice/peppol/setup') &&
+      error.response?.status === 401
+    ) {
+      return Promise.reject(error);
+    }
+
+    if (
       url?.includes('einvoice') &&
       (error.response?.status === 401 ||
         error.response?.status === 403 ||

--- a/src/pages/settings/e-invoice/peppol/Onboarding.tsx
+++ b/src/pages/settings/e-invoice/peppol/Onboarding.tsx
@@ -373,6 +373,7 @@ function Form({ onContinue, businessType }: FormProps) {
   const account = useCurrentAccount();
 
   const [errors, setErrors] = useState<ValidationBag | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const form = useFormik({
     initialValues: {
@@ -417,6 +418,10 @@ function Form({ onContinue, businessType }: FormProps) {
             return;
           }
 
+          if (e.response?.status === 401 && e.response.data?.message) {
+            setErrorMessage(e.response.data.message);
+          }
+
           toast.error();
         })
         .finally(() => setSubmitting(false));
@@ -429,6 +434,8 @@ function Form({ onContinue, businessType }: FormProps) {
       <p>{t('details_update_info')}</p>
 
       <div className="my-4">
+        {errorMessage ? <ErrorMessage>{errorMessage}</ErrorMessage> : null}
+
         {errors ? (
           <ErrorMessage>
             {errors.message ?? get(errors, 'errors.0.details')}


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adding logic to handle 401 errors and display a message for the "/api/v1/einvoice/peppol/setup" endpoint. Screenshot:

<img width="564" height="604" alt="Screenshot 2026-01-02 at 19 47 13" src="https://github.com/user-attachments/assets/4b8b3842-e00d-4d21-a8b8-742a6cbb50f1" />

Let me know your thoughts.