### PR TITLE
[Cleanup] Payment Terms Tooltip | Invoices & Quotes

### DIFF
--- a/src/components/PaymentTermsTooltip.tsx
+++ b/src/components/PaymentTermsTooltip.tsx
@@ -1,0 +1,67 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { useColorScheme } from '$app/common/colors';
+import { useGetSetting } from '$app/common/hooks/useGetSetting';
+import { Client } from '$app/common/interfaces/client';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { MdInfoOutline } from 'react-icons/md';
+import { Icon } from './icons/Icon';
+import { Tooltip } from './Tooltip';
+import { Link } from './forms';
+
+interface Props {
+  client?: Client;
+}
+
+export function PaymentTermsTooltip({ client }: Props) {
+  const [t] = useTranslation();
+
+  const colors = useColorScheme();
+  const getSetting = useGetSetting();
+
+  const { paymentTerms, hasPaymentTerms } = useMemo(() => {
+    const value = client ? getSetting(client, 'payment_terms') : undefined;
+
+    return {
+      paymentTerms: value,
+      hasPaymentTerms: value && Number(value) > 0,
+    };
+  }, [client]);
+
+  return (
+    <Tooltip
+      width="auto"
+      placement="top"
+      withoutArrow
+      tooltipElement={
+        <div className="flex flex-col space-y-1 whitespace-nowrap text-left">
+          <span>
+            {t('payment_terms')}:{' '}
+            {hasPaymentTerms
+              ? `${t('net')} ${paymentTerms} ${t('days')}`
+              : t('none')}
+          </span>
+
+          <Link to="/settings/payment_terms" className="text-xs">
+            {t('configure')}
+          </Link>
+        </div>
+      }
+    >
+      <Icon
+        element={MdInfoOutline}
+        size={16}
+        style={{ color: colors.$22, opacity: 0.7 }}
+      />
+    </Tooltip>
+  );
+}

--- a/src/components/PaymentTermsTooltip.tsx
+++ b/src/components/PaymentTermsTooltip.tsx
@@ -10,9 +10,10 @@
 
 import { useColorScheme } from '$app/common/colors';
 import { route } from '$app/common/helpers/route';
+import { useClientResolver } from '$app/common/hooks/clients/useClientResolver';
 import { useGetSetting } from '$app/common/hooks/useGetSetting';
 import { Client } from '$app/common/interfaces/client';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MdInfoOutline } from 'react-icons/md';
 import { Icon } from './icons/Icon';
@@ -21,22 +22,51 @@ import { Link } from './forms';
 
 interface Props {
   client?: Client;
+  clientId?: string;
 }
 
-export function PaymentTermsTooltip({ client }: Props) {
+export function PaymentTermsTooltip({ client, clientId }: Props) {
   const [t] = useTranslation();
 
-  const colors = useColorScheme();
   const getSetting = useGetSetting();
 
+  const colors = useColorScheme();
+  const clientResolver = useClientResolver();
+
+  const [resolvedClient, setResolvedClient] = useState<Client | undefined>(
+    client
+  );
+
+  useEffect(() => {
+    if (client) {
+      setResolvedClient(client);
+
+      return;
+    }
+
+    if (clientId) {
+      clientResolver.find(clientId).then((c) => setResolvedClient(c));
+
+      return;
+    }
+
+    setResolvedClient(undefined);
+  }, [client, clientId]);
+
   const { paymentTerms, hasPaymentTerms } = useMemo(() => {
-    const value = client ? getSetting(client, 'payment_terms') : undefined;
+    const value = resolvedClient
+      ? getSetting(resolvedClient, 'payment_terms')
+      : undefined;
 
     return {
       paymentTerms: value,
       hasPaymentTerms: value && Number(value) > 0,
     };
-  }, [client]);
+  }, [resolvedClient]);
+
+  if (!resolvedClient) {
+    return null;
+  }
 
   return (
     <Tooltip
@@ -52,14 +82,12 @@ export function PaymentTermsTooltip({ client }: Props) {
               : t('none')}
           </span>
 
-          {client && (
-            <Link
-              to={route('/clients/:id/settings', { id: client.id })}
-              className="text-xs"
-            >
-              {t('configure')}
-            </Link>
-          )}
+          <Link
+            to={route('/clients/:id/settings', { id: resolvedClient.id })}
+            className="text-xs"
+          >
+            {t('configure')}
+          </Link>
         </div>
       }
     >

--- a/src/components/PaymentTermsTooltip.tsx
+++ b/src/components/PaymentTermsTooltip.tsx
@@ -9,6 +9,7 @@
  */
 
 import { useColorScheme } from '$app/common/colors';
