### PR TITLE
Set correct payload for purchase order previews for existing purchase…

### DIFF
--- a/src/pages/purchase-orders/edit/Edit.tsx
+++ b/src/pages/purchase-orders/edit/Edit.tsx
@@ -231,7 +231,7 @@ export default function Edit() {
         <div className="my-4">
           {purchaseOrder && (
             <InvoicePreview
-              for="create"
+              for="invoice"
               resource={purchaseOrder}
               entity="purchase_order"
               relationType="vendor_id"


### PR DESCRIPTION
Previously we were sending create prop which would stub virtual invitations, this corrects this issue.