### PR TITLE
Fix inconsistent link color (wrong target branch)

### DIFF
--- a/src/common/hooks/useAccentColor.ts
+++ b/src/common/hooks/useAccentColor.ts
@@ -21,5 +21,5 @@ export function useAccentColor() {
     userState.changes?.company_user?.settings?.accent_color ||
     user?.company_user?.settings?.accent_color ||
     colors.accent
-  );
+  ) as string;
 }

--- a/src/components/dropdown/Dropdown.tsx
+++ b/src/components/dropdown/Dropdown.tsx
@@ -142,7 +142,7 @@ export function Dropdown(props: Props) {
               }
             )}
             style={{
-              backgroundColor: props.cardActions && accentColor,
+              backgroundColor: props.cardActions ? accentColor : '',
               color: props.cardActions ? 'white' : '',
             }}
             data-cy={props.triggerCypressRef ?? 'chevronDownButton'}

--- a/src/components/forms/Link.tsx
+++ b/src/components/forms/Link.tsx
@@ -16,6 +16,7 @@ import classNames from 'classnames';
 import { useAtomValue } from 'jotai';
 import { preventLeavingPageAtom } from '$app/common/hooks/useAddPreventNavigationEvents';
 import { ExternalLink } from '../icons/ExternalLink';
+import { useAccentColor } from '$app/common/hooks/useAccentColor';
 
 interface Props extends CommonProps {
   to: string;
@@ -33,6 +34,8 @@ export function Link(props: Props) {
 
   const preventNavigation = usePreventNavigation();
 
+  const accentColor = useAccentColor();
+
   const {
     withoutDefaultStyling,
     setBaseFont,
@@ -41,7 +44,7 @@ export function Link(props: Props) {
   } = props;
 
   const css: React.CSSProperties = {
-    color: '#0062FF',
+    color: accentColor,
     ...props.style,
   };
 
@@ -62,7 +65,7 @@ export function Link(props: Props) {
       >
         {!withoutExternalIcon && (
           <div>
-            <ExternalLink size="1rem" color="#0062FF" />
+            <ExternalLink size="1rem" color={accentColor} />
           </div>
         )}
 

--- a/src/pages/expenses/create/components/Details.tsx
+++ b/src/pages/expenses/create/components/Details.tsx
@@ -38,6 +38,7 @@ import { TaxRate } from '$app/common/interfaces/tax-rate';
 import { getTaxRateComboValue } from '$app/common/helpers/tax-rates/tax-rates-combo';
 import { useColorScheme } from '$app/common/colors';
 import { ExternalLink } from '$app/components/icons/ExternalLink';
+import { useAccentColor } from '$app/common/hooks/useAccentColor';
 
 export interface ExpenseCardProps {
   expense: Expense | undefined;
@@ -61,6 +62,7 @@ export function Details(props: Props) {
   const { expense, handleChange, taxInputType, pageType, errors } = props;
 
   const colors = useColorScheme();
+  const accentColor = useAccentColor();
   const company = useCurrentCompany();
 
   const { data: taxes } = useTaxRatesQuery({ status: ['active'] });
@@ -157,7 +159,7 @@ export function Details(props: Props) {
                     target="_blank"
                   >
                     <div>
-                      <ExternalLink color="#0062FF" size="1.1rem" />
+                      <ExternalLink color={accentColor} size="1.1rem" />
                     </div>
                   </Link>
                 )}
@@ -205,7 +207,7 @@ export function Details(props: Props) {
                     target="_blank"
                   >
                     <div>
-                      <ExternalLink color="#0062FF" size="1.1rem" />
+                      <ExternalLink color={accentColor} size="1.1rem" />
                     </div>
                   </Link>
                 )}

--- a/src/pages/payments/edit/PaymentOverviewInvoice.tsx
+++ b/src/pages/payments/edit/PaymentOverviewInvoice.tsx
@@ -19,6 +19,7 @@ import { useColorScheme } from '$app/common/colors';
 import { Credit } from '$app/common/interfaces/credit';
 import { ExternalLink } from '$app/components/icons/ExternalLink';
 import { dateUTC } from '$app/common/helpers/payment';
+import { useAccentColor } from '$app/common/hooks/useAccentColor';
 
 interface Props {
   payment: Payment;
@@ -51,6 +52,7 @@ export function PaymentOverviewInvoice(props: Props) {
   const formatMoney = useFormatMoney();
 
   const colors = useColorScheme();
+  const accentColor = useAccentColor();
   const { dateFormat } = useCurrentCompanyDateFormats();
 
   return (
@@ -76,7 +78,7 @@ export function PaymentOverviewInvoice(props: Props) {
                   <span>{setLabel(props.payment, props.paymentable)}</span>
 
                   <div>
-                    <ExternalLink color="#0062FF" size="1.1rem" />
+                    <ExternalLink color={accentColor} size="1.1rem" />
                   </div>
                 </div>
               </Link>
@@ -136,7 +138,7 @@ export function PaymentOverviewInvoice(props: Props) {
                   </span>
 
                   <div>
-                    <ExternalLink color="#0062FF" size="1.1rem" />
+                    <ExternalLink color={accentColor} size="1.1rem" />
                   </div>
                 </div>
               </Link>

--- a/src/pages/settings/account-management/component/plan/CreditCard.tsx
+++ b/src/pages/settings/account-management/component/plan/CreditCard.tsx
@@ -104,7 +104,7 @@ export function CreditCard({ gateway, onDelete }: CreditCardProps) {
 
       <div
         className="flex flex-col w-full lg:w-72 p-4 rounded border"
-        style={{ borderColor: gateway.is_default ? accentColor : colors.$11 }}
+        style={{ borderColor: gateway.is_default ? accentColor : colors.$1 }}
       >
         <div className="flex justify-between items-center">
           <img src={image()} alt={gateway.meta.brand} className="h-10" />

--- a/src/pages/settings/gateways/create/Create.tsx
+++ b/src/pages/settings/gateways/create/Create.tsx
@@ -387,7 +387,7 @@ export function Create() {
           <>
             {tabIndex === 1 && (
               <button
-                style={{ color: '#0062FF' }}
+                style={{ color: accentColor }}
                 type="button"
                 onClick={() =>
                   $help('gateways', {
@@ -404,7 +404,7 @@ export function Create() {
 
             {tabIndex === 3 && (
               <button
-                style={{ color: '#0062FF' }}
+                style={{ color: accentColor }}
                 type="button"
                 onClick={() =>
                   $help('gateways', {


### PR DESCRIPTION
Fix for [Inconsistent Link Color #3172
](https://github.com/invoiceninja/ui/issues/3172)

* Use `accentColor` on `<Link>` component too, aligning it with other links.
* Type the result of `useAccentColor` to avoid `any`, which revealed two type conflicts, that I fixed to the best of my knowledge.
* Use `accentColor` in three other places that don't use `<Link>` but act as links too.

# Comparison before/after

## One example of `<Link>` usage

Before
<img width="1257" height="774" alt="Bildschirmfoto 2026-05-23 um 11 19 04" src="https://github.com/user-attachments/assets/59dbb9cb-6ab6-4204-821a-af96bea0d24f" />

After 
<img width="1256" height="776" alt="Bildschirmfoto 2026-05-23 um 11 17 14" src="https://github.com/user-attachments/assets/ee9c6a24-56d8-4796-b949-777f2c32a027" />

## Gateway documentation links

Before
<img width="1256" height="747" alt="Bildschirmfoto 2026-05-23 um 11 18 18" src="https://github.com/user-attachments/assets/110050b6-0897-43c5-ad70-c0f5e49c4ca8" />

After 
<img width="1249" height="386" alt="Bildschirmfoto 2026-05-23 um 11 11 15" src="https://github.com/user-attachments/assets/47e1cf74-9121-4fd8-9e76-2997d27e91dd" />

## Expense

Before
<img width="1255" height="699" alt="Bildschirmfoto 2026-05-23 um 11 18 42" src="https://github.com/user-attachments/assets/2b46e64c-a5fd-4bc1-9d8b-3fabaa88b3dd" />

After
<img width="1256" height="701" alt="Bildschirmfoto 2026-05-23 um 11 14 07" src="https://github.com/user-attachments/assets/5ea864f3-d333-44bc-912a-82a57ad42666" />

## Payment

Before
<img width="1257" height="707" alt="Bildschirmfoto 2026-05-23 um 11 18 57" src="https://github.com/user-attachments/assets/7b9b6fd0-944c-408b-8d18-6e44d3bd6303" />

After
<img width="1255" height="715" alt="Bildschirmfoto 2026-05-23 um 11 12 20" src="https://github.com/user-attachments/assets/83c34a01-f0b2-42f2-920c-6a9954c3081e" />