### PR TITLE
[Cleanup] Stripe Integration Helper Modal

### DIFF
--- a/src/pages/settings/gateways/edit/Edit.tsx
+++ b/src/pages/settings/gateways/edit/Edit.tsx
@@ -42,7 +42,7 @@ export function Edit() {
   const { documentTitle } = useTitle('edit_gateway');
 
   const [t] = useTranslation();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const { id } = useParams();
   const actions = useActions();
@@ -118,6 +118,14 @@ export function Edit() {
   useEffect(() => {
     if (searchParams.get('show_onboarding') === 'true' && companyGateway) {
       setShowOnboardingModal(true);
+
+      setSearchParams(
+        (params) => {
+          params.delete('show_onboarding');
+          return params;
+        },
+        { replace: true }
+      );
     }
   }, [companyGateway, searchParams]);
 

--- a/src/pages/settings/gateways/edit/Edit.tsx
+++ b/src/pages/settings/gateways/edit/Edit.tsx
@@ -118,18 +118,6 @@ export function Edit() {
   useEffect(() => {
     if (searchParams.get('show_onboarding') === 'true' && companyGateway) {
       setShowOnboardingModal(true);
-
-      const newParams = new URLSearchParams(searchParams);
-      newParams.delete('show_onboarding');
-
-      const newSearch = newParams.toString();
-      window.history.replaceState(
-        {},
-        '',
-        `${window.location.pathname}${newSearch ? `?${newSearch}` : ''}${
-          window.location.hash
-        }`
-      );
     }
   }, [companyGateway, searchParams]);
 

--- a/src/pages/settings/gateways/edit/Edit.tsx
+++ b/src/pages/settings/gateways/edit/Edit.tsx
@@ -36,6 +36,7 @@ import { $help, HelpWidget } from '$app/components/HelpWidget';
 import { useColorScheme } from '$app/common/colors';
 import { useAccentColor } from '$app/common/hooks/useAccentColor';
 import { CircleQuestion } from '$app/components/icons/CircleQuestion';
+import { HelperModal } from './components/stripe/HelperModal';
 
 export function Edit() {
   const { documentTitle } = useTitle('edit_gateway');
@@ -61,6 +62,8 @@ export function Edit() {
   const [tabs, setTabs] = useState<string[]>(defaultTab);
   const [isFormBusy, setIsFormBusy] = useState<boolean>(false);
   const [companyGateway, setCompanyGateway] = useState<CompanyGateway>();
+  const [showOnboardingModal, setShowOnboardingModal] =
+    useState<boolean>(false);
 
   const additionalTabs = [
     t('credentials'),
@@ -111,6 +114,24 @@ export function Edit() {
       setTabs([...defaultTab]);
     }
   }, [gateway]);
+
+  useEffect(() => {
+    if (searchParams.get('show_onboarding') === 'true' && companyGateway) {
+      setShowOnboardingModal(true);
+
+      const newParams = new URLSearchParams(searchParams);
+      newParams.delete('show_onboarding');
+
+      const newSearch = newParams.toString();
+      window.history.replaceState(
+        {},
+        '',
+        `${window.location.pathname}${newSearch ? `?${newSearch}` : ''}${
+          window.location.hash
+        }`
+      );
+    }
+  }, [companyGateway, searchParams]);
 
   return (
     <Settings
@@ -257,6 +278,12 @@ export function Edit() {
           </div>
         </TabGroup>
       </Card>
+
+      <HelperModal
+        visible={showOnboardingModal}
+        setVisible={setShowOnboardingModal}
+        setTabIndex={setTabIndex}
+      />
     </Settings>
   );
 }

--- a/src/pages/settings/gateways/edit/components/stripe/HelperModal.tsx
+++ b/src/pages/settings/gateways/edit/components/stripe/HelperModal.tsx
@@ -47,7 +47,7 @@ export function HelperModal({ visible, setVisible, setTabIndex }: Props) {
   return (
     <Modal
       title={t('gateway_setup_complete')}
-      visible={true}
+      visible={visible}
       onClose={() => setVisible(false)}
       size="regular"
     >

--- a/src/pages/settings/gateways/edit/components/stripe/HelperModal.tsx
+++ b/src/pages/settings/gateways/edit/components/stripe/HelperModal.tsx
@@ -1,0 +1,118 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { useTranslation } from 'react-i18next';
+
+import { Modal } from '$app/components/Modal';
+import { Dispatch, SetStateAction } from 'react';
+import { useAccentColor } from '$app/common/hooks/useAccentColor';
+import { useColorScheme } from '$app/common/colors';
+import { LuCheckCircle2 } from 'react-icons/lu';
+import { CreditCard } from 'react-feather';
+import { Sliders } from 'react-feather';
+
+interface props {
+  visible: boolean;
+  setVisible: Dispatch<SetStateAction<boolean>>;
+  setTabIndex: Dispatch<SetStateAction<number>>;
+}
+
+export function HelperModal({ visible, setVisible, setTabIndex }: props) {
+  const [t] = useTranslation();
+
+  const colors = useColorScheme();
+  const accentColor = useAccentColor();
+
+  return (
+    <Modal
+      title={t('gateway_setup_complete')}
+      visible={visible}
+      onClose={() => setVisible(false)}
+      size="regular"
+    >
+      <div className="flex flex-col space-y-6 pb-2">
+        <div className="flex flex-col items-center text-center space-y-2">
+          <div
+            className="w-12 h-12 rounded-full flex items-center justify-center"
+            style={{ backgroundColor: `${accentColor}15` }}
+          >
+            <LuCheckCircle2 size={24} style={{ color: accentColor }} />
+          </div>
+
+          <p className="text-sm" style={{ color: colors.$17 }}>
+            {t('gateway_onboarding_description')}
+          </p>
+        </div>
+
+        <div className="flex flex-col space-y-3">
+          <button
+            type="button"
+            className="flex items-center space-x-3 p-3 rounded-md border text-left transition-colors hover:opacity-80"
+            style={{ borderColor: colors.$20 }}
+            onClick={() => {
+              setVisible(false);
+              setTabIndex(2);
+            }}
+          >
+            <div
+              className="w-8 h-8 rounded-md flex items-center justify-center flex-shrink-0"
+              style={{ backgroundColor: `${accentColor}15` }}
+            >
+              <CreditCard size={16} style={{ color: accentColor }} />
+            </div>
+
+            <div className="flex flex-col">
+              <span
+                className="text-sm font-medium"
+                style={{ color: colors.$3 }}
+              >
+                {t('payment_methods')}
+              </span>
+
+              <span className="text-xs" style={{ color: colors.$17 }}>
+                {t('gateway_onboarding_payment_methods_help')}
+              </span>
+            </div>
+          </button>
+
+          <button
+            type="button"
+            className="flex items-center space-x-3 p-3 rounded-md border text-left transition-colors hover:opacity-80"
+            style={{ borderColor: colors.$20 }}
+            onClick={() => {
+              setVisible(false);
+              setTabIndex(4);
+            }}
+          >
+            <div
+              className="w-8 h-8 rounded-md flex items-center justify-center flex-shrink-0"
+              style={{ backgroundColor: `${accentColor}15` }}
+            >
+              <Sliders size={16} style={{ color: accentColor }} />
+            </div>
+
+            <div className="flex flex-col">
+              <span
+                className="text-sm font-medium"
+                style={{ color: colors.$3 }}
+              >
+                {t('limits_and_fees')}
+              </span>
+
+              <span className="text-xs" style={{ color: colors.$17 }}>
+                {t('gateway_onboarding_limits_fees_help')}
+              </span>
+            </div>
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/pages/settings/gateways/edit/components/stripe/HelperModal.tsx
+++ b/src/pages/settings/gateways/edit/components/stripe/HelperModal.tsx
@@ -9,22 +9,36 @@
  */
 
 import { useTranslation } from 'react-i18next';
-
 import { Modal } from '$app/components/Modal';
 import { Dispatch, SetStateAction } from 'react';
 import { useAccentColor } from '$app/common/hooks/useAccentColor';
 import { useColorScheme } from '$app/common/colors';
 import { LuCheckCircle2 } from 'react-icons/lu';
-import { CreditCard } from 'react-feather';
-import { Sliders } from 'react-feather';
+import { CreditCard, Sliders } from 'react-feather';
+import { Icon } from '$app/components/icons/Icon';
+import { ArrowRight } from '$app/components/icons/ArrowRight';
+import styled from 'styled-components';
 
-interface props {
+interface BoxTheme {
+  backgroundColor: string;
+  hoverBackgroundColor: string;
+}
+
+const Box = styled.div<{ theme: BoxTheme }>`
+  background-color: ${({ theme }) => theme.backgroundColor};
+
+  &:hover {
+    background-color: ${({ theme }) => theme.hoverBackgroundColor};
+  }
+`;
+
+interface Props {
   visible: boolean;
   setVisible: Dispatch<SetStateAction<boolean>>;
   setTabIndex: Dispatch<SetStateAction<number>>;
 }
 
-export function HelperModal({ visible, setVisible, setTabIndex }: props) {
+export function HelperModal({ visible, setVisible, setTabIndex }: Props) {
   const [t] = useTranslation();
 
   const colors = useColorScheme();
@@ -33,7 +47,7 @@ export function HelperModal({ visible, setVisible, setTabIndex }: props) {
   return (
     <Modal
       title={t('gateway_setup_complete')}
-      visible={visible}
+      visible={true}
       onClose={() => setVisible(false)}
       size="regular"
     >
@@ -43,7 +57,7 @@ export function HelperModal({ visible, setVisible, setTabIndex }: props) {
             className="w-12 h-12 rounded-full flex items-center justify-center"
             style={{ backgroundColor: `${accentColor}15` }}
           >
-            <LuCheckCircle2 size={24} style={{ color: accentColor }} />
+            <Icon element={LuCheckCircle2} size={24} color={accentColor} />
           </div>
 
           <p className="text-sm" style={{ color: colors.$17 }}>
@@ -52,65 +66,73 @@ export function HelperModal({ visible, setVisible, setTabIndex }: props) {
         </div>
 
         <div className="flex flex-col space-y-3">
-          <button
-            type="button"
-            className="flex items-center space-x-3 p-3 rounded-md border text-left transition-colors hover:opacity-80"
-            style={{ borderColor: colors.$20 }}
+          <Box
+            className="flex justify-between items-center p-4 border shadow-sm w-full rounded-md cursor-pointer"
+            theme={{
+              backgroundColor: colors.$1,
+              hoverBackgroundColor: colors.$4,
+            }}
+            style={{ borderColor: colors.$24 }}
             onClick={() => {
               setVisible(false);
               setTabIndex(2);
             }}
           >
-            <div
-              className="w-8 h-8 rounded-md flex items-center justify-center flex-shrink-0"
-              style={{ backgroundColor: `${accentColor}15` }}
-            >
-              <CreditCard size={16} style={{ color: accentColor }} />
+            <div className="flex items-center space-x-3">
+              <CreditCard size={18} style={{ color: colors.$3 }} />
+
+              <div className="flex flex-col">
+                <span
+                  className="text-sm font-medium"
+                  style={{ color: colors.$3 }}
+                >
+                  {t('payment_methods')}
+                </span>
+
+                <span className="text-xs" style={{ color: colors.$17 }}>
+                  {t('gateway_onboarding_payment_methods_help')}
+                </span>
+              </div>
             </div>
 
-            <div className="flex flex-col">
-              <span
-                className="text-sm font-medium"
-                style={{ color: colors.$3 }}
-              >
-                {t('payment_methods')}
-              </span>
-
-              <span className="text-xs" style={{ color: colors.$17 }}>
-                {t('gateway_onboarding_payment_methods_help')}
-              </span>
+            <div>
+              <ArrowRight color={colors.$3} size="1.4rem" strokeWidth="1.5" />
             </div>
-          </button>
+          </Box>
 
-          <button
-            type="button"
-            className="flex items-center space-x-3 p-3 rounded-md border text-left transition-colors hover:opacity-80"
-            style={{ borderColor: colors.$20 }}
+          <Box
+            className="flex justify-between items-center p-4 border shadow-sm w-full rounded-md cursor-pointer"
+            theme={{
+              backgroundColor: colors.$1,
+              hoverBackgroundColor: colors.$4,
+            }}
+            style={{ borderColor: colors.$24 }}
             onClick={() => {
               setVisible(false);
               setTabIndex(4);
             }}
           >
-            <div
-              className="w-8 h-8 rounded-md flex items-center justify-center flex-shrink-0"
-              style={{ backgroundColor: `${accentColor}15` }}
-            >
-              <Sliders size={16} style={{ color: accentColor }} />
+            <div className="flex items-center space-x-3">
+              <Sliders size={18} style={{ color: colors.$3 }} />
+
+              <div className="flex flex-col">
+                <span
+                  className="text-sm font-medium"
+                  style={{ color: colors.$3 }}
+                >
+                  {t('limits_and_fees')}
+                </span>
+
+                <span className="text-xs" style={{ color: colors.$17 }}>
+                  {t('gateway_onboarding_limits_fees_help')}
+                </span>
+              </div>
             </div>
 
-            <div className="flex flex-col">
-              <span
-                className="text-sm font-medium"
-                style={{ color: colors.$3 }}
-              >
-                {t('limits_and_fees')}
-              </span>
-
-              <span className="text-xs" style={{ color: colors.$17 }}>
-                {t('gateway_onboarding_limits_fees_help')}
-              </span>
+            <div>
+              <ArrowRight color={colors.$3} size="1.4rem" strokeWidth="1.5" />
             </div>
-          </button>
+          </Box>
         </div>
       </div>
     </Modal>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes implementation of a Stripe helper modal when the Stripe configuration is done and the user is redirected to the edit page. The modal only displays if the URL contains `show_onboarding=true`. The modal explains what the user can additionally configure, and once clicked, the user will be navigated to another tab. Screenshot:

<img width="1262" height="768" alt="Screenshot 2026-05-11 at 22 51 34" src="https://github.com/user-attachments/assets/b8f24e08-317b-49d5-9e9d-e0622bf18151" />

Let me know your thoughts.
