### PR TITLE
[Bugfix] Generating _id For Payments

### DIFF
--- a/src/pages/payments/apply/Apply.tsx
+++ b/src/pages/payments/apply/Apply.tsx
@@ -34,6 +34,7 @@ import {
   useApplyInvoiceTableColumns,
 } from '../common/hooks/useApplyInvoiceTableColumns';
 import { PaymentOnCreation } from '..';
+import { v4 } from 'uuid';
 
 export default function Apply() {
   const [t] = useTranslation();
@@ -186,7 +187,7 @@ export default function Apply() {
 
                   selectedResources.forEach((resource: Invoice) => {
                     newInvoices.push({
-                      _id: window.crypto.randomUUID(),
+                      _id: v4(),
                       amount: calcApplyAmount(resource.balance, newInvoices),
                       credit_id: '',
                       invoice_id: resource.id,

--- a/src/pages/payments/create/Create.tsx
+++ b/src/pages/payments/create/Create.tsx
@@ -43,6 +43,7 @@ import { DataTable } from '$app/components/DataTable';
 import { useApplyInvoiceTableColumns } from '../common/hooks/useApplyInvoiceTableColumns';
 import { useCreditColumns } from './hooks/useCreditColumns';
 import { TableTotalFooter } from './components/TableTotalFooter';
+import { v4 } from 'uuid';
 
 export interface PaymentOnCreation
   extends Omit<Payment, 'invoices' | 'credits'> {
@@ -153,7 +154,7 @@ export default function Create() {
                 ...current,
                 invoices: [
                   {
-                    _id: window.crypto.randomUUID(),
+                    _id: v4(),
                     invoice_id: invoice.id,
                     amount:
                       invoice.balance > 0 ? invoice.balance : invoice.amount,
@@ -172,7 +173,7 @@ export default function Create() {
               ...current,
               credits: [
                 {
-                  _id: window.crypto.randomUUID(),
+                  _id: v4(),
                   credit_id: credit.id,
                   amount: credit.balance > 0 ? credit.balance : credit.amount,
                 },
@@ -331,7 +332,7 @@ export default function Create() {
                       );
 
                       newInvoices.push({
-                        _id: window.crypto.randomUUID(),
+                        _id: v4(),
                         amount: existingInvoice
                           ? existingInvoice.amount
                           : resource.balance > 0
@@ -405,7 +406,7 @@ export default function Create() {
                       );
 
                       newCredits.push({
-                        _id: window.crypto.randomUUID(),
+                        _id: v4(),
                         amount: existingCredit
                           ? existingCredit.amount
                           : resource.balance > 0


### PR DESCRIPTION
@beganovich @turbo124 The PR reverts to the `uuid()` function after a client reported that `window.crypto.randomUUID()` does not exist in their browser.

Closes #2921 

Let me know your thoughts.