### PR TITLE
[Cleanup] Payment Terms Link | Clients

### DIFF
--- a/src/pages/clients/common/components/Settings.tsx
+++ b/src/pages/clients/common/components/Settings.tsx
@@ -18,6 +18,7 @@ import { set } from 'lodash';
 import { useCurrencies } from '$app/common/hooks/useCurrencies';
 import { useLanguages } from '$app/common/hooks/useLanguages';
 import { SelectField } from '$app/components/forms/SelectField';
+import { Link } from '$app/components/forms';
 import { usePaymentTermsQuery } from '$app/common/queries/payment-terms';
 import { LanguageSelector } from '$app/components/LanguageSelector';
 import { PaymentTerm } from '$app/common/interfaces/payment-term';
@@ -87,7 +88,21 @@ export default function Settings() {
         )}
 
         {paymentTermsResponse && (
-          <Element leftSide={t('payment_terms')}>
+          <Element
+            leftSide={
+              <div className="flex items-center space-x-1 whitespace-nowrap">
+                <span>{t('payment_terms')}</span>
+
+                <div className="flex">
+                  <span style={{ color: colors.$3 }}>(</span>
+
+                  <Link to="/settings/payment_terms">{t('configure')}</Link>
+
+                  <span style={{ color: colors.$3 }}>)</span>
+                </div>
+              </div>
+            }
+          >
             <SelectField
               id="settings.payment_terms"
               value={client?.settings?.payment_terms || ''}

--- a/src/pages/clients/common/components/Settings.tsx
+++ b/src/pages/clients/common/components/Settings.tsx
@@ -96,7 +96,9 @@ export default function Settings() {
                 <div className="flex">
                   <span style={{ color: colors.$3 }}>(</span>
 
-                  <Link to="/settings/payment_terms">{t('configure')}</Link>
+                  <Link to="/settings/payment_terms/create">
+                    {t('configure')}
+                  </Link>
 
                   <span style={{ color: colors.$3 }}>)</span>
                 </div>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the addition of a 'configure' link for payment terms navigation to the create payment term page. Screenshot:

<img width="521" height="452" alt="Screenshot 2026-05-20 at 18 53 05" src="https://github.com/user-attachments/assets/afb09e82-d78e-434b-b478-f670112d42ba" />

Let me know your thoughts.