### PR TITLE
[Cleanup] Hiding Calculated Taxes If Verifactu Is E-Invoice Type

### DIFF
--- a/src/pages/settings/tax-settings/TaxSettings.tsx
+++ b/src/pages/settings/tax-settings/TaxSettings.tsx
@@ -37,6 +37,7 @@ import { CalculateTaxesNotificationModal } from './components/calculate-taxes/co
 import { useColorScheme } from '$app/common/colors';
 import { useHandleCurrentCompanyChangeProperty } from '../common/hooks/useHandleCurrentCompanyChange';
 import { DefaultLineItemTaxes } from './components/DefaultLineItemTaxes';
+import { useCompanyVerifactu } from '$app/common/hooks/useCompanyVerifactu';
 
 export function TaxSettings() {
   const [t] = useTranslation();
@@ -51,6 +52,7 @@ export function TaxSettings() {
 
   const colors = useColorScheme();
   const isPaidOrSelfHost = usePaidOrSelfHost();
+  const verifactuEnabled = useCompanyVerifactu();
 
   const calculateTaxesRegion = useCalculateTaxesRegion();
 
@@ -178,7 +180,8 @@ export function TaxSettings() {
             )}
 
             {isPaidOrSelfHost &&
-              calculateTaxesRegion(companyChanges?.settings?.country_id) && (
+              calculateTaxesRegion(companyChanges?.settings?.country_id) &&
+              !verifactuEnabled && (
                 <>
                   <div className="px-4 sm:px-6 pt-4 pb-2">
                     <Divider


### PR DESCRIPTION
@beganovich @turbo124 This PR adds logic to hide calculated taxes if Verifactu is the e-invoice type. Screenshot:

<img width="790" height="606" alt="Screenshot 2026-01-12 at 08 43 34" src="https://github.com/user-attachments/assets/1bd59344-818f-4c5e-a2cf-d76ccfdb68ff" />

Let me know your thoughts.