### PR TITLE
[Cleanup] Hiding Toggle For Hosted | Contact Us Modal

### DIFF
--- a/src/components/HelpSidebarIcons.tsx
+++ b/src/components/HelpSidebarIcons.tsx
@@ -146,6 +146,8 @@ export function HelpSidebarIcons(props: Props) {
         title={t('contact_us')}
         visible={isContactVisible}
         onClose={setIsContactVisible}
+        disableClosing
+        enableClosingOnXMark
       >
         <InputField
           label={t('from')}
@@ -161,18 +163,30 @@ export function HelpSidebarIcons(props: Props) {
           onChange={formik.handleChange}
         />
 
-        <Toggle
-          id="send_errors"
-          label={t('include_recent_errors')}
-          onChange={(value) => formik.setFieldValue('send_logs', value)}
-        />
+        {isSelfHosted() && (
+          <Toggle
+            id="send_errors"
+            label={t('include_recent_errors')}
+            onChange={(value) => formik.setFieldValue('send_logs', value)}
+          />
+        )}
 
-        <Button
-          onClick={() => formik.submitForm()}
-          disabled={formik.isSubmitting}
-        >
-          {t('send')}
-        </Button>
+        <div className="flex gap-x-4 justify-end">
+          <Button
+            type="secondary"
+            onClick={() => setIsContactVisible(false)}
+            disabled={formik.isSubmitting}
+          >
+            {t('cancel')}
+          </Button>
+
+          <Button
+            onClick={() => formik.submitForm()}
+            disabled={formik.isSubmitting}
+          >
+            {t('send')}
+          </Button>
+        </div>
       </Modal>
 
       <Modal

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -34,6 +34,7 @@ interface Props {
   withoutBorderLine?: boolean;
   withoutVerticalMargin?: boolean;
   withoutHorizontalPadding?: boolean;
+  enableClosingOnXMark?: boolean;
 }
 
 interface TransitionChildProps {
@@ -63,7 +64,8 @@ function TransitionChild(props: TransitionChildProps) {
 export function Modal(props: Props) {
   const [open, setOpen] = useState(false);
 
-  const { enableCloseOnClickAway, disableClosing } = props;
+  const { enableCloseOnClickAway, disableClosing, enableClosingOnXMark } =
+    props;
 
   useEffect(() => {
     setOpen(props.visible);
@@ -162,7 +164,7 @@ export function Modal(props: Props) {
                       {props.title}
                     </Dialog.Title>
 
-                    {!props.disableClosing && (
+                    {(!props.disableClosing || enableClosingOnXMark) && (
                       <div
                         className="cursor-pointer"
                         onClick={() => props.onClose(false)}
@@ -200,7 +202,8 @@ export function Modal(props: Props) {
                   className={classNames('text-sm flex flex-col space-y-4', {
                     'justify-center items-center': props.centerContent,
                     'mt-5 sm:mt-6':
-                      !props.disableClosing && !props.withoutVerticalMargin,
+                      (!props.disableClosing || enableClosingOnXMark) &&
+                      !props.withoutVerticalMargin,
                     'px-5':
                       !props.withoutPadding && !props.withoutHorizontalPadding,
                   })}


### PR DESCRIPTION
@beganovich @turbo124 The PR includes hiding the toggle for the hosted platform along with UX improvements to prevent users from accidentally closing the modal and adding a cancel button for that purpose alongside the existing X button in the modal header. Screenshot:

<img width="425" height="400" alt="Screenshot 2026-01-19 at 17 39 53" src="https://github.com/user-attachments/assets/2cfdf690-c375-4744-ad54-df63d25ca578" />

Let me know your thoughts.