### PR TITLE
[Cleanup] Implementing Actions For Show And Edit Bank Account Pages

### DIFF
--- a/src/pages/settings/bank-accounts/common/hooks/useActions.tsx
+++ b/src/pages/settings/bank-accounts/common/hooks/useActions.tsx
@@ -1,0 +1,48 @@
+import { useBulkAction } from '../queries';
+import { useTranslation } from 'react-i18next';
+import { DropdownElement } from '$app/components/dropdown/DropdownElement';
+import { BankAccount } from '$app/common/interfaces/bank-accounts';
+import { Icon } from '$app/components/icons/Icon';
+import { MdArchive, MdDelete, MdRestore } from 'react-icons/md';
+import { getEntityState } from '$app/common/helpers';
+import { EntityState } from '$app/common/enums/entity-state';
+
+export function useActions() {
+  const [t] = useTranslation();
+
+  const bulk = useBulkAction();
+
+  const actions = [
+    (bankIntegration: BankAccount) =>
+      getEntityState(bankIntegration) === EntityState.Active && (
+        <DropdownElement
+          onClick={() => bulk(bankIntegration.id, 'archive')}
+          icon={<Icon element={MdArchive} />}
+        >
+          {t('archive')}
+        </DropdownElement>
+      ),
+    (bankIntegration: BankAccount) =>
+      (getEntityState(bankIntegration) === EntityState.Archived ||
+        getEntityState(bankIntegration) === EntityState.Deleted) && (
+        <DropdownElement
+          onClick={() => bulk(bankIntegration.id, 'restore')}
+          icon={<Icon element={MdRestore} />}
+        >
+          {t('restore')}
+        </DropdownElement>
+      ),
+    (bankIntegration: BankAccount) =>
+      (getEntityState(bankIntegration) === EntityState.Active ||
+        getEntityState(bankIntegration) === EntityState.Archived) && (
+        <DropdownElement
+          onClick={() => bulk(bankIntegration.id, 'delete')}
+          icon={<Icon element={MdDelete} />}
+        >
+          {t('delete')}
+        </DropdownElement>
+      ),
+  ];
+
+  return actions;
+}

--- a/src/pages/settings/bank-accounts/common/queries.ts
+++ b/src/pages/settings/bank-accounts/common/queries.ts
@@ -15,6 +15,8 @@ import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-ap
 import { BankAccount } from '$app/common/interfaces/bank-accounts';
 import { useAdmin } from '$app/common/hooks/permissions/useHasPermission';
 import { Params } from '$app/common/queries/common/params.interface';
+import { toast } from '$app/common/helpers/toast/toast';
+import { $refetch } from '$app/common/hooks/useRefetch';
 
 interface BankAccountParams {
   id: string | undefined;
@@ -72,4 +74,19 @@ export function useBlankBankAccountQuery() {
       ),
     { staleTime: Infinity, enabled: isAdmin || isOwner }
   );
+}
+
+export function useBulkAction() {
+  return (id: string, action: 'archive' | 'restore' | 'delete') => {
+    toast.processing();
+
+    request('POST', endpoint('/api/v1/bank_integrations/bulk'), {
+      action,
+      ids: [id],
+    }).then(() => {
+      toast.success(`${action}d_bank_account`);
+
+      $refetch(['bank_integrations']);
+    });
+  };
 }

--- a/src/pages/settings/bank-accounts/edit/Edit.tsx
+++ b/src/pages/settings/bank-accounts/edit/Edit.tsx
@@ -18,7 +18,7 @@ import { toast } from '$app/common/helpers/toast/toast';
 import { useTitle } from '$app/common/hooks/useTitle';
 import { BankAccount } from '$app/common/interfaces/bank-accounts';
 import { ValidationBag } from '$app/common/interfaces/validation-bag';
