### PR TITLE
[Bugfix] Subdomain Error Message

### DIFF
--- a/src/pages/settings/company/edit/CompanyEdit.tsx
+++ b/src/pages/settings/company/edit/CompanyEdit.tsx
@@ -185,6 +185,7 @@ export function CompanyEdit(props: Props) {
                 label={t('subdomain')}
                 value={companyChanges?.subdomain}
                 onValueChange={(value) => handleChange('subdomain', value)}
+                errorMessage={errors?.errors?.subdomain}
                 changeOverride
               />
             )}


### PR DESCRIPTION
@beganovich @turbo124 The PR includes a fix for the missing subdomain 422 error message. Screenshot:

<img width="382" height="511" alt="Screenshot 2026-03-05 at 20 19 29" src="https://github.com/user-attachments/assets/b6839902-1fbf-4a76-8bd9-94dcc5a14e7c" />

Let me know your thoughts.