### PR TITLE
[Cleanup] Refetching Invoices Query While Listening to InvoiceWasPaid

### DIFF
--- a/src/common/hooks/useGetSetting.ts
+++ b/src/common/hooks/useGetSetting.ts
@@ -27,10 +27,6 @@ export function useGetSetting({
   return (client: Client | undefined, propertyKey: keyof Settings) => {
     if (groupSettings && client) {
       if (client.settings[propertyKey] !== undefined) {
-        if (import.meta.env.VITE_IS_TEST === 'true') {
-          return `Client: ${client.settings[propertyKey]}`;
-        }
-
         return client.settings[propertyKey];
       }
 
@@ -38,10 +34,6 @@ export function useGetSetting({
         client.group_settings &&
         client.group_settings.settings[propertyKey] !== undefined
       ) {
-        if (import.meta.env.VITE_IS_TEST === 'true') {
-          return `Group: ${client.group_settings.settings[propertyKey]}`;
-        }
-
         return client.group_settings.settings[propertyKey];
       }
 
@@ -54,16 +46,8 @@ export function useGetSetting({
           currentGroupSettings &&
           currentGroupSettings.settings[propertyKey] !== undefined
         ) {
-          if (import.meta.env.VITE_IS_TEST === 'true') {
-            return `Group: ${currentGroupSettings.settings[propertyKey]}`;
-          }
-
           return currentGroupSettings.settings[propertyKey];
         }
-      }
-
-      if (import.meta.env.VITE_IS_TEST === 'true') {
-        return `Company: ${company.settings[propertyKey]}`;
       }
 
       if (withoutCompanySettingsFallback) {

--- a/src/common/queries/invoices.ts
+++ b/src/common/queries/invoices.ts
@@ -38,7 +38,7 @@ export function useInvoiceQuery(params: InvoiceQueryParams) {
   const isLockedParam = includeIsLocked ? '&is_locked=true' : '';
 
   return useQuery<Invoice>(
-    ['/api/v1/invoices', params.id],
+    ['/api/v1/invoices', 'detail', params.id],
     () =>
       request(
         'GET',

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -12,7 +12,7 @@ import classNames from 'classnames';
 import { CSSProperties, ReactNode } from 'react';
 
 interface Props {
-  variant: 'orange' | 'red';
+  variant: 'orange' | 'red' | 'blue';
   children: ReactNode;
   className?: string;
   id?: string;
@@ -28,6 +28,7 @@ export function Banner({ variant, children, className, id, style }: Props) {
         {
           'bg-orange-300': variant === 'orange',
           'bg-red-300': variant === 'red',
+          'bg-blue-300': variant === 'blue',
         },
         className
       )}

--- a/src/components/Notifications.tsx
+++ b/src/components/Notifications.tsx
@@ -14,7 +14,12 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { atomWithStorage } from 'jotai/utils';
 import { useAtom } from 'jotai';
-import { GenericMessage, useSocketEvent } from '$app/common/queries/sockets';
+import {
+  GenericMessage,
+  socketId,
+  useSocketEvent,
+  WithSocketId,
+} from '$app/common/queries/sockets';
 import { Invoice } from '$app/common/interfaces/invoice';
 import { route } from '$app/common/helpers/route';
 import { date, isHosted, isSelfHosted, trans } from '$app/common/helpers';
@@ -38,6 +43,7 @@ import { FileEdit } from './icons/FileEdit';
 import dayjs from 'dayjs';
 import { useCompanyTimeFormat } from '$app/common/hooks/useCompanyTimeFormat';
 import { useCurrentCompanyDateFormats } from '$app/common/hooks/useCurrentCompanyDateFormats';
+import { $refetch } from '$app/common/hooks/useRefetch';
 
 type NotificationType =
   | 'invoiceWasPaid'
@@ -283,8 +289,6 @@ export function Notifications() {
       'App\\Events\\Payment\\PaymentWasUpdated',
     ],
     callback: ({ event, data }) => {
-      console.log(event, data);
-
       if (event === 'App\\Events\\Invoice\\InvoiceWasPaid') {
         const $invoice = data as Invoice;
 
@@ -307,6 +311,13 @@ export function Notifications() {
           notifications.some((n) => n.link === notification.link)
         ) {
           return;
+        }
+
+        if (
+          socketId()?.toString() !==
+          (data as WithSocketId<Invoice>)['x-socket-id']
+        ) {
+          $refetch(['invoices']);
         }
 
         setNotifications((notifications) => [...notifications, notification]);
@@ -344,6 +355,13 @@ export function Notifications() {
           notifications.some((n) => n.link === notification.link)
         ) {
           return;
+        }
+
+        if (
+          socketId()?.toString() !==
+          (data as WithSocketId<Invoice>)['x-socket-id']
+        ) {
+          $refetch(['invoices']);
         }
 
         setNotifications((notifications) => [...notifications, notification]);

--- a/src/components/Notifications.tsx
+++ b/src/components/Notifications.tsx
@@ -44,6 +44,7 @@ import dayjs from 'dayjs';
 import { useCompanyTimeFormat } from '$app/common/hooks/useCompanyTimeFormat';
 import { useCurrentCompanyDateFormats } from '$app/common/hooks/useCurrentCompanyDateFormats';
 import { $refetch } from '$app/common/hooks/useRefetch';
+import { useQueryClient } from 'react-query';
 
 type NotificationType =
   | 'invoiceWasPaid'
@@ -81,6 +82,8 @@ export const notificationsAtom = atomWithStorage<Notification[]>(
 
 export function Notifications() {
   const [t] = useTranslation();
+
+  const queryClient = useQueryClient();
 
   const replaceVariables = useReplaceVariables();
 
@@ -317,7 +320,7 @@ export function Notifications() {
           socketId()?.toString() !==
           (data as WithSocketId<Invoice>)['x-socket-id']
         ) {
-          $refetch(['invoices']);
+          queryClient.invalidateQueries(['/api/v1/invoices', $invoice.id]);
         }
 
         setNotifications((notifications) => [...notifications, notification]);

--- a/src/components/Notifications.tsx
+++ b/src/components/Notifications.tsx
@@ -320,7 +320,21 @@ export function Notifications() {
           socketId()?.toString() !==
           (data as WithSocketId<Invoice>)['x-socket-id']
         ) {
-          queryClient.invalidateQueries(['/api/v1/invoices', $invoice.id]);
+          queryClient.invalidateQueries([
+            '/api/v1/invoices',
+            'detail',
+            $invoice.id,
+          ]);
+
+          queryClient.invalidateQueries({
+            predicate: (query) => {
+              const key = query.queryKey as string[];
+
+              return (
+                key.includes('/api/v1/invoices') && !key.includes('detail')
+              );
+            },
+          });
         }
 
         setNotifications((notifications) => [...notifications, notification]);

--- a/src/pages/clients/show/Client.tsx
+++ b/src/pages/clients/show/Client.tsx
@@ -146,11 +146,6 @@ export default function Client() {
   } = useChangeTemplate();
 
   useSocketEvent({
-    on: 'App\\Events\\Invoice\\InvoiceWasPaid',
-    callback: () => $refetch(['invoices']),
-  });
-
-  useSocketEvent({
     on: 'App\\Events\\Payment\\PaymentWasUpdated',
     callback: () => $refetch(['payments']),
   });

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -21,8 +21,6 @@ import { UpcomingQuotes } from './components/UpcomingQuotes';
 import { useEnabled } from '$app/common/guards/guards/enabled';
 import { ModuleBitmask } from '../settings';
 import { UpcomingRecurringInvoices } from './components/UpcomingRecurringInvoices';
-import { useSocketEvent } from '$app/common/queries/sockets';
-import { $refetch } from '$app/common/hooks/useRefetch';
 import { useOpenFeedbackSlider } from '$app/common/hooks/useOpenFeedbackSlider';
 import { useEffect } from 'react';
 
@@ -32,11 +30,6 @@ export default function Dashboard() {
   const [t] = useTranslation();
   const enabled = useEnabled();
   const openFeedbackSlider = useOpenFeedbackSlider();
-
-  useSocketEvent({
-    on: 'App\\Events\\Invoice\\InvoiceWasPaid',
-    callback: () => $refetch(['invoices']),
-  });
 
   useEffect(() => {
     openFeedbackSlider();

--- a/src/pages/invoices/Invoice.tsx
+++ b/src/pages/invoices/Invoice.tsx
@@ -206,7 +206,7 @@ export default function Invoice() {
             </Banner>
 
             <Banner id="invoiceUpdateBanner" className="hidden" variant="blue">
-              {t('invoice_status_changed')}
+              {t('invoice_status_paid')}
             </Banner>
           </>
         }

--- a/src/pages/invoices/Invoice.tsx
+++ b/src/pages/invoices/Invoice.tsx
@@ -34,15 +34,9 @@ import { useInvoiceUtilities } from './create/hooks/useInvoiceUtilities';
 import { Spinner } from '$app/components/Spinner';
 import { AddUninvoicedItemsButton } from './common/components/AddUninvoicedItemsButton';
 import { EInvoiceComponent } from '../settings';
-import {
-  socketId,
-  useSocketEvent,
-  WithSocketId,
-} from '$app/common/queries/sockets';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import { Banner } from '$app/components/Banner';
-import { Invoice as InvoiceType } from '$app/common/interfaces/invoice';
 import { useCheckEInvoiceValidation } from '../settings/e-invoice/common/hooks/useCheckEInvoiceValidation';
 import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { PreviousNextNavigation } from '$app/components/PreviousNextNavigation';
@@ -163,17 +157,6 @@ export default function Invoice() {
     }
   }, [errors]);
 
-  useSocketEvent<WithSocketId<InvoiceType>>({
-    on: ['App\\Events\\Invoice\\InvoiceWasPaid'],
-    callback: ({ data }) => {
-      if (socketId()?.toString() !== data['x-socket-id']) {
-        document
-          .getElementById('invoiceUpdateBanner')
-          ?.classList.remove('hidden');
-      }
-    },
-  });
-
   return (
     <>
       <Default
@@ -196,23 +179,13 @@ export default function Invoice() {
             ),
           })}
         aboveMainContainer={
-          <>
-            <Banner
-              id="paidToDateWarningBanner"
-              className="hidden"
-              variant="orange"
-            >
-              {errors?.errors?.paid_to_date?.[0]}
-            </Banner>
-
-            <Banner
-              id="invoiceUpdateBanner"
-              className="hidden"
-              variant="orange"
-            >
-              {t('invoice_status_changed')}
-            </Banner>
-          </>
+          <Banner
+            id="paidToDateWarningBanner"
+            className="hidden"
+            variant="orange"
+          >
+            {errors?.errors?.paid_to_date?.[0]}
+          </Banner>
         }
         afterBreadcrumbs={<PreviousNextNavigation entity="invoice" />}
       >

--- a/src/pages/invoices/Invoice.tsx
+++ b/src/pages/invoices/Invoice.tsx
@@ -34,9 +34,15 @@ import { useInvoiceUtilities } from './create/hooks/useInvoiceUtilities';
 import { Spinner } from '$app/components/Spinner';
 import { AddUninvoicedItemsButton } from './common/components/AddUninvoicedItemsButton';
 import { EInvoiceComponent } from '../settings';
+import {
+  socketId,
+  useSocketEvent,
+  WithSocketId,
+} from '$app/common/queries/sockets';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import { Banner } from '$app/components/Banner';
+import { Invoice as InvoiceType } from '$app/common/interfaces/invoice';
 import { useCheckEInvoiceValidation } from '../settings/e-invoice/common/hooks/useCheckEInvoiceValidation';
 import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { PreviousNextNavigation } from '$app/components/PreviousNextNavigation';
@@ -157,6 +163,17 @@ export default function Invoice() {
     }
   }, [errors]);
 
+  useSocketEvent<WithSocketId<InvoiceType>>({
+    on: ['App\\Events\\Invoice\\InvoiceWasPaid'],
+    callback: ({ data }) => {
+      if (socketId()?.toString() !== data['x-socket-id']) {
+        document
+          .getElementById('invoiceUpdateBanner')
+          ?.classList.remove('hidden');
+      }
+    },
+  });
+
   return (
     <>
       <Default
@@ -179,13 +196,19 @@ export default function Invoice() {
             ),
           })}
         aboveMainContainer={
-          <Banner
-            id="paidToDateWarningBanner"
-            className="hidden"
-            variant="orange"
-          >
-            {errors?.errors?.paid_to_date?.[0]}
-          </Banner>
+          <>
+            <Banner
+              id="paidToDateWarningBanner"
+              className="hidden"
+              variant="orange"
+            >
+              {errors?.errors?.paid_to_date?.[0]}
+            </Banner>
+
+            <Banner id="invoiceUpdateBanner" variant="blue">
+              {t('invoice_status_changed')}
+            </Banner>
+          </>
         }
         afterBreadcrumbs={<PreviousNextNavigation entity="invoice" />}
       >

--- a/src/pages/invoices/Invoice.tsx
+++ b/src/pages/invoices/Invoice.tsx
@@ -205,7 +205,7 @@ export default function Invoice() {
               {errors?.errors?.paid_to_date?.[0]}
             </Banner>
 
-            <Banner id="invoiceUpdateBanner" variant="blue">
+            <Banner id="invoiceUpdateBanner" className="hidden" variant="blue">
               {t('invoice_status_changed')}
             </Banner>
           </>

--- a/src/pages/invoices/index/Invoices.tsx
+++ b/src/pages/invoices/index/Invoices.tsx
@@ -44,8 +44,6 @@ import { Invoice } from '$app/common/interfaces/invoice';
 import { useFooterColumns } from '../common/hooks/useFooterColumns';
 import { DataTableFooterColumnsPicker } from '$app/components/DataTableFooterColumnsPicker';
 import { useReactSettings } from '$app/common/hooks/useReactSettings';
-import { useSocketEvent } from '$app/common/queries/sockets';
-import { $refetch } from '$app/common/hooks/useRefetch';
 import { InputLabel } from '$app/components/forms';
 import { confirmActionModalAtom } from '$app/pages/recurring-invoices/common/components/ConfirmActionModal';
 import { DeleteInvoicesConfirmationModal } from '../common/components/DeleteInvoicesConfirmationModal';
@@ -99,14 +97,6 @@ export default function Invoices() {
     setChangeTemplateVisible,
     changeTemplateResources,
   } = useChangeTemplate();
-
-  useSocketEvent({
-    on: [
-      'App\\Events\\Invoice\\InvoiceWasPaid',
-      'App\\Events\\Invoice\\InvoiceWasViewed',
-    ],
-    callback: () => $refetch(['invoices']),
-  });
 
   return (
     <Default title={documentTitle} breadcrumbs={pages} docsLink="en/invoices">


### PR DESCRIPTION
@beganovich @turbo124 This PR includes a cleanup of the logic while listening for the `InvoiceWasPaid` event. So instead of displaying any warning banners, we refetch the query to display changes on the UI (status banner, etc.). Let me know your thoughts.