### PR TITLE
[Bugfix] Reseting Status Selector Value | Reports

### DIFF
--- a/src/pages/reports/index/Reports.tsx
+++ b/src/pages/reports/index/Reports.tsx
@@ -580,6 +580,7 @@ export default function Reports() {
           {showReportField('status') && (
             <Element leftSide={t('status')} className={'mb-50 py-50'}>
               <StatusSelector
+                key={`${report.identifier}-status-selector`}
                 report={report.identifier}
                 onValueChange={(statuses) =>
                   handlePayloadChange('status', statuses)


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for resetting the status selector value on reports when the report has been changed. Let me know your thoughts.