### PR TITLE
[Bugfix] Fixing Missmatching Currency On Payments Tab

### DIFF
--- a/src/pages/invoices/edit/components/Payments.tsx
+++ b/src/pages/invoices/edit/components/Payments.tsx
@@ -101,8 +101,8 @@ function Payments() {
                       <span>
                         {formatMoney(
                           paymentable.amount,
-                          payment.client?.country_id,
-                          payment.client?.settings.currency_id
+                          invoice.client?.country_id,
+                          invoice.client?.settings.currency_id
                         )}
                       </span>
 


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for mismatching currency on the Payments tab for invoices. Let me know your thoughts.