### PR TITLE
[Bugfix] Cancelled Status Badge Variant

### DIFF
--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -30,7 +30,8 @@ export type BadgeVariant =
   | 'green'
   | 'black'
   | 'purple'
-  | 'transparent';
+  | 'transparent'
+  | 'teal';
 
 interface Props extends CommonProps {
   variant?: BadgeVariant;
@@ -98,10 +99,12 @@ export function Badge(props: Props) {
             props.variant === 'orange',
           'bg-green-500 bg-opacity-15 text-green-500':
             props.variant === 'green',
-          'bg-black bg-opacity-15 text-black': props.variant === 'black',
+          'bg-[#6B7280] bg-opacity-15 text-[#6B7280]':
+            props.variant === 'black',
           'bg-purple-500 bg-opacity-15 text-purple-500':
             props.variant === 'purple',
           'bg-opacity-15': props.variant === 'primary',
+          'bg-[#0D9488] bg-opacity-15 text-[#0D9488]': props.variant === 'teal',
         },
         props.className
       )}

--- a/src/pages/invoices/common/components/InvoiceStatus.tsx
+++ b/src/pages/invoices/common/components/InvoiceStatus.tsx
@@ -48,7 +48,9 @@ export function InvoiceStatus(props: Props) {
   const isCancelledOrReversed = isCancelled || isReversed;
   const isDeleted = Boolean(props.entity.is_deleted);
 
-  const isRectificativa = verifactuEnabled && ['R1','R2'].includes(props.entity.backup?.document_type ?? '');
+  const isRectificativa =
+    verifactuEnabled &&
+    ['R1', 'R2'].includes(props.entity.backup?.document_type ?? '');
 
   const isPastDue = () => {
     const date =
@@ -148,7 +150,7 @@ export function InvoiceStatus(props: Props) {
 
   if (status_id === InvoiceStatusEnum.Cancelled) {
     return (
-      <Badge variant="black" style={props.style}>
+      <Badge variant="purple" style={props.style}>
         {t('cancelled')}
       </Badge>
     );
@@ -156,14 +158,14 @@ export function InvoiceStatus(props: Props) {
 
   if (status_id === InvoiceStatusEnum.Reversed) {
     return (
-      <Badge variant="purple" style={props.style}>
+      <Badge variant="teal" style={props.style}>
         {t('reversed')}
       </Badge>
     );
   }
 
   return (
-    <Badge variant="purple" style={props.style}>
+    <Badge variant="teal" style={props.style}>
       {t('reversed')}
     </Badge>
   );

--- a/src/pages/purchase-orders/common/components/PurchaseOrderStatus.tsx
+++ b/src/pages/purchase-orders/common/components/PurchaseOrderStatus.tsx
@@ -45,7 +45,7 @@ export function PurchaseOrderStatus(props: Props) {
 
   if (isCancelled) {
     return (
-      <Badge variant="black" style={{ backgroundColor: statusThemeColors.$5 }}>
+      <Badge variant="purple" style={{ backgroundColor: statusThemeColors.$5 }}>
         {t('cancelled')}
       </Badge>
     );


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for the dark mode cancelled status badge color, making it purple so it will be clear on both light and dark mode. Screenshots:

<img width="521" height="307" alt="Screenshot 2026-04-22 at 19 26 45" src="https://github.com/user-attachments/assets/2c98f69a-f368-4510-afa7-0d7a318e9576" />

<img width="655" height="315" alt="Screenshot 2026-04-22 at 19 26 50" src="https://github.com/user-attachments/assets/bcfc085e-6dd1-4250-9587-782b579b16f6" />

Let me know your thoughts.