### PR TITLE
[Cleanup] Reordering Quote Actions

### DIFF
--- a/src/pages/quotes/common/hooks.tsx
+++ b/src/pages/quotes/common/hooks.tsx
@@ -463,6 +463,21 @@ export function useActions(params?: Params) {
     (quote) => (
       <EntityActionElement
         {...(!dropdown && {
+          key: 'email_quote',
+        })}
+        entity="quote"
+        actionKey="email_quote"
+        isCommonActionSection={!dropdown}
+        tooltipText={t('email_quote')}
+        to={route('/quotes/:id/email', { id: quote.id })}
+        icon={MdSend}
+      >
+        {t('email_quote')}
+      </EntityActionElement>
+    ),
+    (quote) => (
+      <EntityActionElement
+        {...(!dropdown && {
           key: 'view_pdf',
         })}
         entity="quote"
@@ -564,21 +579,6 @@ export function useActions(params?: Params) {
           </EntityActionElement>
         }
       />
-    ),
-    (quote) => (
-      <EntityActionElement
-        {...(!dropdown && {
-          key: 'email_quote',
-        })}
-        entity="quote"
-        actionKey="email_quote"
-        isCommonActionSection={!dropdown}
-        tooltipText={t('email_quote')}
-        to={route('/quotes/:id/email', { id: quote.id })}
-        icon={MdSend}
-      >
-        {t('email_quote')}
-      </EntityActionElement>
     ),
     (quote) => (
       <EntityActionElement


### PR DESCRIPTION
@beganovich @turbo124 The PR includes a reordering of quote actions, putting "Email Quote" in the first place. Screenshot:

<img width="257" height="552" alt="Screenshot 2026-03-14 at 01 19 36" src="https://github.com/user-attachments/assets/a47d0693-02c2-46aa-be91-21c7fa6db2a6" />

Let me know your thoughts.