### PR TITLE
[Bugfix] Enable Query Condition | Validate Entity Query

### DIFF
--- a/src/pages/credits/Credit.tsx
+++ b/src/pages/credits/Credit.tsx
@@ -46,7 +46,6 @@ import { useAtomWithPrevent } from '$app/common/hooks/useAtomWithPrevent';
 import { InputLabel } from '$app/components/forms';
 import { useCheckEInvoiceValidation } from '../settings/e-invoice/common/hooks/useCheckEInvoiceValidation';
 import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
-import { useCompanyVerifactu } from '$app/common/hooks/useCompanyVerifactu';
 
 export default function Credit() {
   const { documentTitle } = useTitle('edit_credit');
@@ -68,7 +67,6 @@ export default function Credit() {
   const { data } = useCreditQuery({ id: id! });
 
   const company = useCurrentCompany();
-  const verifactuEnabled = useCompanyVerifactu();
 
   const invoiceSum = useAtomValue(invoiceSumAtom);
   const [credit, setCredit] = useAtomWithPrevent(creditAtom);
@@ -84,9 +82,8 @@ export default function Credit() {
   const { validationResponse } = useCheckEInvoiceValidation({
     resource: credit,
     enableQuery:
-      ((company?.settings.e_invoice_type === 'PEPPOL' &&
-        company?.tax_data?.acts_as_sender) ||
-        verifactuEnabled) &&
+      company?.settings.e_invoice_type === 'PEPPOL' &&
+      company?.tax_data?.acts_as_sender &&
       triggerValidationQuery &&
       id === credit?.id,
     onFinished: () => {

--- a/src/pages/invoices/Invoice.tsx
+++ b/src/pages/invoices/Invoice.tsx
@@ -47,7 +47,6 @@ import { useCheckEInvoiceValidation } from '../settings/e-invoice/common/hooks/u
 import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { PreviousNextNavigation } from '$app/components/PreviousNextNavigation';
 import { useAtomWithPrevent } from '$app/common/hooks/useAtomWithPrevent';
-import { useCompanyVerifactu } from '$app/common/hooks/useCompanyVerifactu';
 dayjs.extend(utc);
 
 export default function Invoice() {
@@ -63,7 +62,6 @@ export default function Invoice() {
 
   const hasPermission = useHasPermission();
   const entityAssigned = useEntityAssigned();
-  const verifactuEnabled = useCompanyVerifactu();
 
   const [isFormBusy, setIsFormBusy] = useState<boolean>(false);
   const [triggerValidationQuery, setTriggerValidationQuery] =
@@ -80,9 +78,8 @@ export default function Invoice() {
   const { validationResponse } = useCheckEInvoiceValidation({
     resource: invoice,
     enableQuery:
-      ((company?.settings.e_invoice_type === 'PEPPOL' &&
-        company?.tax_data?.acts_as_sender) ||
-        verifactuEnabled) &&
+      company?.settings.e_invoice_type === 'PEPPOL' &&
+      company?.tax_data?.acts_as_sender &&
       triggerValidationQuery &&
       id === invoice?.id,
     onFinished: () => {
@@ -170,8 +167,7 @@ export default function Invoice() {
                 actions={actions}
                 onSaveClick={() => setSaveChanges(true)}
                 disableSaveButton={
-                  (invoice &&
-                    (invoice.status_id === InvoiceStatus.Cancelled)) ||
+                  (invoice && invoice.status_id === InvoiceStatus.Cancelled) ||
                   isFormBusy
                 }
                 disableSaveButtonOnly={invoice.is_locked}

--- a/src/pages/recurring-invoices/RecurringInvoice.tsx
+++ b/src/pages/recurring-invoices/RecurringInvoice.tsx
@@ -43,7 +43,6 @@ import { Banner } from '$app/components/Banner';
 import { refreshEntityDataBannerAtom } from '$app/App';
 import { useCheckEInvoiceValidation } from '../settings/e-invoice/common/hooks/useCheckEInvoiceValidation';
 import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
-import { useCompanyVerifactu } from '$app/common/hooks/useCompanyVerifactu';
 
 export default function RecurringInvoice() {
   const { documentTitle } = useTitle('edit_recurring_invoice');
@@ -53,7 +52,6 @@ export default function RecurringInvoice() {
   const actions = useActions();
 
   const company = useCurrentCompany();
-  const verifactuEnabled = useCompanyVerifactu();
 
   const { data } = useRecurringInvoiceQuery({ id: id! });
 
@@ -90,9 +88,8 @@ export default function RecurringInvoice() {
     entity: 'recurring_invoice',
     resource: recurringInvoice,
     enableQuery:
-      ((company?.settings.e_invoice_type === 'PEPPOL' &&
-        company?.tax_data?.acts_as_sender) ||
-        verifactuEnabled) &&
+      company?.settings.e_invoice_type === 'PEPPOL' &&
+      company?.tax_data?.acts_as_sender &&
       triggerValidationQuery &&
       id === recurringInvoice?.id,
     onFinished: () => {


### PR DESCRIPTION
@beganovich @turbo124 This PR includes fixes for the `enableQuery` prop for the validate entity query. The condition for triggering this query is:

```
((company?.settings.e_invoice_type === 'PEPPOL' &&
        company?.tax_data?.acts_as_sender) ||
        verifactuEnabled) &&
      triggerValidationQuery &&
      id === invoice?.id,
```

Which means that `e_invoice_type` needs to be PEPPOL and `acts_as_sender` needs to be true, OR `verificatu` needs to be enabled, along with some additional queries that are not part of the settings logic.

Let me know your thoughts.