### PR TITLE
[Bugfix] Expense Category Sorting And Translation Fixes

### DIFF
--- a/src/pages/settings/expense-categories/ExpenseCategories.tsx
+++ b/src/pages/settings/expense-categories/ExpenseCategories.tsx
@@ -12,12 +12,15 @@ import { Link } from '$app/components/forms';
 import { ExpenseCategory } from '$app/common/interfaces/expense-category';
 import { DataTable, DataTableColumns } from '$app/components/DataTable';
 import { route } from '$app/common/helpers/route';
+import { useTranslation } from 'react-i18next';
 
 export function ExpenseCategories() {
+  const [t] = useTranslation();
+
   const columns: DataTableColumns<ExpenseCategory> = [
     {
-      id: 'category',
-      label: 'name',
+      id: 'name',
+      label: t('name'),
       format: (value, expenseCategory) => (
         <Link
           to={route('/settings/expense_categories/:id/edit', {
@@ -30,7 +33,7 @@ export function ExpenseCategories() {
     },
     {
       id: 'color',
-      label: 'color',
+      label: t('color'),
       format: (value) => (
         <div
           style={{ backgroundColor: value as string }}


### PR DESCRIPTION
@beganovich @turbo124 The PR includes expense category translation fixes for columns and a fix for sorting the 'name' column.

Closes #3079 

Let me know your thoughts.