### PR TITLE
[Bugfix] Unnecessary Opening Send Time Modal | Client Settings

### DIFF
--- a/src/pages/settings/email-settings/EmailSettings.tsx
+++ b/src/pages/settings/email-settings/EmailSettings.tsx
@@ -73,8 +73,9 @@ export function EmailSettings() {
 
   const handleOnSaveClick = () => {
     if (
+      typeof company?.settings.entity_send_time !== 'undefined' &&
       currentCompany?.settings.entity_send_time !==
-      company?.settings.entity_send_time
+        Number(company?.settings.entity_send_time)
     ) {
       setIsSendTimeModalOpen(true);
     } else {


### PR DESCRIPTION
@beganovich @turbo124 The PR fixes an unnecessary opening of the send time modal for client settings configuration. The reason the modal opened unnecessarily was due to the condition we had for comparing changes to the current company configuration:

```
if (
      currentCompany?.settings.entity_send_time !==
      company?.settings.entity_send_time
    ) {
```

So, the current changes are `undefined` because the checkbox is still not checked, but the current company has a numeric value. Once we compare them, they are different, and the modal shows. Now, this has been fixed.

Let me know your thoughts.