### PR TITLE
[Bugfix] Cancelling Queries On Company Switch And Logging Out

### DIFF
--- a/src/components/CompanySwitcher.tsx
+++ b/src/components/CompanySwitcher.tsx
@@ -92,8 +92,8 @@ export function CompanySwitcher() {
 
     sessionStorage.setItem('COMPANY-ACTIVITY-SHOWN', 'false');
 
-    queryClient.invalidateQueries();
-    
+    //queryClient.invalidateQueries();
+
     // Clear DocuNinja data and cache when switching companies
     flushData();
 

--- a/src/pages/authentication/Logout.tsx
+++ b/src/pages/authentication/Logout.tsx
@@ -31,8 +31,8 @@ export function Logout() {
     clearLocalStorage();
     sessionStorage.clear();
 
-    queryClient.invalidateQueries();
-    queryClient.removeQueries();
+    // queryClient.invalidateQueries();
+    // queryClient.removeQueries();
 
     window.location.href = '/';
   }, []);


### PR DESCRIPTION
@beganovich @turbo124 The PR fixes multiple queries being cancelled when switching companies or logging out. The reason for this was unnecessary query invalidation and cache removal calls in both cases. Since we already perform a full redirect in both cases, which does exactly the same thing for the query client as those functions, we can simply rely on the redirect and remove those calls. Let me know your thoughts.