### PR TITLE
Normalize file names

### DIFF
--- a/src/pages/documents/common/components/DocumentCreationDropZone.tsx
+++ b/src/pages/documents/common/components/DocumentCreationDropZone.tsx
@@ -18,6 +18,7 @@ import { Document } from '$app/common/interfaces/docuninja/api';
 import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-api-response';
 import { ValidationBag } from '$app/common/interfaces/validation-bag';
 import { ErrorMessage } from '$app/components/ErrorMessage';
+import { getDocumentNameFromFile } from '../helpers';
 import { CloudUpload } from '$app/components/icons/CloudUpload';
 import { getPasswordForPdf, isPdfPasswordProtected } from '@docuninja/builder2.0';
 import { useState } from 'react';
@@ -118,7 +119,8 @@ export function DocumentCreationDropZone({ onSelectFiles }: Props) {
     }
     
     formData.append(
-      'description', 'Untitled document'
+      'description',
+      acceptedFiles[0] ? getDocumentNameFromFile(acceptedFiles[0]) : 'Untitled document'
     );
 
     handleCreateDocument(formData);

--- a/src/pages/documents/common/helpers.ts
+++ b/src/pages/documents/common/helpers.ts
@@ -1,0 +1,22 @@
+/**
+* Invoice Ninja (https://invoiceninja.com).
+*
+* @link https://github.com/invoiceninja/invoiceninja source repository
+*
+* @copyright Copyright (c) 2024. Invoice Ninja LLC (https://invoiceninja.com)
+*
+* @license https://www.elastic.co/licensing/elastic-license
+*/
+
+function normalizeName(name: string): string {
+  return name
+    .replace(/[-_]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export function getDocumentNameFromFile(file: File, fallback = 'Untitled document'): string {
+  const name = file.name.replace(/\.[^/.]+$/, '').trim();
+  return name ? normalizeName(name) : fallback;
+}

--- a/src/pages/documents/create/Create.tsx
+++ b/src/pages/documents/create/Create.tsx
@@ -27,6 +27,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { DocumentCreationDropZone } from '../common/components/DocumentCreationDropZone';
+import { getDocumentNameFromFile } from '../common/helpers';
 import { X } from 'react-feather';
 
 interface Payload {
@@ -131,7 +132,18 @@ export default function Create() {
 
           <Element>
             <DocumentCreationDropZone
-              onSelectFiles={(f) => setPayload({ ...payload, 'files[]': f })}
+              onSelectFiles={(f) =>
+                setPayload({
+                  ...payload,
+                  'files[]': f,
+                  description:
+                    payload.description === 'Untitled document'
+                      ? f[0]
+                        ? getDocumentNameFromFile(f[0])
+                        : payload.description
+                      : payload.description,
+                })
+              }
             />
           </Element>
 


### PR DESCRIPTION
This normalizes file name instead of using "Untitled document" when document is created by uploading file.

- "some-document.pdf" → "Some Document"
- "my_contract.pdf" → "My Contract"
- "Q4-Report_Final.pdf" → "Q4 Report Final"
- "Untitled document.pdf" → "Untitled Document"