### PR TITLE
Add paymentable for invoice payment resolution.

### DIFF
--- a/src/common/interfaces/invoice.ts
+++ b/src/common/interfaces/invoice.ts
@@ -10,7 +10,7 @@
 import { EInvoiceType } from '$app/pages/settings';
 import { Client } from './client';
 import { InvoiceItem } from './invoice-item';
-import { Payment } from './payment';
+import { Payment, Paymentable } from './payment';
 import { Invitation } from './purchase-order';
 import { ScheduleItem } from './schedule';
 import { TaxInfo } from './tax-info';
@@ -82,6 +82,7 @@ export interface Invoice {
   client?: Client;
   activities?: Activity[];
   payments?: Payment[];
+  paymentables?: Paymentable[];
   reminder_schedule?: string;
   e_invoice?: EInvoiceType;
   is_locked?: boolean;

--- a/src/common/interfaces/payment.ts
+++ b/src/common/interfaces/payment.ts
@@ -52,6 +52,7 @@ export interface Payment {
 
 export interface Paymentable {
   id: string;
+  payment_id?: string;
   invoice_id: string;
   credit_id: string;
   amount: number;

--- a/src/common/queries/invoices.ts
+++ b/src/common/queries/invoices.ts
@@ -43,7 +43,7 @@ export function useInvoiceQuery(params: InvoiceQueryParams) {
       request(
         'GET',
         endpoint(
-          `/api/v1/invoices/:id?include=payments,client.group_settings&show_schedule=true${isLockedParam}`,
+          `/api/v1/invoices/:id?include=paymentables,payments,client.group_settings&show_schedule=true${isLockedParam}`,
           {
             id: params.id,
           }

--- a/src/pages/invoices/common/components/InvoicePaymentAllocationBox.tsx
+++ b/src/pages/invoices/common/components/InvoicePaymentAllocationBox.tsx
@@ -1,0 +1,93 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { useColorScheme } from '$app/common/colors';
+import { dateUTC } from '$app/common/helpers/payment';
+import { route } from '$app/common/helpers/route';
+import { useDisableNavigation } from '$app/common/hooks/useDisableNavigation';
+import { useFormatMoney } from '$app/common/hooks/money/useFormatMoney';
+import { Invoice } from '$app/common/interfaces/invoice';
+import { PaymentStatus } from '$app/pages/payments/common/components/PaymentStatus';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+import { InvoicePaymentAllocationRow } from '../helpers/invoicePaymentAllocations';
+
+const Box = styled.div`
+  background-color: ${({ theme }) => theme.backgroundColor};
+
+  &:hover {
+    background-color: ${({ theme }) => theme.hoverBackgroundColor};
+  }
+`;
+
+interface Props {
+  row: InvoicePaymentAllocationRow;
+  invoice: Invoice;
+  dateFormat: string;
+}
+
+export function InvoicePaymentAllocationBox(props: Props) {
+  const { row, invoice, dateFormat } = props;
+
+  const [t] = useTranslation();
+  const colors = useColorScheme();
+  const navigate = useNavigate();
+  const formatMoney = useFormatMoney();
+  const disableNavigation = useDisableNavigation();
+
+  const { payment, paymentable } = row;
+
+  return (
+    <Box
+      className="flex flex-col items-start justify-center space-y-2 shadow-sm text-sm border p-5 w-full cursor-pointer rounded-md"
+      onClick={() => {
+        !disableNavigation('payment', payment) &&
+          navigate(
+            route('/payments/:id/edit', {
+              id: payment.id,
+            })
+          );
+      }}
+      style={{
+        borderColor: colors.$20,
+      }}
+      theme={{
+        backgroundColor: colors.$1,
+        hoverBackgroundColor: colors.$4,
+      }}
+    >
+      <span className="font-medium" style={{ color: colors.$3 }}>
+        {t('payment')} {payment.number}
+      </span>
+
+      <div
+        className="inline-flex items-center space-x-1"
+        style={{ color: colors.$17 }}
+      >
+        <span>
+          {formatMoney(
+            paymentable.amount,
+            invoice.client?.country_id,
+            invoice.client?.settings?.currency_id
+          )}
+        </span>
+
+        <span>-</span>
+
+        <span>{dateUTC(paymentable.created_at, dateFormat)}</span>
+      </div>
+
+      <div>
+        <PaymentStatus entity={payment} />
+      </div>
+    </Box>
+  );
+}

--- a/src/pages/invoices/common/components/InvoiceSlider.tsx
+++ b/src/pages/invoices/common/components/InvoiceSlider.tsx
@@ -29,7 +29,6 @@ import { useQuery, useQueryClient } from 'react-query';
 import { request } from '$app/common/helpers/request';
 import { GenericManyResponse } from '$app/common/interfaces/generic-many-response';
 import { AxiosResponse } from 'axios';
-import { PaymentStatus } from '$app/pages/payments/common/components/PaymentStatus';
 import { InvoiceStatus } from './InvoiceStatus';
 import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-api-response';
 import { NonClickableElement } from '$app/components/cards/NonClickableElement';
@@ -40,7 +39,8 @@ import { MdInfo } from 'react-icons/md';
 import { InvoiceActivity } from '$app/common/interfaces/invoice-activity';
 import { route } from '$app/common/helpers/route';
 import reactStringReplace from 'react-string-replace';
-import { Payment, Paymentable } from '$app/common/interfaces/payment';
+import { InvoicePaymentAllocationBox } from './InvoicePaymentAllocationBox';
+import { getInvoicePaymentAllocationRows } from '../helpers/invoicePaymentAllocations';
 import { Tooltip } from '$app/components/Tooltip';
 import React, { useEffect, useState } from 'react';
 import { EmailRecord as EmailRecordType } from '$app/common/interfaces/email-history';
@@ -70,7 +70,6 @@ import { History } from '$app/components/icons/History';
 import { SquareActivityChart } from '$app/components/icons/SquareActivityChart';
 import { Icon } from '$app/components/icons/Icon';
 import { ChevronRight } from 'react-feather';
-import { dateUTC } from '$app/common/helpers/payment';
 
 export const invoiceSliderAtom = atom<Invoice | null>(null);
 export const invoiceSliderVisibilityAtom = atom(false);
@@ -94,14 +93,6 @@ const HistoryBox = styled.div`
 `;
 
 const ActivityBox = styled.div`
-  background-color: ${({ theme }) => theme.backgroundColor};
-
-  &:hover {
-    background-color: ${({ theme }) => theme.hoverBackgroundColor};
-  }
-`;
-
-const PaymentableBox = styled.div`
   background-color: ${({ theme }) => theme.backgroundColor};
 
   &:hover {
@@ -234,7 +225,7 @@ export function InvoiceSlider() {
       request(
         'GET',
         endpoint(
-          `/api/v1/invoices/${invoice?.id}?include=payments,activities.history&reminder_schedule=true&show_schedule=true`
+          `/api/v1/invoices/${invoice?.id}?include=paymentables,payments,activities.history&reminder_schedule=true&show_schedule=true`
         )
       ).then(
         (response: GenericSingleResourceResponse<Invoice>) => response.data.data
@@ -242,6 +233,8 @@ export function InvoiceSlider() {
     enabled: invoice !== null && isVisible,
     staleTime: Infinity,
   });
+
+  const paymentAllocationRows = getInvoicePaymentAllocationRows(resource);
 
   const fetchEmailHistory = async () => {
     const response = await queryClient
@@ -530,68 +523,16 @@ export function InvoiceSlider() {
             </>
           ) : null}
 
-          {Boolean(resource?.payments?.length) && (
+          {invoice && Boolean(paymentAllocationRows.length) && (
             <div className="flex flex-col space-y-4 px-6 py-5">
-              {resource?.payments &&
-                resource.payments.map((payment: Payment) =>
-                  payment.paymentables
-                    .filter(
-                      (item) =>
-                        item.invoice_id === invoice?.id &&
-                        item.archived_at === 0
-                    )
-                    .map((paymentable: Paymentable) => (
-                      <PaymentableBox
-                        key={payment.id}
-                        className="flex flex-col items-start justify-center space-y-2 shadow-sm text-sm border p-5 w-full cursor-pointer rounded-md"
-                        onClick={() => {
-                          !disableNavigation('payment', payment) &&
-                            navigate(
-                              route('/payments/:id/edit', {
-                                id: payment.id,
-                              })
-                            );
-                        }}
-                        style={{
-                          borderColor: colors.$20,
-                        }}
-                        theme={{
-                          backgroundColor: colors.$1,
-                          hoverBackgroundColor: colors.$4,
-                        }}
-                      >
-                        <span
-                          className="font-medium"
-                          style={{ color: colors.$3 }}
-                        >
-                          {t('payment')} {payment.number}
-                        </span>
-
-                        <div
-                          className="inline-flex items-center space-x-1"
-                          style={{ color: colors.$17 }}
-                        >
-                          <span>
-                            {formatMoney(
-                              paymentable.amount,
-                              invoice?.client?.country_id,
-                              invoice?.client?.settings.currency_id
-                            )}
-                          </span>
-
-                          <span>-</span>
-
-                          <span>
-                            {dateUTC(paymentable.created_at, dateFormat)}
-                          </span>
-                        </div>
-
-                        <div>
-                          <PaymentStatus entity={payment} />
-                        </div>
-                      </PaymentableBox>
-                    ))
-                )}
+              {paymentAllocationRows.map((row) => (
+                <InvoicePaymentAllocationBox
+                  key={row.paymentable.id}
+                  row={row}
+                  invoice={invoice}
+                  dateFormat={dateFormat}
+                />
+              ))}
             </div>
           )}
 

--- a/src/pages/invoices/common/helpers/invoicePaymentAllocations.ts
+++ b/src/pages/invoices/common/helpers/invoicePaymentAllocations.ts
@@ -1,0 +1,95 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { Invoice } from '$app/common/interfaces/invoice';
+import { Payment, Paymentable } from '$app/common/interfaces/payment';
+
+export interface InvoicePaymentAllocationRow {
+  paymentable: Paymentable;
+  payment: Payment;
+}
+
+function isActiveInvoicePaymentable(
+  invoice: Invoice,
+  paymentable: Paymentable,
+  allowMissingInvoiceId = false
+) {
+  return (
+    paymentable.archived_at === 0 &&
+    (paymentable.invoice_id === invoice.id ||
+      (allowMissingInvoiceId && !paymentable.invoice_id))
+  );
+}
+
+function buildPaymentByPaymentableIdMap(payments: Payment[]) {
+  return new Map(
+    payments.flatMap((payment) =>
+      (payment.paymentables ?? []).map(
+        (paymentable) => [paymentable.id, payment] as const
+      )
+    )
+  );
+}
+
+export function getInvoicePaymentAllocationRows(
+  invoice: Invoice | undefined
+): InvoicePaymentAllocationRow[] {
+  if (!invoice) {
+    return [];
+  }
+
+  const payments = invoice.payments ?? [];
+  const nestedPaymentableRows = payments.flatMap((payment) =>
+    (payment.paymentables ?? [])
+      .filter((paymentable) => isActiveInvoicePaymentable(invoice, paymentable))
+      .map((paymentable) => ({
+        paymentable,
+        payment,
+      }))
+  );
+
+  if (!invoice.paymentables?.length) {
+    return nestedPaymentableRows;
+  }
+
+  const paymentsById = new Map(
+    payments.map((payment) => [payment.id, payment] as const)
+  );
+  const paymentsByPaymentableId = buildPaymentByPaymentableIdMap(payments);
+
+  const topLevelPaymentableRows = invoice.paymentables.flatMap(
+    (paymentable): InvoicePaymentAllocationRow[] => {
+      if (!isActiveInvoicePaymentable(invoice, paymentable, true)) {
+        return [];
+      }
+
+      const payment = paymentable.payment_id
+        ? paymentsById.get(paymentable.payment_id)
+        : paymentsByPaymentableId.get(paymentable.id);
+
+      return payment ? [{ paymentable, payment }] : [];
+    }
+  );
+
+  if (!topLevelPaymentableRows.length) {
+    return nestedPaymentableRows;
+  }
+
+  const topLevelPaymentableIds = new Set(
+    topLevelPaymentableRows.map(({ paymentable }) => paymentable.id)
+  );
+
+  return [
+    ...topLevelPaymentableRows,
+    ...nestedPaymentableRows.filter(
+      ({ paymentable }) => !topLevelPaymentableIds.has(paymentable.id)
+    ),
+  ];
+}

--- a/src/pages/invoices/edit/components/Payments.tsx
+++ b/src/pages/invoices/edit/components/Payments.tsx
@@ -8,30 +8,15 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
-import { Paymentable } from '$app/common/interfaces/payment';
-
-import { useNavigate, useOutletContext } from 'react-router-dom';
+import { useOutletContext } from 'react-router-dom';
 import { Context } from '../Edit';
-import { useDisableNavigation } from '$app/common/hooks/useDisableNavigation';
-import { Payment } from '$app/common/interfaces/payment';
 import { useTranslation } from 'react-i18next';
-import { PaymentStatus } from '$app/pages/payments/common/components/PaymentStatus';
 import { useCurrentCompanyDateFormats } from '$app/common/hooks/useCurrentCompanyDateFormats';
-import { useFormatMoney } from '$app/common/hooks/money/useFormatMoney';
 import { Card } from '$app/components/cards';
-import styled from 'styled-components';
 import { useColorScheme } from '$app/common/colors';
-import { route } from '$app/common/helpers/route';
 import classNames from 'classnames';
-import { dateUTC } from '$app/common/helpers/payment';
-
-const Box = styled.div`
-  background-color: ${({ theme }) => theme.backgroundColor};
-
-  &:hover {
-    background-color: ${({ theme }) => theme.hoverBackgroundColor};
-  }
-`;
+import { InvoicePaymentAllocationBox } from '../../common/components/InvoicePaymentAllocationBox';
+import { getInvoicePaymentAllocationRows } from '../../common/helpers/invoicePaymentAllocations';
 
 function Payments() {
   const [t] = useTranslation();
@@ -41,11 +26,8 @@ function Payments() {
 
   const colors = useColorScheme();
 
-  const navigate = useNavigate();
-  const formatMoney = useFormatMoney();
-  const disableNavigation = useDisableNavigation();
-
   const { dateFormat } = useCurrentCompanyDateFormats();
+  const paymentAllocationRows = getInvoicePaymentAllocationRows(invoice);
 
   return (
     <Card
@@ -58,67 +40,20 @@ function Payments() {
     >
       <div
         className={classNames('flex justify-center w-full px-2 pt-2', {
-          'pb-10': invoice?.payments?.length,
-          'pb-6': !invoice?.payments?.length,
+          'pb-10': paymentAllocationRows.length,
+          'pb-6': !paymentAllocationRows.length,
         })}
       >
         <div className="flex flex-col space-y-2 w-full lg:w-2/4">
-          {invoice?.payments &&
-            invoice.payments.map((payment: Payment) =>
-              payment.paymentables
-                .filter(
-                  (item) =>
-                    item.invoice_id == invoice?.id && item.archived_at == 0
-                )
-                .map((paymentable: Paymentable) => (
-                  <Box
-                    key={payment.id}
-                    className="flex flex-col items-start justify-center space-y-2 shadow-sm text-sm border p-5 w-full cursor-pointer rounded-md"
-                    onClick={() => {
-                      !disableNavigation('payment', payment) &&
-                        navigate(
-                          route('/payments/:id/edit', {
-                            id: payment.id,
-                          })
-                        );
-                    }}
-                    style={{
-                      borderColor: colors.$20,
-                    }}
-                    theme={{
-                      backgroundColor: colors.$1,
-                      hoverBackgroundColor: colors.$4,
-                    }}
-                  >
-                    <span className="font-medium" style={{ color: colors.$3 }}>
-                      {t('payment')} {payment.number}
-                    </span>
-
-                    <div
-                      className="inline-flex items-center space-x-1"
-                      style={{ color: colors.$17 }}
-                    >
-                      <span>
-                        {formatMoney(
-                          paymentable.amount,
-                          invoice.client?.country_id,
-                          invoice.client?.settings.currency_id
-                        )}
-                      </span>
-
-                      <span>-</span>
-                        
-                      <span>
-                        {dateUTC(paymentable.created_at, dateFormat)}
-                      </span>
-                    </div>
-
-                    <div>
-                      <PaymentStatus entity={payment} />
-                    </div>
-                  </Box>
-                ))
-            )}
+          {invoice &&
+            paymentAllocationRows.map((row) => (
+              <InvoicePaymentAllocationBox
+                key={row.paymentable.id}
+                row={row}
+                invoice={invoice}
+                dateFormat={dateFormat}
+              />
+            ))}
         </div>
       </div>
     </Card>

--- a/src/pages/invoices/edit/hooks/useInvoiceSave.ts
+++ b/src/pages/invoices/edit/hooks/useInvoiceSave.ts
@@ -65,7 +65,11 @@ export function useHandleSave(params: Params) {
       apiEndpoint += 'save_default_footer=true';
     }
 
-    request('PUT', endpoint(apiEndpoint, { id: invoice.id }), invoice)
+    const invoicePayload = { ...invoice };
+
+    delete invoicePayload.paymentables;
+
+    request('PUT', endpoint(apiEndpoint, { id: invoice.id }), invoicePayload)
       .then(async () => {
         if (isDefaultTerms || isDefaultFooter) {
           await refreshCompanyUsers();


### PR DESCRIPTION
Changes the functionality around displaying an invoices payment from mthe Invoice context.

Previously we passed in the Payments, but this was not always displaying the correct data (ie applying an amount from the same payment was shown multiple times). 

In this implementation we pass in the invoices paymentables which are the most accurate representation of the total amount of payments applied to the invoice.

To support this, and backward compatibility with links to payments, we have introduced a payment_id prop on the paymentable transformer.

We have also extracted the components for reuse.