### PR TITLE
[Cleanup] Adding PEPPOL Sent Status Toggle

### DIFF
--- a/src/common/hooks/useReactSettings.ts
+++ b/src/common/hooks/useReactSettings.ts
@@ -49,6 +49,7 @@ export interface Preferences {
   enable_public_notifications: boolean | null;
   use_system_fonts: boolean;
   use_legacy_editor: boolean;
+  hide_peppol_sent_status: boolean;
   feedback_slider_displayed_at: number;
   feedback_given_at: number;
   price_increase_banner_dismissed_at?: number;
@@ -114,6 +115,7 @@ export const preferencesDefaults: Preferences = {
   enable_public_notifications: null,
   use_system_fonts: false,
   use_legacy_editor: false,
+  hide_peppol_sent_status: false,
   feedback_slider_displayed_at: 0,
   feedback_given_at: 0,
   price_increase_banner_dismissed_at: 0,

--- a/src/pages/invoices/common/hooks/useInvoiceColumns.tsx
+++ b/src/pages/invoices/common/hooks/useInvoiceColumns.tsx
@@ -159,6 +159,10 @@ export function useInvoiceColumns(): DataTableColumns<Invoice> {
     });
 
   const isPeppolEnabled = (currentInvoice: Invoice) => {
+    if (reactSettings?.preferences?.hide_peppol_sent_status) {
+      return false;
+    }
+    
     return (
       currentCompany.settings.e_invoice_type === 'PEPPOL' && PEPPOL_COUNTRIES.includes(currentInvoice.client?.country_id || '')
     );

--- a/src/pages/settings/user/components/Preferences.tsx
+++ b/src/pages/settings/user/components/Preferences.tsx
@@ -187,6 +187,18 @@ export function Preferences() {
         />
       </Element>
 
+      <Element leftSide={t('hide_peppol_sent_status')}>
+        <Toggle
+          checked={Boolean(reactSettings.preferences.hide_peppol_sent_status)}
+          onValueChange={(value) =>
+            handleChange(
+              'company_user.react_settings.preferences.hide_peppol_sent_status',
+              value
+            )
+          }
+        />
+      </Element>
+
       <StatusColorTheme />
 
       <PreferenceCard


### PR DESCRIPTION
@beganovich @turbo124 The PR includes implementation of logic for hiding the sent status icon on the invoices table, even if it is allowed in a specific country. By turning on this toggle, the status icon will always be hidden. Let me know your thoughts.