### PR TITLE
[Cleanup] Invalidating Activities After Sending E-Invoice

### DIFF
--- a/src/pages/invoices/edit/components/EInvoice.tsx
+++ b/src/pages/invoices/edit/components/EInvoice.tsx
@@ -62,6 +62,7 @@ const EINVOICE_ACTIVITY_TYPES = [145, 146, 147] as number[];
 
 export default function EInvoice() {
   const [t] = useTranslation();
+
   const queryClient = useQueryClient();
 
   const location = useLocation();
@@ -115,7 +116,9 @@ export default function EInvoice() {
         .then(() => {
           setTimeout(() => {
             queryClient.invalidateQueries(['/api/v1/invoices', invoice?.id]);
+            queryClient.invalidateQueries(['/api/v1/activities/entity']);
           }, 2000);
+
           toast.success('success');
         })
         .finally(() => setIsFormBusy(false));


### PR DESCRIPTION
@beganovich @turbo124 Dave, you mentioned on the ticket that we can only trigger activities by going to the Activities tab. However, we actually have that query on the e-invoice tab as well, but with additional conditions. The important one is this: `invoice?.status_id === InvoiceStatus.Sent && invoice?.backup?.guid`. So, I think the issue here is that when the 'Send' button has been triggered and the invoice has been sent, only the invoices queries are invalidated, not the activities. Therefore, I believe adding invalidation for the `/activities/entity` queries would resolve the issue of activities not displaying correctly after the invoice is sent. Let me know your thoughts.