### PR TITLE
[Bugfix] External Icon Visibility Fixes

### DIFF
--- a/src/components/forms/Link.tsx
+++ b/src/components/forms/Link.tsx
@@ -51,6 +51,10 @@ export function Link(props: Props) {
       : `https://${props.to}`;
   };
 
+  if (!props.to) {
+    return null;
+  }
+
   if (props.external) {
     return (
       <div

--- a/src/pages/clients/common/hooks/useClientColumns.tsx
+++ b/src/pages/clients/common/hooks/useClientColumns.tsx
@@ -20,11 +20,9 @@ import { useResolveLanguage } from '$app/common/hooks/useResolveLanguage';
 import { Client } from '$app/common/interfaces/client';
 import { CopyToClipboard } from '$app/components/CopyToClipboard';
 import { EntityStatus } from '$app/components/EntityStatus';
-import { Inline } from '$app/components/Inline';
 import { Tooltip } from '$app/components/Tooltip';
 import { DataTableColumnsExtended } from '$app/pages/invoices/common/hooks/useInvoiceColumns';
 import { useCallback } from 'react';
-import { ExternalLink } from 'react-feather';
 import { useTranslation } from 'react-i18next';
 import { useEntityCustomFields } from '$app/common/hooks/useEntityCustomFields';
 import { useReactSettings } from '$app/common/hooks/useReactSettings';
@@ -415,10 +413,7 @@ export function useClientColumns() {
       label: t('website'),
       format: (value) => (
         <Link to={value.toString()} external>
-          <Inline>
-            <span>{value}</span>
-            {value.toString().length > 0 && <ExternalLink size={14} />}
-          </Inline>
+          {value}
         </Link>
       ),
     },


### PR DESCRIPTION
@beganovich @turbo124 The PR includes visibility fixes for the "external" icon when the link component has an empty string value, such as when a client's website field is not filled. Screenshot:

<img width="1346" height="591" alt="Screenshot 2026-01-28 at 16 54 42" src="https://github.com/user-attachments/assets/6433917c-dd03-46af-ab68-a7bc0b01bf7d" />

Let me know your thoughts.