### PR TITLE
[Bugfix] Templates And Reminder Behavior When Configuring Settings

### DIFF
--- a/src/pages/settings/templates-and-reminders/TemplatesAndReminders.tsx
+++ b/src/pages/settings/templates-and-reminders/TemplatesAndReminders.tsx
@@ -204,13 +204,18 @@ export function TemplatesAndReminders() {
 
   const { data: statics } = useStaticsQuery();
 
-  const [templateId, setTemplateId] = useState('invoice');
+  const [templateId, setTemplateId] = useState(
+    isCompanySettingsActive || company?.settings.email_template_invoice
+      ? 'invoice'
+      : ''
+  );
 
   const [templateBody, setTemplateBody] = useState<TemplateBody>();
   const [preview, setPreview] = useState<EmailTemplate>();
 
   const canChangeEmailTemplate = (isHosted() && !freePlan()) || isSelfHosted();
 
+  const [isInitial, setIsInitial] = useState<boolean>(true);
   const [reminderIndex, setReminderIndex] = useState<number>(-1);
   const [isLoadingPdf, setIsLoadingPdf] = useState<boolean>(false);
 
@@ -434,9 +439,18 @@ export function TemplatesAndReminders() {
 
       const template = company?.settings[emailTemplateKey];
 
-      if (isCompanySettingsActive || (template && !isCompanySettingsActive)) {
+      if (
+        isCompanySettingsActive ||
+        (template && !isCompanySettingsActive) ||
+        (templateId === 'invoice' &&
+          !template &&
+          !isCompanySettingsActive &&
+          isInitial)
+      ) {
         handleSetTemplateBody();
       }
+
+      isInitial && setIsInitial(false);
     }
   }, [statics, templateId]);
 

--- a/src/pages/settings/templates-and-reminders/TemplatesAndReminders.tsx
+++ b/src/pages/settings/templates-and-reminders/TemplatesAndReminders.tsx
@@ -93,14 +93,12 @@ const getActiveCategory = (templateId: string): string => {
 interface TemplateSelectorProps {
   value: string;
   onChange: (value: string) => void;
-  disabled?: boolean;
   rightSide?: ReactNode;
 }
 
 function TemplateSelector({
   value,
   onChange,
-  disabled = false,
   rightSide,
 }: TemplateSelectorProps) {
   const [t] = useTranslation();
@@ -125,17 +123,10 @@ function TemplateSelector({
     }
   };
 
-  const disabledStyle = {
-    opacity: disabled ? 0.4 : 1,
-    pointerEvents: (disabled
-      ? 'none'
-      : 'auto') as React.CSSProperties['pointerEvents'],
-  };
-
   return (
     <div className="flex flex-col mb-3">
       <div className="flex overflow-x-auto">
-        <div className="flex" style={disabledStyle}>
+        <div className="flex">
           {MAIN_TABS.map((tab) => (
             <button
               key={tab.value}
@@ -164,7 +155,7 @@ function TemplateSelector({
       </div>
 
       {submenuItems && (
-        <div className="flex flex-wrap gap-1.5 pt-3" style={disabledStyle}>
+        <div className="flex flex-wrap gap-1.5 pt-3">
           {submenuItems.map((item) => (
             <button
               key={item.value}
@@ -213,18 +204,13 @@ export function TemplatesAndReminders() {
 
   const { data: statics } = useStaticsQuery();
 
-  const [templateId, setTemplateId] = useState(
-    isCompanySettingsActive || company?.settings.email_template_invoice
-      ? 'invoice'
-      : ''
-  );
+  const [templateId, setTemplateId] = useState('invoice');
 
   const [templateBody, setTemplateBody] = useState<TemplateBody>();
   const [preview, setPreview] = useState<EmailTemplate>();
 
   const canChangeEmailTemplate = (isHosted() && !freePlan()) || isSelfHosted();
 
-  const [isInitial, setIsInitial] = useState<boolean>(true);
   const [reminderIndex, setReminderIndex] = useState<number>(-1);
   const [isLoadingPdf, setIsLoadingPdf] = useState<boolean>(false);
 
@@ -411,6 +397,7 @@ export function TemplatesAndReminders() {
         }
 
         setTemplateBody(undefined);
+        setPreview(undefined);
       }
     }
 
@@ -447,18 +434,9 @@ export function TemplatesAndReminders() {
 
       const template = company?.settings[emailTemplateKey];
 
-      if (
-        isCompanySettingsActive ||
-        (template && !isCompanySettingsActive) ||
-        (templateId === 'invoice' &&
-          !template &&
-          !isCompanySettingsActive &&
-          isInitial)
-      ) {
+      if (isCompanySettingsActive || (template && !isCompanySettingsActive)) {
         handleSetTemplateBody();
       }
-
-      isInitial && setIsInitial(false);
     }
   }, [statics, templateId]);
 
@@ -503,12 +481,13 @@ export function TemplatesAndReminders() {
         <div className="px-4 sm:px-6 pb-1">
           <TemplateSelector
             value={templateId}
-            disabled={
-              !isCompanySettingsActive && disableSettingsField(emailTemplateKey)
-            }
             onChange={(value) => {
               setTemplateId(value);
-              !isCompanySettingsActive && setTemplateBody(undefined);
+
+              if (!isCompanySettingsActive) {
+                setTemplateBody(undefined);
+                setPreview(undefined);
+              }
             }}
             rightSide={
               !isCompanySettingsActive ? (


### PR DESCRIPTION
@beganovich @turbo124 The PR includes logic fixes for templates and reminders when configuring client/group settings, enabling each template or reminder separately, making tabs selectable and never disabled, but only fields if a specific template or reminder is not selected. Let me know your thoughts.