### PR TITLE
[Cleanup] Admin Toggle Behavior Changes | User Permissions

### DIFF
--- a/src/pages/settings/users/edit/components/Permissions.tsx
+++ b/src/pages/settings/users/edit/components/Permissions.tsx
@@ -52,6 +52,14 @@ export function Permissions(props: Props) {
     'recurring_expense',
   ];
 
+  const isPermissionDisabled = () => {
+    if (user?.company_user?.is_admin) {
+      return true;
+    }
+
+    return false;
+  };
+
   const handleAdministratorToggle = (value: boolean) => {
     setUser(
       (user) =>
@@ -176,6 +184,7 @@ export function Permissions(props: Props) {
             handlePermissionChange('view_dashboard', value)
           }
           cypressRef="viewDashboard"
+          disabled={isPermissionDisabled()}
         />
       </Element>
 
@@ -189,6 +198,7 @@ export function Permissions(props: Props) {
             handlePermissionChange('view_reports', value)
           }
           cypressRef="viewReports"
+          disabled={isPermissionDisabled()}
         />
       </Element>
 
@@ -201,6 +211,7 @@ export function Permissions(props: Props) {
           onValueChange={(value) =>
             handlePermissionChange('disable_emails', value)
           }
+          disabled={isPermissionDisabled()}
         />
       </Element>
 
@@ -235,6 +246,7 @@ export function Permissions(props: Props) {
                 handlePermissionChange('create_all', event.target.checked)
               }
               cypressRef="create_all"
+              disabled={isPermissionDisabled()}
             />
           </div>
           <div className="col-1">
@@ -244,6 +256,7 @@ export function Permissions(props: Props) {
                 handlePermissionChange('view_all', event.target.checked)
               }
               cypressRef="view_all"
+              disabled={isPermissionDisabled()}
             />
           </div>
           <div className="col-1">
@@ -253,6 +266,7 @@ export function Permissions(props: Props) {
                 handlePermissionChange('edit_all', event.target.checked)
               }
               cypressRef="edit_all"
+              disabled={isPermissionDisabled()}
             />
           </div>
         </div>
@@ -273,6 +287,7 @@ export function Permissions(props: Props) {
                   )
                 }
                 cypressRef={`create_${permission}`}
+                disabled={isPermissionDisabled()}
               />
             </div>
             <div className="col-1">
@@ -287,6 +302,7 @@ export function Permissions(props: Props) {
                   )
                 }
                 cypressRef={`view_${permission}`}
+                disabled={isPermissionDisabled()}
               />
             </div>
             <div className="col-1">
@@ -301,6 +317,7 @@ export function Permissions(props: Props) {
                   )
                 }
                 cypressRef={`edit_${permission}`}
+                disabled={isPermissionDisabled()}
               />
             </div>
           </div>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the removal of logic that turned on all permissions when "Admin" was enabled. Now, when "Admin" is turned on, the rest of the permissions remain available for the same action without being disabled. Screenshot:

<img width="1581" height="930" alt="Screenshot 2026-03-17 at 14 37 42" src="https://github.com/user-attachments/assets/018025c1-5881-47f9-8a76-2e90609c36c6" />

Let me know your thoughts.