### PR TITLE
Pass e invoice type into invoicesum to handle divergence with handlin…

### DIFF
--- a/src/common/helpers/invoices/invoice-item-sum-inclusive.ts
+++ b/src/common/helpers/invoices/invoice-item-sum-inclusive.ts
@@ -32,8 +32,13 @@ export class InvoiceItemSumInclusive {
       | Credit
       | Quote
       | PurchaseOrder
-      | RecurringInvoice
+      | RecurringInvoice,
+    protected eInvoiceType?: string
   ) {}
+
+  public get isPeppol(): boolean {
+    return this.eInvoiceType === 'PEPPOL';
+  }
 
   public async process() {
     if (!this.invoice?.line_items || this.invoice.line_items?.length === 0) {

--- a/src/common/helpers/invoices/invoice-item-sum.ts
+++ b/src/common/helpers/invoices/invoice-item-sum.ts
@@ -27,8 +27,13 @@ export class InvoiceItemSum {
 
   constructor(
     protected invoice: Invoice | RecurringInvoice | PurchaseOrder,
-    protected currency: Currency
+    protected currency: Currency,
+    protected eInvoiceType?: string
   ) {}
+
+  public get isPeppol(): boolean {
+    return this.eInvoiceType === 'PEPPOL';
+  }
 
   public async process() {
     if (!this.invoice?.line_items || this.invoice.line_items?.length === 0) {
@@ -158,8 +163,9 @@ export class InvoiceItemSum {
   protected calculateAmountLineTax(rate: number, amount: number) {
     const result = (amount * rate) / 100;
     
-
-    if(result > 0){
+    if(this.isPeppol){
+      return result;
+    }else if(result > 0){
       return Math.round((result * 1000) / 10) / 100; // for positive numbers, we need to round towards zero
     }else{
       return Math.floor((result * 1000) / 10) / 100; // for negative numbers, we need to round away from zero

--- a/src/common/helpers/invoices/invoice-sum-inclusive.ts
+++ b/src/common/helpers/invoices/invoice-sum-inclusive.ts
@@ -31,9 +31,14 @@ export class InvoiceSumInclusive {
 
   constructor(
     public invoice: Invoice | Credit | PurchaseOrder | Quote | RecurringInvoice,
-    protected currency: Currency
+    protected currency: Currency,
+    protected eInvoiceType?: string
   ) {
-    this.invoiceItems = new InvoiceItemSumInclusive(this.invoice);
+    this.invoiceItems = new InvoiceItemSumInclusive(this.invoice, this.eInvoiceType);
+  }
+
+  public get isPeppol(): boolean {
+    return this.eInvoiceType === 'PEPPOL';
   }
 
   public build() {

--- a/src/common/helpers/invoices/invoice-sum.ts
+++ b/src/common/helpers/invoices/invoice-sum.ts
@@ -37,9 +37,14 @@ export class InvoiceSum {
 
   constructor(
     public invoice: Invoice | RecurringInvoice | PurchaseOrder | Credit | Quote,
-    protected currency: Currency
+    protected currency: Currency,
+    protected eInvoiceType?: string
   ) {
-    this.invoiceItems = new InvoiceItemSum(this.invoice, this.currency);
+    this.invoiceItems = new InvoiceItemSum(this.invoice, this.currency, this.eInvoiceType);
+  }
+
+  public get isPeppol(): boolean {
+    return this.eInvoiceType === 'PEPPOL';
   }
 
   public build() {

--- a/src/pages/credits/common/hooks.tsx
+++ b/src/pages/credits/common/hooks.tsx
@@ -197,9 +197,11 @@ export function useCreditUtilities(props: CreditUtilitiesProps) {
     );
 
     if (currency && credit) {
+      const eInvoiceType = company?.settings.e_invoice_type;
+
       const invoiceSum = credit.uses_inclusive_taxes
-        ? new InvoiceSumInclusive(credit, currency).build()
-        : new InvoiceSum(credit, currency).build();
+        ? new InvoiceSumInclusive(credit, currency, eInvoiceType).build()
+        : new InvoiceSum(credit, currency, eInvoiceType).build();
 
       setInvoiceSum(invoiceSum);
     }

--- a/src/pages/invoices/create/hooks/useInvoiceUtilities.ts
+++ b/src/pages/invoices/create/hooks/useInvoiceUtilities.ts
@@ -68,9 +68,11 @@ export function useInvoiceUtilities(props: Props) {
     );
 
     if (currency && invoice) {
+      const eInvoiceType = company?.settings.e_invoice_type;
+
       const invoiceSum = invoice.uses_inclusive_taxes
-        ? new InvoiceSumInclusive(invoice, currency).build()
-        : new InvoiceSum(invoice, currency).build();
+        ? new InvoiceSumInclusive(invoice, currency, eInvoiceType).build()
+        : new InvoiceSum(invoice, currency, eInvoiceType).build();
 
       setInvoiceSum(invoiceSum);
     }

--- a/src/pages/purchase-orders/edit/hooks/usePurchaseOrderUtilities.ts
+++ b/src/pages/purchase-orders/edit/hooks/usePurchaseOrderUtilities.ts
@@ -10,6 +10,7 @@
 
 import { InvoiceSum } from '$app/common/helpers/invoices/invoice-sum';
 import { InvoiceSumInclusive } from '$app/common/helpers/invoices/invoice-sum-inclusive';
+import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { InvoiceItem } from '$app/common/interfaces/invoice-item';
 import {
   Invitation,
@@ -33,6 +34,7 @@ export function usePurchaseOrderUtilities({
   setPurchaseOrder,
   setInvoiceSum,
 }: Props) {
+  const company = useCurrentCompany();
   const resolveCurrency = useResolveCurrency();
 
   const handleChange = <T extends keyof PurchaseOrder>(
@@ -73,10 +75,11 @@ export function usePurchaseOrderUtilities({
 
   const calculateInvoiceSum = async (purchaseOrder: PurchaseOrder) => {
     const currency = await resolveCurrency(purchaseOrder.vendor_id);
+    const eInvoiceType = company?.settings.e_invoice_type;
 
     const invoiceSum = purchaseOrder.uses_inclusive_taxes
-      ? new InvoiceSumInclusive(purchaseOrder, currency!).build()
-      : new InvoiceSum(purchaseOrder, currency!).build();
+      ? new InvoiceSumInclusive(purchaseOrder, currency!, eInvoiceType).build()
+      : new InvoiceSum(purchaseOrder, currency!, eInvoiceType).build();
 
     if (setInvoiceSum) {
       setInvoiceSum(invoiceSum);

--- a/src/pages/quotes/common/hooks.tsx
+++ b/src/pages/quotes/common/hooks.tsx
@@ -200,9 +200,11 @@ export function useQuoteUtilities(props: QuoteUtilitiesProps) {
     );
 
     if (currency && quote) {
+      const eInvoiceType = company?.settings.e_invoice_type;
+
       const invoiceSum = quote.uses_inclusive_taxes
-        ? new InvoiceSumInclusive(quote, currency).build()
-        : new InvoiceSum(quote, currency).build();
+        ? new InvoiceSumInclusive(quote, currency, eInvoiceType).build()
+        : new InvoiceSum(quote, currency, eInvoiceType).build();
 
       setInvoiceSum(invoiceSum);
     }

--- a/src/pages/recurring-invoices/common/hooks.tsx
+++ b/src/pages/recurring-invoices/common/hooks.tsx
@@ -197,9 +197,11 @@ export function useRecurringInvoiceUtilities(
     );
 
     if (currency && recurringInvoice) {
+      const eInvoiceType = company?.settings.e_invoice_type;
+
       const invoiceSum = recurringInvoice.uses_inclusive_taxes
-        ? new InvoiceSumInclusive(recurringInvoice, currency).build()
-        : new InvoiceSum(recurringInvoice, currency).build();
+        ? new InvoiceSumInclusive(recurringInvoice, currency, eInvoiceType).build()
+        : new InvoiceSum(recurringInvoice, currency, eInvoiceType).build();
 
       setInvoiceSum(invoiceSum);
     }


### PR DESCRIPTION
Fixes for the way rounding is performed when e_invoice_type === PEPPOL.

PEPPOL requires summing of all taxes, rounding after all line taxes have been performed.