### PR TITLE
[Cleanup] Reducing Tooltip Text Length On Main Nav Bar

### DIFF
--- a/src/components/layouts/common/navigation.ts
+++ b/src/components/layouts/common/navigation.ts
@@ -61,7 +61,7 @@ export function useNavigation() {
         to: '/clients/create',
         label: t('new_client'),
         visible: hasPermission('create_client'),
-        tooltipLabel: `${t('new_client')} (Ctrl + Shift + C)`,
+        tooltipLabel: 'Ctrl + Shift + C',
       },
     },
     {
@@ -77,7 +77,7 @@ export function useNavigation() {
         to: '/products/create',
         label: t('new_product'),
         visible: hasPermission('create_product'),
-        tooltipLabel: `${t('new_product')} (Ctrl + Shift + K)`,
+        tooltipLabel: 'Ctrl + Shift + K',
       },
     },
     {
@@ -94,7 +94,7 @@ export function useNavigation() {
         to: '/invoices/create',
         label: t('new_invoice'),
         visible: hasPermission('create_invoice'),
-        tooltipLabel: `${t('new_invoice')} (Ctrl + Shift + I)`,
+        tooltipLabel: 'Ctrl + Shift + I',
       },
     },
     {
@@ -111,7 +111,7 @@ export function useNavigation() {
         to: '/recurring_invoices/create',
         label: t('new_recurring_invoice'),
         visible: hasPermission('create_recurring_invoice'),
-        tooltipLabel: `${t('new_recurring_invoice')} (Ctrl + Shift + R)`,
+        tooltipLabel: 'Ctrl + Shift + R',
       },
     },
     {
@@ -127,7 +127,7 @@ export function useNavigation() {
         to: '/payments/create',
         label: t('new_payment'),
         visible: hasPermission('create_payment'),
-        tooltipLabel: `${t('new_payment')} (Ctrl + Shift + P)`,
+        tooltipLabel: 'Ctrl + Shift + P',
       },
     },
     {
@@ -144,7 +144,7 @@ export function useNavigation() {
         to: '/quotes/create',
         label: t('new_quote'),
         visible: hasPermission('create_quote'),
-        tooltipLabel: `${t('new_quote')} (Ctrl + Shift + Q)`,
+        tooltipLabel: 'Ctrl + Shift + Q',
       },
     },
     {
@@ -161,7 +161,7 @@ export function useNavigation() {
         to: '/credits/create',
         label: t('new_credit'),
         visible: hasPermission('create_credit'),
-        tooltipLabel: `${t('new_credit')} (Ctrl + Shift + D)`,
+        tooltipLabel: 'Ctrl + Shift + D',
       },
     },
     {
@@ -178,7 +178,7 @@ export function useNavigation() {
         to: '/projects/create',
         label: t('new_project'),
         visible: hasPermission('create_project'),
-        tooltipLabel: `${t('new_project')} (Ctrl + Shift + J)`,
+        tooltipLabel: 'Ctrl + Shift + J',
       },
     },
     {
@@ -195,7 +195,7 @@ export function useNavigation() {
         to: '/tasks/create',
         label: t('new_task'),
         visible: hasPermission('create_task'),
-        tooltipLabel: `${t('new_task')} (Ctrl + Shift + T)`,
+        tooltipLabel: 'Ctrl + Shift + T',
       },
     },
     {
@@ -212,7 +212,7 @@ export function useNavigation() {
         to: '/vendors/create',
         label: t('new_vendor'),
         visible: hasPermission('create_vendor'),
-        tooltipLabel: `${t('new_vendor')} (Ctrl + Shift + V)`,
+        tooltipLabel: 'Ctrl + Shift + V',
       },
     },
     {
@@ -229,7 +229,7 @@ export function useNavigation() {
         to: '/purchase_orders/create',
         label: t('new_purchase_order'),
         visible: hasPermission('create_purchase_order'),
-        tooltipLabel: `${t('new_purchase_order')} (Ctrl + Shift + O)`,
+        tooltipLabel: 'Ctrl + Shift + O',
       },
     },
     {
@@ -246,7 +246,7 @@ export function useNavigation() {
         to: '/expenses/create',
         label: t('new_expense'),
         visible: hasPermission('create_expense'),
-        tooltipLabel: `${t('new_expense')} (Ctrl + Shift + E)`,
+        tooltipLabel: 'Ctrl + Shift + E',
       },
     },
     {
@@ -263,7 +263,7 @@ export function useNavigation() {
         to: '/recurring_expenses/create',
         label: t('new_recurring_expense'),
         visible: hasPermission('create_recurring_expense'),
-        tooltipLabel: `${t('new_recurring_expense')} (Ctrl + Shift + X)`,
+        tooltipLabel: 'Ctrl + Shift + X',
       },
     },
     {
@@ -280,7 +280,7 @@ export function useNavigation() {
         to: '/transactions/create',
         label: t('new_transaction'),
         visible: hasPermission('create_bank_transaction'),
-        tooltipLabel: `${t('new_transaction')} (Ctrl + Shift + A)`,
+        tooltipLabel: 'Ctrl + Shift + A',
       },
     },
     {
@@ -298,7 +298,7 @@ export function useNavigation() {
         to: '/docuninja/create',
         label: t('new_document'),
         visible: import.meta.env.VITE_ENABLE_DOCUNINJA === 'true',
-        tooltipLabel: `${t('new_document')} (Ctrl + Shift + N)`,
+        tooltipLabel: 'Ctrl + Shift + N',
       },
       visible: import.meta.env.VITE_ENABLE_DOCUNINJA === 'true',
       subOptions: [


### PR DESCRIPTION
@beganovich @turbo124 The PR removes extraneous text from the main navbar tooltip, leaving only the shortcut command instruction. Screenshot:

<img width="436" height="327" alt="Screenshot 2026-03-03 at 22 41 41" src="https://github.com/user-attachments/assets/27d458a3-cae7-4cbd-a0ce-104949257d48" />

Let me know your thoughts.