### PR TITLE
[Feature] Adding Unlinking When Expenses Are Linked To Transaction

### DIFF
--- a/src/pages/transactions/common/hooks/useActions.tsx
+++ b/src/pages/transactions/common/hooks/useActions.tsx
@@ -77,7 +77,7 @@ export function useActions() {
         </DropdownElement>
       ),
     (transaction) =>
-      transaction.payment_id && (
+      (transaction.payment_id || transaction.expense_id) && (
         <DropdownElement
           onClick={() => bulk([transaction.id], 'unlink')}
           icon={<Icon element={MdLinkOff} />}
@@ -85,10 +85,10 @@ export function useActions() {
           {t('unlink')}
         </DropdownElement>
       ),
-
     (transaction) =>
       Boolean(
         (transaction.payment_id ||
+          transaction.expense_id ||
           transaction.base_type === ApiTransactionType.Credit) &&
           isEditPage
       ) && <Divider withoutPadding />,

--- a/src/pages/transactions/common/hooks/useCustomBulkActions.tsx
+++ b/src/pages/transactions/common/hooks/useCustomBulkActions.tsx
@@ -30,7 +30,9 @@ export const useCustomBulkActions = () => {
   };
 
   const showUnlinkAction = (selectedTransactions: Transaction[]) => {
-    return selectedTransactions.every(({ payment_id }) => payment_id);
+    return selectedTransactions.every(
+      ({ payment_id, expense_id }) => payment_id || expense_id
+    );
   };
 
   const customBulkActions: CustomBulkAction<Transaction>[] = [


### PR DESCRIPTION
@beganovich @turbo124 The PR includes implementation of unlinking action functionality for expenses as well as for payments from earlier. Screenshot:

<img width="1058" height="449" alt="Screenshot 2026-02-16 at 20 29 54" src="https://github.com/user-attachments/assets/97474c33-3efb-417f-889f-74f89677075b" />

Let me know your thoughts.