### PR TITLE
[Cleanup] Changes For Value On Copying Link Value | Quotes

### DIFF
--- a/src/pages/quotes/common/hooks.tsx
+++ b/src/pages/quotes/common/hooks.tsx
@@ -882,7 +882,9 @@ export function useQuoteColumns() {
           </DynamicLink>
 
           {quote.invitations?.[0]?.link && field && (
-            <CopyToClipboardIconOnly text={quote.invitations?.[0]?.link} />
+            <Tooltip width="auto" message={t('copy_link') as string} placement="top" withoutArrow>
+              <CopyToClipboardIconOnly text={quote.invitations?.[0]?.link} />
+            </Tooltip>
           )}
         </div>
       ),

--- a/src/pages/quotes/common/hooks.tsx
+++ b/src/pages/quotes/common/hooks.tsx
@@ -881,7 +881,9 @@ export function useQuoteColumns() {
             {field}
           </DynamicLink>
 
-          <CopyToClipboardIconOnly text={quote.number} />
+          {quote.invitations?.[0]?.link && field && (
+            <CopyToClipboardIconOnly text={quote.invitations?.[0]?.link} />
+          )}
         </div>
       ),
     },


### PR DESCRIPTION
@beganovich @turbo124 The PR includes changes for copying the value of the icon in the "number" column for quotes to the portal URL. Example: https://staging.invoicing.co/client/quote/qwMcybxtNbq2qIGUiySdGHsfmZoCZDWF. Let me know your thoughts.