### PR TITLE
[Cleanup] Cropping Logo

### DIFF
--- a/src/common/helpers/logo-image.ts
+++ b/src/common/helpers/logo-image.ts
@@ -124,25 +124,24 @@ export const compressImageFileForLogo = async (file: File): Promise<File> => {
 
   const image = await loadImageFromFile(file);
 
-  const needsResize =
-    image.naturalWidth > LOGO_MAX_DIMENSION ||
-    image.naturalHeight > LOGO_MAX_DIMENSION;
+  try {
+    const needsResize =
+      image.naturalWidth > LOGO_MAX_DIMENSION ||
+      image.naturalHeight > LOGO_MAX_DIMENSION;
 
-  URL.revokeObjectURL(image.src);
+    if (isWithinSize && !needsResize) {
+      return file;
+    }
 
-  if (isWithinSize && !needsResize) {
-    return file;
+    const { canvas } = drawImageToCanvas(image);
+
+    const preferredType: 'image/png' | 'image/jpeg' =
+      file.type === 'image/jpeg' ? 'image/jpeg' : 'image/png';
+
+    const compressedBlob = await compressCanvasToMaxSize(canvas, preferredType);
+
+    return blobToFile(compressedBlob, file.name);
+  } finally {
+    URL.revokeObjectURL(image.src);
   }
-
-  const reloadedImage = await loadImageFromFile(file);
-  const { canvas } = drawImageToCanvas(reloadedImage);
-
-  URL.revokeObjectURL(reloadedImage.src);
-
-  const preferredType: 'image/png' | 'image/jpeg' =
-    file.type === 'image/jpeg' ? 'image/jpeg' : 'image/png';
-
-  const compressedBlob = await compressCanvasToMaxSize(canvas, preferredType);
-
-  return blobToFile(compressedBlob, file.name);
 };

--- a/src/common/helpers/logo-image.ts
+++ b/src/common/helpers/logo-image.ts
@@ -1,0 +1,148 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+export const LOGO_MAX_DIMENSION = 800;
+export const LOGO_MAX_BLOB_SIZE = 2 * 1024 * 1024;
+
+export const canvasToBlob = (
+  canvas: HTMLCanvasElement,
+  type: string,
+  quality?: number
+): Promise<Blob> =>
+  new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) =>
+        blob
+          ? resolve(blob)
+          : reject(new Error('Converting canvas to blob failed')),
+      type,
+      quality
+    );
+  });
+
+export const compressCanvasToMaxSize = async (
+  canvas: HTMLCanvasElement,
+  preferredType: 'image/png' | 'image/jpeg' = 'image/png'
+): Promise<Blob> => {
+  if (preferredType === 'image/png') {
+    const pngBlob = await canvasToBlob(canvas, 'image/png');
+
+    if (pngBlob.size <= LOGO_MAX_BLOB_SIZE) {
+      return pngBlob;
+    }
+  }
+
+  let quality = 0.9;
+
+  while (quality >= 0.1) {
+    const jpegBlob = await canvasToBlob(canvas, 'image/jpeg', quality);
+
+    if (jpegBlob.size <= LOGO_MAX_BLOB_SIZE) {
+      return jpegBlob;
+    }
+
+    quality -= 0.1;
+  }
+
+  return canvasToBlob(canvas, 'image/jpeg', 0.1);
+};
+
+const loadImageFromFile = (file: File): Promise<HTMLImageElement> =>
+  new Promise((resolve, reject) => {
+    const objectUrl = URL.createObjectURL(file);
+    const image = new Image();
+
+    image.onload = () => {
+      resolve(image);
+    };
+
+    image.onerror = () => {
+      URL.revokeObjectURL(objectUrl);
+      reject(new Error('Failed to load image'));
+    };
+
+    image.src = objectUrl;
+  });
+
+const drawImageToCanvas = (
+  image: HTMLImageElement
+): { canvas: HTMLCanvasElement; isOpaque: boolean } => {
+  let outputWidth = image.naturalWidth;
+  let outputHeight = image.naturalHeight;
+
+  if (outputWidth > LOGO_MAX_DIMENSION || outputHeight > LOGO_MAX_DIMENSION) {
+    const ratio = Math.min(
+      LOGO_MAX_DIMENSION / outputWidth,
+      LOGO_MAX_DIMENSION / outputHeight
+    );
+
+    outputWidth = Math.max(1, Math.floor(outputWidth * ratio));
+    outputHeight = Math.max(1, Math.floor(outputHeight * ratio));
+  }
+
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+
+  if (!ctx) {
+    throw new Error('No 2d context');
+  }
+
+  canvas.width = outputWidth;
+  canvas.height = outputHeight;
+
+  ctx.imageSmoothingQuality = 'high';
+
+  ctx.drawImage(image, 0, 0, outputWidth, outputHeight);
+
+  return { canvas, isOpaque: false };
+};
+
+const blobToFile = (blob: Blob, originalName: string): File => {
+  const extension = blob.type === 'image/jpeg' ? 'jpg' : 'png';
+
+  const baseName = originalName.replace(/\.[^/.]+$/, '') || 'company_logo';
+
+  return new File([blob], `${baseName}.${extension}`, {
+    type: blob.type,
+    lastModified: Date.now(),
+  });
+};
+
+export const compressImageFileForLogo = async (file: File): Promise<File> => {
+  if (!file.type.startsWith('image/')) {
+    return file;
+  }
+
+  const isWithinSize = file.size <= LOGO_MAX_BLOB_SIZE;
+
+  const image = await loadImageFromFile(file);
+
+  const needsResize =
+    image.naturalWidth > LOGO_MAX_DIMENSION ||
+    image.naturalHeight > LOGO_MAX_DIMENSION;
+
+  URL.revokeObjectURL(image.src);
+
+  if (isWithinSize && !needsResize) {
+    return file;
+  }
+
+  const reloadedImage = await loadImageFromFile(file);
+  const { canvas } = drawImageToCanvas(reloadedImage);
+
+  URL.revokeObjectURL(reloadedImage.src);
+
+  const preferredType: 'image/png' | 'image/jpeg' =
+    file.type === 'image/jpeg' ? 'image/jpeg' : 'image/png';
+
+  const compressedBlob = await compressCanvasToMaxSize(canvas, preferredType);
+
+  return blobToFile(compressedBlob, file.name);
+};

