### PR TITLE
[Cleanup] Client Contact Custom Fields

### DIFF
--- a/src/pages/clients/show/components/Contacts.tsx
+++ b/src/pages/clients/show/components/Contacts.tsx
@@ -18,10 +18,19 @@ import { route } from '$app/common/helpers/route';
 import { Link } from '$app/components/forms';
 import { useColorScheme } from '$app/common/colors';
 import { InfoCard } from '$app/components/InfoCard';
+import { CustomFields, useCustomField } from '$app/components/CustomField';
+import { useFormatCustomFieldValue } from '$app/common/hooks/useFormatCustomFieldValue';
 
 interface Props {
   client: Client;
 }
+
+const contactCustomFieldKeys: CustomFields[] = [
+  'contact1',
+  'contact2',
+  'contact3',
+  'contact4',
+];
 
 export function Contacts(props: Props) {
   const [t] = useTranslation();
@@ -29,6 +38,19 @@ export function Contacts(props: Props) {
   const colors = useColorScheme();
 
   const { client } = props;
+
+  const customField = useCustomField();
+  const formatCustomFieldValue = useFormatCustomFieldValue();
+
+  const hasAnyContactCustomField = (contact: ClientContact) => {
+    return contactCustomFieldKeys.some((field) => {
+      const label = customField(field).label();
+      const value =
+        contact[`custom_value${field.slice(-1)}` as keyof ClientContact];
+
+      return Boolean(label && value);
+    });
+  };
 
   return (
     <>
@@ -46,7 +68,8 @@ export function Contacts(props: Props) {
                   contact.first_name ||
                     contact.last_name ||
                     contact.phone ||
-                    contact.email
+                    contact.email ||
+                    hasAnyContactCustomField(contact)
                 ) && (
                   <div
                     key={index}
@@ -91,6 +114,38 @@ export function Contacts(props: Props) {
                           </Tooltip>
                         </div>
                       )}
+
+                      {contactCustomFieldKeys.map((field) => {
+                        const label = customField(field).label();
+                        const value =
+                          contact[
+                            `custom_value${field.slice(
+                              -1
+                            )}` as keyof ClientContact
+                          ];
+
+                        if (!label || !value) {
+                          return null;
+                        }
+
+                        return (
+                          <div key={field} className="flex space-x-1">
+                            <span
+                              className="font-medium"
+                              style={{ color: colors.$22 }}
+                            >
+                              {label}:
+                            </span>
+
+                            <span
+                              className="font-medium"
+                              style={{ color: colors.$3 }}
+                            >
+                              {formatCustomFieldValue(field, value as string)}
+                            </span>
+                          </div>
+                        );
+                      })}
 
                       <div className="flex items-center space-x-2">
                         <Link


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of displaying client contact custom fields on the client show page. Screenshot:

<img width="1262" height="772" alt="Screenshot 2026-05-13 at 15 30 06" src="https://github.com/user-attachments/assets/ac21508f-4c26-4704-96ed-a931a7ebe7cc" />

Let me know your thoughts.