### PR TITLE
[Bugfix] Disabling Slider Query

### DIFF
--- a/src/common/queries/payments.ts
+++ b/src/common/queries/payments.ts
@@ -43,7 +43,7 @@ export function usePaymentQuery(params: PaymentParams) {
       ).then(
         (response: GenericSingleResourceResponse<Payment>) => response.data.data
       ),
-    { enabled: params.enabled ?? true, staleTime: Infinity }
+    { enabled: params.enabled ?? Boolean(params.id), staleTime: Infinity }
   );
 }
 

--- a/src/common/queries/tasks.ts
+++ b/src/common/queries/tasks.ts
@@ -34,7 +34,7 @@ export function useTaskQuery(params: TaskParams) {
         'GET',
         endpoint('/api/v1/tasks/:id?include=status', { id: params.id })
       ).then((response) => response.data.data),
-    { staleTime: Infinity, enabled: params.enabled ?? true }
+    { staleTime: Infinity, enabled: params.enabled ?? Boolean(params.id) }
   );
 }
 

--- a/src/pages/quotes/common/queries.ts
+++ b/src/pages/quotes/common/queries.ts
@@ -47,6 +47,6 @@ export function useQuoteQuery({ id }: QuoteQueryParams) {
       ).then(
         (response: GenericSingleResourceResponse<Quote>) => response.data.data
       ),
-    { staleTime: Infinity }
+    { staleTime: Infinity, enabled: Boolean(id) }
   );
 }


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adding a prop to enable slider queries to only be triggered if the slider is opened (when we know the resource ID). Fixes have been made for Quotes, Payments, and Tasks. Let me know your thoughts.