### PR TITLE
[Bugfix] Delete Company Reason Field

### DIFF
--- a/src/pages/settings/account-management/component/DangerZone.tsx
+++ b/src/pages/settings/account-management/component/DangerZone.tsx
@@ -8,7 +8,7 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 import { Button, InputField } from '$app/components/forms';
-import { endpoint } from '$app/common/helpers';
+import { endpoint, isHosted } from '$app/common/helpers';
 import { request } from '$app/common/helpers/request';
 import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { Modal } from '$app/components/Modal';
@@ -162,14 +162,16 @@ export function DangerZone() {
           required
         />
 
-        <InputField
-          type="text"
-          label={t('reason_for_canceling')}
-          id="feedback"
-          onChange={(event: ChangeEvent<HTMLInputElement>) =>
-            setFeedback(event.target.value)
-          }
-        />
+        {isHosted() && (
+          <InputField
+            type="text"
+            label={t('reason_for_canceling')}
+            id="feedback"
+            onChange={(event: ChangeEvent<HTMLInputElement>) =>
+              setFeedback(event.target.value)
+            }
+          />
+        )}
 
         <InputField
           type="password"


### PR DESCRIPTION
@beganovich @turbo124 The PR adds logic to remove the "reason for canceling" field from the delete company modal for self-hosted users. Screenshot:

<img width="325" height="292" alt="Screenshot 2026-02-18 at 19 49 06" src="https://github.com/user-attachments/assets/c421e39b-b8e8-456e-a2d4-f124c4eac3f0" />

Let me know 