### PR TITLE
[Cleanup] Implementing Paid To Date Warning Banner For Invoices

### DIFF
--- a/src/pages/invoices/Invoice.tsx
+++ b/src/pages/invoices/Invoice.tsx
@@ -143,6 +143,14 @@ export default function Invoice() {
     }
   }, [saveChanges]);
 
+  useEffect(() => {
+    if (errors?.errors?.paid_to_date) {
+      document
+        .getElementById('paidToDateWarningBanner')
+        ?.classList.remove('hidden');
+    }
+  }, [errors]);
+
   useSocketEvent<WithSocketId<InvoiceType>>({
     on: ['App\\Events\\Invoice\\InvoiceWasPaid'],
     callback: ({ data }) => {
@@ -176,9 +184,23 @@ export default function Invoice() {
             ),
           })}
         aboveMainContainer={
-          <Banner id="invoiceUpdateBanner" className="hidden" variant="orange">
-            {t('invoice_status_changed')}
-          </Banner>
+          <>
+            <Banner
+              id="paidToDateWarningBanner"
+              className="hidden"
+              variant="orange"
+            >
+              {errors?.errors?.paid_to_date?.[0]}
+            </Banner>
+
+            <Banner
+              id="invoiceUpdateBanner"
+              className="hidden"
+              variant="orange"
+            >
+              {t('invoice_status_changed')}
+            </Banner>
+          </>
         }
         afterBreadcrumbs={<PreviousNextNavigation entity="invoice" />}
       >


### PR DESCRIPTION
@beganovich @turbo124 The PR includes implementation of a paid_to_date warning banner once a 422 error has been returned with a message for this specific property. Screenshot:

<img width="1638" height="929" alt="Screenshot 2026-03-03 at 05 21 52" src="https://github.com/user-attachments/assets/f5f30b89-1403-46f7-9a89-54999f3edf79" />

Let me know your thoughts.