+import { route } from '$app/common/helpers/route';
 import { useGetSetting } from '$app/common/hooks/useGetSetting';
 import { Client } from '$app/common/interfaces/client';
 import { useMemo } from 'react';
@@ -51,9 +52,14 @@ export function PaymentTermsTooltip({ client }: Props) {
               : t('none')}
           </span>
 
-          <Link to="/settings/payment_terms" className="text-xs">
-            {t('configure')}
-          </Link>
+          {client && (
+            <Link
+              to={route('/clients/:id/settings', { id: client.id })}
+              className="text-xs"
+            >
+              {t('configure')}
+            </Link>
+          )}
         </div>
       }
     >

--- a/src/pages/invoices/common/components/InvoiceDetails.tsx
+++ b/src/pages/invoices/common/components/InvoiceDetails.tsx
@@ -18,6 +18,7 @@ import { ChangeHandler } from '$app/pages/invoices/create/Create';
 import { useTranslation } from 'react-i18next';
 import { NumberInputField } from '$app/components/forms/NumberInputField';
 import { useColorScheme } from '$app/common/colors';
+import { PaymentTermsTooltip } from '$app/components/PaymentTermsTooltip';
 
 interface Props {
   invoice?: Invoice;
@@ -48,7 +49,15 @@ export function InvoiceDetails(props: Props) {
           />
         </Element>
 
-        <Element leftSide={t('due_date')}>
+        <Element
+          leftSide={
+            <div className="flex items-center space-x-2">
+              <span>{t('due_date')}</span>
+
+              <PaymentTermsTooltip client={invoice?.client} />
+            </div>
+          }
+        >
           <InputField
             type="date"
             onValueChange={(value) => handleChange('due_date', value)}

--- a/src/pages/invoices/common/components/InvoiceDetails.tsx
+++ b/src/pages/invoices/common/components/InvoiceDetails.tsx
@@ -54,7 +54,10 @@ export function InvoiceDetails(props: Props) {
             <div className="flex items-center space-x-2">
               <span>{t('due_date')}</span>
 
-              <PaymentTermsTooltip client={invoice?.client} />
+              <PaymentTermsTooltip
+                client={invoice?.client}
+                clientId={invoice?.client_id}
+              />
             </div>
           }
         >

--- a/src/pages/quotes/common/components/QuoteDetails.tsx
+++ b/src/pages/quotes/common/components/QuoteDetails.tsx
@@ -19,6 +19,7 @@ import { quoteAtom } from '../atoms';
 import { ChangeHandler } from '../hooks';
 import { NumberInputField } from '$app/components/forms/NumberInputField';
 import { useColorScheme } from '$app/common/colors';
+import { PaymentTermsTooltip } from '$app/components/PaymentTermsTooltip';
 
 interface Props {
   handleChange: ChangeHandler;
@@ -50,7 +51,15 @@ export function QuoteDetails(props: Props) {
           />
         </Element>
 
-        <Element leftSide={t('valid_until')}>
+        <Element
+          leftSide={
+            <div className="flex items-center space-x-2">
+              <span>{t('valid_until')}</span>
+
+              <PaymentTermsTooltip client={quote?.client} />
+            </div>
+          }
+        >
           <InputField
             type="date"
             onValueChange={(value) => handleChange('due_date', value)}

--- a/src/pages/quotes/common/components/QuoteDetails.tsx
+++ b/src/pages/quotes/common/components/QuoteDetails.tsx
@@ -56,7 +56,10 @@ export function QuoteDetails(props: Props) {
             <div className="flex items-center space-x-2">
               <span>{t('valid_until')}</span>
 
-              <PaymentTermsTooltip client={quote?.client} />
+              <PaymentTermsTooltip
+                client={quote?.client}
+                clientId={quote?.client_id}
+              />
             </div>
           }
         >


### PR DESCRIPTION
@beganovich @turbo124 The PR includes implementation of a payment terms tooltip for invoices and quotes on the edit page, showing payment terms settings details along with a configure link if the user wants to add more payment terms. Screenshot:

<img width="347" height="283" alt="Screenshot 2026-05-16 at 17 58 09" src="https://github.com/user-attachments/assets/a2776e8a-8338-4dca-8b0d-f221ac39300a" />

<img width="350" height="285" alt="Screenshot 2026-05-16 at 17 58 17" src="https://github.com/user-attachments/assets/2d4ea501-550c-4186-9846-55e676edb3e6" />

Let me know your thoughts.