--- a/src/pages/settings/company/components/Logo.tsx
+++ b/src/pages/settings/company/components/Logo.tsx
@@ -33,6 +33,9 @@ import { useConfigureClientSettings } from '$app/pages/clients/common/hooks/useC
 import { $refetch } from '$app/common/hooks/useRefetch';
 import { CloudUpload } from '$app/components/icons/CloudUpload';
 import { useColorScheme } from '$app/common/colors';
+import { Button } from '$app/components/forms';
+import { MdCrop } from 'react-icons/md';
+import { useCompanyChanges } from '$app/common/hooks/useCompanyChanges';
 
 interface Props {
   isSettingsPage?: boolean;
@@ -46,9 +49,12 @@ export function Logo({ isSettingsPage = true }: Props) {
   const logo = useLogo();
   const colors = useColorScheme();
   const company = useCurrentCompany();
+  const companyChanges = useCompanyChanges();
 
   const [pendingImageSrc, setPendingImageSrc] = useState<string>('');
   const [cropModalVisible, setCropModalVisible] = useState<boolean>(false);
+  const [isLoadingCropSource, setIsLoadingCropSource] =
+    useState<boolean>(false);
 
   const {
     isGroupSettingsActive,
@@ -113,18 +119,23 @@ export function Logo({ isSettingsPage = true }: Props) {
     });
   };
 
-  const onDrop = useCallback((acceptedFiles: File[]) => {
-    const file = acceptedFiles[0];
+  const onDrop = useCallback(
+    (acceptedFiles: File[]) => {
+      const file = acceptedFiles[0];
 
-    if (!file) {
-      return;
-    }
+      if (!file) {
+        return;
+      }
 
-    const objectUrl = URL.createObjectURL(file);
+      const formData = new FormData();
 
-    setPendingImageSrc(objectUrl);
-    setCropModalVisible(true);
-  }, []);
+      formData.append('company_logo', file);
+      formData.append('_method', 'PUT');
+
+      uploadLogo(formData);
+    },
+    [uploadLogo]
+  );
 
   const handleCropComplete = useCallback(
     (croppedBlob: Blob): Promise<void> => {
@@ -151,6 +162,31 @@ export function Logo({ isSettingsPage = true }: Props) {
     setCropModalVisible(false);
   };
 
+  const handleOpenCropExistingLogo = async () => {
+    if (isLoadingCropSource) {
+      return;
+    }
+
+    setIsLoadingCropSource(true);
+    setCropModalVisible(true);
+
+    request(
+      'GET',
+      endpoint('/api/v1/companies/:id/logo', { id: company.id }),
+      {},
+      { responseType: 'blob' }
+    )
+      .then((response: AxiosResponse) => {
+        setPendingImageSrc(URL.createObjectURL(response.data as Blob));
+      })
+      .catch(() => {
+        setCropModalVisible(false);
+      })
+      .finally(() => {
+        setIsLoadingCropSource(false);
+      });
+  };
+
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
     multiple: false,
@@ -165,6 +201,7 @@ export function Logo({ isSettingsPage = true }: Props) {
       <LogoCropModal
         visible={cropModalVisible}
         imageSrc={pendingImageSrc}
+        isLoading={isLoadingCropSource}
         onClose={handleCropModalClose}
         onCropComplete={handleCropComplete}
       />
@@ -215,7 +252,27 @@ export function Logo({ isSettingsPage = true }: Props) {
             </div>
           </Element>
 
-          <DeleteLogo />
+          <Element className="pb-3" pushContentToRight noVerticalPadding>
+            <div className="flex items-center space-x-3">
+              <Button
+                behavior="button"
+                type="secondary"
+                onClick={handleOpenCropExistingLogo}
+                disabled={
+                  !companyChanges?.settings?.company_logo || isLoadingCropSource
+                }
+                disableWithoutIcon
+              >
+                <div className="flex items-center space-x-2">
+                  <MdCrop fontSize={16} />
+
+                  <span className="text-sm">{t('crop_logo')}</span>
+                </div>
+              </Button>
+
+              <DeleteLogo isSettingsPage={false} />
+            </div>
+          </Element>
         </>
       ) : (
         <div className="flex flex-col space-y-5">

--- a/src/pages/settings/company/components/Logo.tsx
+++ b/src/pages/settings/company/components/Logo.tsx
@@ -36,6 +36,7 @@ import { useColorScheme } from '$app/common/colors';
 import { Button } from '$app/components/forms';
 import { MdCrop } from 'react-icons/md';
 import { useCompanyChanges } from '$app/common/hooks/useCompanyChanges';
+import { compressImageFileForLogo } from '$app/common/helpers/logo-image';
 
 interface Props {
   isSettingsPage?: boolean;
@@ -120,16 +121,25 @@ export function Logo({ isSettingsPage = true }: Props) {
   };
 
   const onDrop = useCallback(
-    (acceptedFiles: File[]) => {
+    async (acceptedFiles: File[]) => {
       const file = acceptedFiles[0];
 
       if (!file) {
         return;
       }
 
+      let preparedFile: File;
+
+      try {
+        preparedFile = await compressImageFileForLogo(file);
+      } catch {
+        toast.error();
+        return;
+      }
+
       const formData = new FormData();
 
-      formData.append('company_logo', file);
+      formData.append('company_logo', preparedFile);
       formData.append('_method', 'PUT');
 
       uploadLogo(formData);

--- a/src/pages/settings/company/components/LogoCropModal.tsx
+++ b/src/pages/settings/company/components/LogoCropModal.tsx
@@ -11,6 +11,7 @@
 import { useColorScheme } from '$app/common/colors';
 import { Button } from '$app/components/forms';
 import { Modal } from '$app/components/Modal';
+import { Spinner } from '$app/components/Spinner';
 import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import ReactCrop, {
@@ -23,6 +24,7 @@ import 'react-image-crop/dist/ReactCrop.css';
 interface Props {
   visible: boolean;
   imageSrc: string;
+  isLoading?: boolean;
   onClose: () => void;
   onCropComplete: (croppedBlob: Blob) => Promise<void>;
 }
@@ -132,6 +134,7 @@ const cropImageToBlob = async (
 export function LogoCropModal({
   visible,
   imageSrc,
+  isLoading = false,
   onClose,
   onCropComplete,
 }: Props) {
@@ -200,9 +203,15 @@ export function LogoCropModal({
       <div className="flex flex-col space-y-5">
         <div
           className="flex items-center justify-center w-full p-4 rounded-lg border"
-          style={{ backgroundColor: colors.$15, borderColor: colors.$24 }}
+          style={{
+            backgroundColor: colors.$15,
+            borderColor: colors.$24,
+            minHeight: '18rem',
+          }}
         >
-          {imageSrc && (
+          {isLoading || !imageSrc ? (
+            <Spinner />
+          ) : (
             <ReactCrop
               crop={crop}
               onChange={(c) => setCrop(c)}
@@ -225,7 +234,7 @@ export function LogoCropModal({
             behavior="button"
             type="secondary"
             onClick={handleReset}
-            disabled={isFormBusy}
+            disabled={isFormBusy || isLoading || !imageSrc}
             disableWithoutIcon
           >
             {t('reset')}
@@ -234,8 +243,8 @@ export function LogoCropModal({
           <Button
             behavior="button"
             onClick={handleConfirm}
-            disabled={isFormBusy || !completedCrop}
-            disableWithoutIcon={!completedCrop}
+            disabled={isFormBusy || isLoading || !completedCrop}
+            disableWithoutIcon={!completedCrop || isLoading}
           >
             {t('upload')}
           </Button>

--- a/src/pages/settings/company/components/LogoCropModal.tsx
+++ b/src/pages/settings/company/components/LogoCropModal.tsx
@@ -9,6 +9,10 @@
  */
 
 import { useColorScheme } from '$app/common/colors';
+import {
+  LOGO_MAX_DIMENSION,
+  compressCanvasToMaxSize,
+} from '$app/common/helpers/logo-image';
 import { Button } from '$app/components/forms';
 import { Modal } from '$app/components/Modal';
 import { Spinner } from '$app/components/Spinner';
@@ -37,47 +41,6 @@ const FULL_CROP: Crop = {
   height: 100,
 };
 
-const MAX_DIMENSION = 800;
-const MAX_BLOB_SIZE = 2 * 1024 * 1024;
-
-const canvasToBlob = (
-  canvas: HTMLCanvasElement,
-  type: string,
-  quality?: number
-): Promise<Blob> =>
-  new Promise((resolve, reject) => {
-    canvas.toBlob(
-      (blob) =>
-        blob
-          ? resolve(blob)
-          : reject(new Error('Converting canvas to blob failed')),
-      type,
-      quality
-    );
-  });
-
-const compressToMaxSize = async (canvas: HTMLCanvasElement): Promise<Blob> => {
-  const pngBlob = await canvasToBlob(canvas, 'image/png');
-
-  if (pngBlob.size <= MAX_BLOB_SIZE) {
-    return pngBlob;
-  }
-
-  let quality = 0.9;
-
-  while (quality >= 0.1) {
-    const jpegBlob = await canvasToBlob(canvas, 'image/jpeg', quality);
-
-    if (jpegBlob.size <= MAX_BLOB_SIZE) {
-      return jpegBlob;
-    }
-
-    quality -= 0.1;
-  }
-
-  return canvasToBlob(canvas, 'image/jpeg', 0.1);
-};
-
 const cropImageToBlob = async (
   image: HTMLImageElement,
   crop: PixelCrop
@@ -94,10 +57,10 @@ const cropImageToBlob = async (
 
   let outputHeight = sourceHeight;
 
-  if (outputWidth > MAX_DIMENSION || outputHeight > MAX_DIMENSION) {
+  if (outputWidth > LOGO_MAX_DIMENSION || outputHeight > LOGO_MAX_DIMENSION) {
     const ratio = Math.min(
-      MAX_DIMENSION / outputWidth,
-      MAX_DIMENSION / outputHeight
+      LOGO_MAX_DIMENSION / outputWidth,
+      LOGO_MAX_DIMENSION / outputHeight
     );
 
     outputWidth = Math.floor(outputWidth * ratio);
@@ -128,7 +91,7 @@ const cropImageToBlob = async (
     outputHeight
   );
 
-  return compressToMaxSize(canvas);
+  return compressCanvasToMaxSize(canvas);
 };
 
 export function LogoCropModal({


### PR DESCRIPTION
@beganovich @turbo124 The PR includes reimplementation of the crop logo functionality so that instead of forcing it, we offer a button to crop after upload if needed. Screenshot:

<img width="790" height="509" alt="Screenshot 2026-05-21 at 19 56 43" src="https://github.com/user-attachments/assets/cbf1363b-c0dd-4f66-af41-e9692b670bca" />

Let me know your thoughts.