### PR TITLE
[Feature] Adding "VAT Number" Field On Client Modal

### DIFF
--- a/src/pages/invoices/common/components/ClientCreate.tsx
+++ b/src/pages/invoices/common/components/ClientCreate.tsx
@@ -196,6 +196,13 @@ export function ClientCreate({
               />
 
               <InputField
+                label={t('vat_number')}
+                value={client?.vat_number || ''}
+                onValueChange={(value) => handleChange('vat_number', value)}
+                errorMessage={errors?.errors.vat_number}
+              />
+
+              <InputField
                 label={`${t('contact')} ${t('first_name')}`}
                 value={contacts[0].first_name}
                 onValueChange={(value) =>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the addition of a "VAT Number" field on the client creation modal. Screenshot:

<img width="331" height="596" alt="Screenshot 2026-03-14 at 00 43 42" src="https://github.com/user-attachments/assets/3c1076a5-ef3d-4f3a-8bca-8ac5dfe2d9f8" />

Let me know your thoughts.