### PR TITLE
[Bugfix] Custom Label Dropdown

### DIFF
--- a/src/pages/settings/localization/components/CustomLabels.tsx
+++ b/src/pages/settings/localization/components/CustomLabels.tsx
@@ -188,7 +188,7 @@ export function CustomLabels() {
         <Button
           behavior="button"
           type="secondary"
-          onClick={() => setTimeout(() => setIsCustomModalOpen(true), 250)}
+          onClick={() => setTimeout(() => setIsCustomModalOpen(true), 200)}
         >
           {t('add_custom')}
         </Button>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for a simultaneously opened dropdown and modal for custom labels. I was not able to recreate the issue Dave reported, but we had a similar issue earlier, so I slightly increased the delay on the button's onClick event to ensure the dropdown is closed before opening the modal. Let me know your thoughts.