### PR TITLE
[Bugfix] Disabling Version Query For Hosted Platform

### DIFF
--- a/src/components/HelpSidebarIcons.tsx
+++ b/src/components/HelpSidebarIcons.tsx
@@ -75,6 +75,7 @@ export function HelpSidebarIcons(props: Props) {
         .get('https://pdf.invoicing.co/api/version')
         .then((response) => response.data),
     staleTime: Infinity,
+    enabled: isSelfHosted(),
   });
 
   const { data: currentSystemInfo } = useQuery({


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adding a condition to disable the `/pdf.invoicing.co/api/version` endpoint for the `hosted` platform. I researched where we use that data and found we use it only in modals that can only be opened by icons displayed only for SELF-HOSTED users. So we do not need data from this query on the hosted platform and it is disabled right now. Let me know your thoughts.