### PR TITLE
[Cleanup] Improving Payment Actions UI/UX

### DIFF
--- a/src/pages/payments/Payment.tsx
+++ b/src/pages/payments/Payment.tsx
@@ -37,6 +37,8 @@ import {
 } from '$app/common/queries/sockets';
 import { PreviousNextNavigation } from '$app/components/PreviousNextNavigation';
 import { InputLabel } from '$app/components/forms';
+import { useAtomValue } from 'jotai';
+import { paymentPageSaveActionAtom } from './common/hooks/usePaymentPageSaveAction';
 
 export default function Payment() {
   const [t] = useTranslation();
@@ -65,6 +67,8 @@ export default function Payment() {
   const onSave = useSave({ setErrors, isFormBusy, setIsFormBusy });
 
   const actions = useActions();
+
+  const subPageSaveAction = useAtomValue(paymentPageSaveActionAtom);
 
   useEffect(() => {
     if (data) {
@@ -95,16 +99,23 @@ export default function Payment() {
       breadcrumbs={pages}
       {...((hasPermission('edit_payment') || entityAssigned(paymentValue)) &&
         paymentValue && {
-          onSaveClick: () => onSave(paymentValue as unknown as PaymentEntity),
           navigationTopRight: (
             <ResourceActions
-              label={t('more_actions')}
               resource={paymentValue}
               actions={actions}
+              onSaveClick={
+                subPageSaveAction
+                  ? subPageSaveAction.onClick
+                  : () => onSave(paymentValue as unknown as PaymentEntity)
+              }
+              disableSaveButton={
+                subPageSaveAction
+                  ? subPageSaveAction.disabled
+                  : !paymentValue || isFormBusy
+              }
               cypressRef="paymentActionDropdown"
             />
           ),
-          disableSaveButton: !paymentValue || isFormBusy,
         })}
       aboveMainContainer={
         <Banner id="paymentUpdateBanner" className="hidden" variant="orange">

--- a/src/pages/payments/apply/Apply.tsx
+++ b/src/pages/payments/apply/Apply.tsx
@@ -22,7 +22,7 @@ import { useTranslation } from 'react-i18next';
 import { useParams, useSearchParams } from 'react-router-dom';
 import { useNavigate } from 'react-router-dom';
 import { useFormatMoney } from '$app/common/hooks/money/useFormatMoney';
-import { useSaveBtn } from '$app/components/layouts/common/hooks';
+import { usePaymentPageSaveAction } from '../common/hooks/usePaymentPageSaveAction';
 import { toast } from '$app/common/helpers/toast/toast';
 import { $refetch } from '$app/common/hooks/useRefetch';
 import { useColorScheme } from '$app/common/colors';
@@ -122,10 +122,10 @@ export default function Apply() {
     });
   }, [formik.values.invoices]);
 
-  useSaveBtn(
+  usePaymentPageSaveAction(
     {
       onClick: () => formik.submitForm(),
-      disableSaveButton: formik.isSubmitting,
+      disabled: formik.isSubmitting,
     },
     [formik.values, formik.isSubmitting]
   );

--- a/src/pages/payments/common/hooks/useActions.tsx
+++ b/src/pages/payments/common/hooks/useActions.tsx
@@ -21,6 +21,7 @@ import { Icon } from '$app/components/icons/Icon';
 import { Action } from '$app/components/ResourceActions';
 import { useChangeTemplate } from '$app/pages/settings/invoice-design/pages/custom-designs/components/ChangeTemplate';
 import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router-dom';
 import {
   MdArchive,
   MdDelete,
@@ -55,6 +56,10 @@ export function useActions(params?: Params) {
     ],
   });
 
+  const location = useLocation();
+  const isApplyPage = location.pathname.endsWith('/apply');
+  const isRefundPage = location.pathname.endsWith('/refund');
+
   const bulk = useBulk();
 
   const {
@@ -75,6 +80,7 @@ export function useActions(params?: Params) {
       ),
     () => Boolean(showEditAction) && <Divider withoutPadding />,
     (resource: Payment) =>
+      !isApplyPage &&
       resource.amount - resource.applied > 0 &&
       !resource.is_deleted && (
         <DropdownElement
@@ -85,6 +91,7 @@ export function useActions(params?: Params) {
         </DropdownElement>
       ),
     (resource: Payment) =>
+      !isRefundPage &&
       resource.amount !== resource.refunded &&
       !resource.is_deleted && (
         <DropdownElement

--- a/src/pages/payments/common/hooks/useActions.tsx
+++ b/src/pages/payments/common/hooks/useActions.tsx
@@ -39,6 +39,9 @@ interface Params {
 }
 export function useActions(params?: Params) {
   const [t] = useTranslation();
+  const location = useLocation();
+
+  const bulk = useBulk();
 
   const { showEditAction, showCommonBulkAction } = params || {};
 
@@ -55,12 +58,6 @@ export function useActions(params?: Params) {
       'activity',
     ],
   });
-
-  const location = useLocation();
-  const isApplyPage = location.pathname.endsWith('/apply');
-  const isRefundPage = location.pathname.endsWith('/refund');
-
-  const bulk = useBulk();
 
   const {
     setChangeTemplateVisible,
@@ -80,7 +77,7 @@ export function useActions(params?: Params) {
       ),
     () => Boolean(showEditAction) && <Divider withoutPadding />,
     (resource: Payment) =>
-      !isApplyPage &&
+      !location.pathname.includes('/apply') &&
       resource.amount - resource.applied > 0 &&
       !resource.is_deleted && (
         <DropdownElement
@@ -91,7 +88,7 @@ export function useActions(params?: Params) {
         </DropdownElement>
       ),
     (resource: Payment) =>
-      !isRefundPage &&
+      !location.pathname.includes('/refund') &&
       resource.amount !== resource.refunded &&
       !resource.is_deleted && (
         <DropdownElement

--- a/src/pages/payments/common/hooks/usePaymentPageSaveAction.ts
+++ b/src/pages/payments/common/hooks/usePaymentPageSaveAction.ts
@@ -1,0 +1,33 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { atom, useSetAtom } from 'jotai';
+import { useEffect } from 'react';
+
+export interface PaymentPageSaveAction {
+  onClick: () => void;
+  disabled?: boolean;
+}
+
+export const paymentPageSaveActionAtom =
+  atom<PaymentPageSaveAction | null>(null);
+
+export function usePaymentPageSaveAction(
+  options: PaymentPageSaveAction,
+  deps: unknown[] = []
+) {
+  const setAction = useSetAtom(paymentPageSaveActionAtom);
+
+  useEffect(() => {
+    setAction(options);
+
+    return () => setAction(null);
+  }, deps);
+}

--- a/src/pages/payments/refund/Refund.tsx
+++ b/src/pages/payments/refund/Refund.tsx
@@ -27,7 +27,7 @@ import { Gateway } from '$app/common/interfaces/statics';
 import { toast } from '$app/common/helpers/toast/toast';
 import collect from 'collect.js';
 import { useFormatMoney } from '$app/common/hooks/money/useFormatMoney';
-import { useSaveBtn } from '$app/components/layouts/common/hooks';
+import { usePaymentPageSaveAction } from '../common/hooks/usePaymentPageSaveAction';
 import { $refetch } from '$app/common/hooks/useRefetch';
 import { NumberInputField } from '$app/components/forms/NumberInputField';
 import { useColorScheme } from '$app/common/colors';
@@ -167,10 +167,10 @@ export default function Refund() {
     );
   };
 
-  useSaveBtn(
+  usePaymentPageSaveAction(
     {
       onClick: () => formik.handleSubmit(),
-      disableSaveButton: formik.isSubmitting || !formik.values.invoices.length,
+      disabled: formik.isSubmitting || !formik.values.invoices.length,
     },
     [formik.values, formik.isSubmitting]
   );


### PR DESCRIPTION
@beganovich @turbo124 The PR includes improvements for actions on the payment edit page, hiding the refund or apply action when the user is on one of those tabs, and combining actions and buttons into one element. Screenshot:

<img width="1670" height="928" alt="Screenshot 2026-05-15 at 17 55 55" src="https://github.com/user-attachments/assets/612506a5-fcf6-477b-a95b-2d17ccbba047" />

Let me know your thoughts.