-import { FormEvent, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import Toggle from '$app/components/forms/Toggle';
@@ -26,12 +26,15 @@ import { useBankAccountQuery } from '$app/pages/settings/bank-accounts/common/qu
 import { Settings } from '$app/components/layouts/Settings';
 import { $refetch } from '$app/common/hooks/useRefetch';
 import { useColorScheme } from '$app/common/colors';
+import { ResourceActions } from '$app/components/ResourceActions';
+import { useActions } from '../common/hooks/useActions';
 
 export function Edit() {
   useTitle('edit_bank_account');
 
   const [t] = useTranslation();
 
+  const actions = useActions();
   const colors = useColorScheme();
 
   const navigate = useNavigate();
@@ -40,10 +43,8 @@ export function Edit() {
 
   const { data: response } = useBankAccountQuery({ id });
 
-  const [isFormBusy, setIsFormBusy] = useState<boolean>(false);
-
   const [errors, setErrors] = useState<ValidationBag>();
-
+  const [isFormBusy, setIsFormBusy] = useState<boolean>(false);
   const [accountDetails, setAccountDetails] = useState<BankAccount>();
 
   const pages = [
@@ -64,10 +65,8 @@ export function Edit() {
     );
   };
 
-  const handleSave = async (event: FormEvent<HTMLFormElement>) => {
+  const handleSave = async () => {
     if (!isFormBusy) {
-      event.preventDefault();
-
       toast.processing();
       setErrors(undefined);
       setIsFormBusy(true);
@@ -105,8 +104,16 @@ export function Edit() {
       title={t('edit_bank_account')}
       breadcrumbs={pages}
       docsLink="en/basic-settings/#edit_bank_account"
-      onSaveClick={handleSave}
-      disableSaveButton={isFormBusy}
+      navigationTopRight={
+        accountDetails && (
+          <ResourceActions
+            resource={accountDetails}
+            onSaveClick={handleSave}
+            actions={actions}
+            disableSaveButton={!accountDetails || isFormBusy}
+          />
+        )
+      }
     >
       <Card
         onFormSubmit={handleSave}

--- a/src/pages/settings/bank-accounts/show/BankAccount.tsx
+++ b/src/pages/settings/bank-accounts/show/BankAccount.tsx
@@ -13,10 +13,12 @@ import { useTitle } from '$app/common/hooks/useTitle';
 import { BankAccount as BankAccountEntity } from '$app/common/interfaces/bank-accounts';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { Settings } from '../../../../components/layouts/Settings';
 import { useBankAccountQuery } from '../common/queries';
 import { Details } from '../components/Details';
+import { ResourceActions } from '$app/components/ResourceActions';
+import { useActions } from '../common/hooks/useActions';
 
 export function BankAccount() {
   useTitle('bank_account');
@@ -24,6 +26,8 @@ export function BankAccount() {
   const { id } = useParams();
 
   const [t] = useTranslation();
+  const actions = useActions();
+  const navigate = useNavigate();
 
   const pages = [
     { name: t('settings'), href: '/settings' },
@@ -47,6 +51,19 @@ export function BankAccount() {
       title={t('bank_account')}
       breadcrumbs={pages}
       docsLink="en/basic-settings/#bank_account_details"
+      navigationTopRight={
+        accountDetails && (
+          <ResourceActions
+            resource={accountDetails}
+            saveButtonLabel={t('edit')}
+            onSaveClick={() =>
+              navigate(route('/settings/bank_accounts/:id/edit', { id }))
+            }
+            actions={actions}
+            disableSaveButton={!accountDetails}
+          />
+        )
+      }
     >
       <Details accountDetails={accountDetails} />
     </Settings>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of actions for the show and edit pages for bank accounts. Screenshots:

<img width="1000" height="485" alt="Screenshot 2026-04-22 at 19 52 47" src="https://github.com/user-attachments/assets/b27299cc-cb20-456e-a1fc-2c2dc2d4fd23" />

<img width="1037" height="408" alt="Screenshot 2026-04-22 at 19 52 54" src="https://github.com/user-attachments/assets/88b15bc8-9130-4ba6-bc89-68d686129876" />

Let me know your thoughts.