### PR TITLE
[Bugfix] Quotes Expiration Badge Logic

### DIFF
--- a/src/pages/quotes/common/components/QuoteStatus.tsx
+++ b/src/pages/quotes/common/components/QuoteStatus.tsx
@@ -13,6 +13,7 @@ import { Badge } from '$app/components/Badge';
 import { useTranslation } from 'react-i18next';
 import { QuoteStatus as QuoteStatusEnum } from '$app/common/enums/quote-status';
 import { useStatusThemeColorScheme } from '$app/pages/settings/user/components/StatusColorTheme';
+import dayjs from 'dayjs';
 
 interface Props {
   entity: Quote;
@@ -21,8 +22,14 @@ interface Props {
 export function QuoteStatus(props: Props) {
   const [t] = useTranslation();
 
-  const { status_id, is_deleted, archived_at, invoice_id, invitations } =
-    props.entity;
+  const {
+    status_id,
+    is_deleted,
+    archived_at,
+    invoice_id,
+    invitations,
+    due_date,
+  } = props.entity;
 
   const statusThemeColors = useStatusThemeColorScheme();
 
@@ -36,8 +43,10 @@ export function QuoteStatus(props: Props) {
   const isUnpaid = !isApproved;
   const isViewed = checkQuoteInvitationsViewedDate();
 
+  const isExpiringToday = dayjs(due_date).isSame(dayjs(), 'day');
   const statusExpired = status_id === QuoteStatusEnum.Expired;
   const statusRejected = status_id === QuoteStatusEnum.Rejected;
+
   if (is_deleted) return <Badge variant="red">{t('deleted')}</Badge>;
 
   if (archived_at) return <Badge variant="orange">{t('archived')}</Badge>;
@@ -50,7 +59,7 @@ export function QuoteStatus(props: Props) {
     );
   }
 
-  if (statusExpired) {
+  if (statusExpired && !isExpiringToday) {
     return (
       <Badge variant="red" style={{ backgroundColor: statusThemeColors.$5 }}>
         {t('expired')}
@@ -74,7 +83,10 @@ export function QuoteStatus(props: Props) {
     return <Badge variant="generic">{t('draft')}</Badge>;
   }
 
-  if (status_id === QuoteStatusEnum.Sent) {
+  if (
+    status_id === QuoteStatusEnum.Sent ||
+    (statusExpired && isExpiringToday)
+  ) {
     return (
       <Badge
         variant="light-blue"


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for which badge should be displayed on quotes. So, we have a case where the current day is when the quote is expiring and the status sent from the backend is `-1` (which is the expired status), but we should not display it because the quote is still valid until midnight. So, the fixed logic is like this: if the quote has a `-1` status and is expiring today, the "sent" status badge will be displayed instead, otherwise, the "expired" status badge will be displayed in the case of a `status_id='-1'`. Screenshot:

<img width="723" height="373" alt="Screenshot 2026-02-25 at 16 49 34" src="https://github.com/user-attachments/assets/7b0c0680-2e24-43bc-adfb-181ec7c5a623" />

Closes #2997 

Let me know your thoughts.