### PR TITLE
[Bugfix] Tasks Tab Hours Rounding

### DIFF
--- a/src/pages/invoices/common/components/TasksTabLabel.tsx
+++ b/src/pages/invoices/common/components/TasksTabLabel.tsx
@@ -37,7 +37,7 @@ export function TasksTabLabel({ lineItems }: Props) {
       <div className="flex space-x-2">
         <span>{t('tasks')}</span>
 
-        <span className="font-medium">({Math.floor(totalQuantity)} h)</span>
+        <span className="font-medium">({Math.round(totalQuantity)} h)</span>
       </div>
     );
   }


### PR DESCRIPTION
@beganovich @turbo124 The PR includes a fix for rounding hours in the Tasks tab. Instead of displaying decimal values, hours will be rounded down to the nearest whole number (e.g., 2.6712 → 2h). Screenshot:

<img width="1384" height="455" alt="Screenshot 2026-02-26 at 01 07 53" src="https://github.com/user-attachments/assets/d05c04a8-296d-4a4e-ba99-d7a5899e8958" />

Let me know your thoughts.