### PR TITLE
[Bugfix] Reloading Beta Screen Fixes

### DIFF
--- a/src/pages/documents/beta/Beta.tsx
+++ b/src/pages/documents/beta/Beta.tsx
@@ -22,6 +22,7 @@ import { ValidationBag } from '$app/common/interfaces/validation-bag';
 import { useAdmin } from '$app/common/hooks/permissions/useHasPermission';
 import { useEffect } from 'react';
 import { ValidationAlert } from '$app/components/ValidationAlert';
+import { routeWithOrigin } from '$app/common/helpers/route';
 
 export default function Beta() {
   const navigate = useNavigate();
@@ -153,7 +154,6 @@ function Join() {
   const [code, setCode] = useState('');
   const [errors, setErrors] = useState<ValidationBag | null>(null);
 
-  const navigate = useNavigate();
   const account = useCurrentAccount();
   const { isOwner } = useAdmin();
 
@@ -176,7 +176,7 @@ function Join() {
         );
 
         setTimeout(() => {
-          window.location.reload();
+          window.location.href = routeWithOrigin('/docuninja');
         }, 3000);
       })
       .catch((error: AxiosError<ValidationBag>) => {


### PR DESCRIPTION
@beganovich @turbo124 Initially, the user does not have a DocuNinja account, so the login route returns an error and we redirect to `/docuninja/beta?ie=true`. However, this query parameter forces the beta join screen to display regardless of whether the user has already joined. The same issue occurs when a user joins for the first time, the page reloads but retains the `?ie=true` parameter, which causes the join screen to appear again as if the enrollment was unsuccessful. The fix is simply to reload the page without this parameter. Let me know your thoughts.