### PR TITLE
[Bugfix] Expense Category Creation By Clicking 'Enter'

### DIFF
--- a/src/pages/settings/expense-categories/components/CreateExpenseCategoryForm.tsx
+++ b/src/pages/settings/expense-categories/components/CreateExpenseCategoryForm.tsx
@@ -63,6 +63,7 @@ export function CreateExpenseCategoryForm(props: Props) {
           onValueChange={(value) => handleChange('name', value)}
           errorMessage={errors?.errors.name}
           cypressRef="expenseCategoryNameField"
+          changeOverride
         />
 
         <div>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes changes for overriding the `onBlur` event, which we mostly use throughout the app, and in this case, leaving the `onChange` function to manage changes. Let me know your thoughts.