### PR TITLE
[Bugfix] Decimal Places Formatting | Tax Sales

### DIFF
--- a/src/pages/invoices/edit/components/TaxDataBadge.tsx
+++ b/src/pages/invoices/edit/components/TaxDataBadge.tsx
@@ -1,4 +1,5 @@
 import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
+import { useNumericFormatter } from '$app/common/hooks/useNumericFormatter';
 import { Invoice } from '$app/common/interfaces/invoice';
 import { Quote } from '$app/common/interfaces/quote';
 import { RecurringInvoice } from '$app/common/interfaces/recurring-invoice';
@@ -12,6 +13,8 @@ interface Props {
 export function TaxDataBadge({ resource }: Props) {
   const currentCompany = useCurrentCompany();
 
+  const numericFormatter = useNumericFormatter();
+
   if (
     !resource ||
     currentCompany?.settings.country_id !== '840' ||
@@ -24,7 +27,10 @@ export function TaxDataBadge({ resource }: Props) {
     <>
       {Object.entries(resource.client?.tax_info || {}).length ? (
         <Badge variant="yellow">
-          {(resource.client?.tax_info?.taxSales || 0) * 100} %
+          {numericFormatter(
+            String((resource.client?.tax_info?.taxSales || 0) * 100)
+          )}{' '}
+          %
         </Badge>
       ) : (
         <TaxDataModal


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the addition of numeric formatting for decimal places on the tax sales badge. Screenshot:

<img width="699" height="390" alt="Screenshot 2026-04-07 at 21 44 01" src="https://github.com/user-attachments/assets/28a53efe-5092-4e8f-8e00-03cf34ca3573" />

`Note`: From the number 4.299999999, we got 4.29.

Let me know your thoughts.