### PR TITLE
Refactor react_settings to prevent multiple re renders.

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -100,8 +100,9 @@ export default defineConfig({
    * Build first with: npx vite build --mode testing
    * This ensures VITE_* vars are loaded from .env.testing */
   webServer: {
-    command: 'npx vite preview',
+    command: 'npx vite build --mode testing && npx vite preview',
     port: 4173,
     reuseExistingServer: true,
+    timeout: 180_000, // give the build ~3 min to settle
   },
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,7 +44,10 @@ import {
 import { useWebSessionTimeout } from './common/hooks/useWebSessionTimeout';
 import { isPasswordRequiredAtom } from './common/atoms/password-confirmation';
 import { useSystemFonts } from './common/hooks/useSystemFonts';
-import { useReactSettings } from './common/hooks/useReactSettings';
+import {
+  useFetchReactSettings,
+  useReactSettings,
+} from './common/hooks/useReactSettings';
 import { useKeyboardShortcuts } from './common/hooks/useKeyboardShortcuts';
 import { useCompanyTranslations } from './common/hooks/useCompanyTranslations';
 
@@ -89,7 +92,9 @@ export function App() {
   const resolveDayJSLocale = useResolveDayJSLocale();
   const switchToCompanySettings = useSwitchToCompanySettings();
 
-  const reactSettings = useReactSettings({ overwrite: false });
+  useFetchReactSettings();
+
+  const reactSettings = useReactSettings();
   const setIsPasswordRequired = useSetAtom(isPasswordRequiredAtom);
   const setRefreshEntityDataBanner = useSetAtom(refreshEntityDataBannerAtom);
 

--- a/src/common/colors.ts
+++ b/src/common/colors.ts
@@ -85,7 +85,7 @@ export const lightColorScheme = {
 };
 
 export function useColorScheme() {
-  const reactSettings = useReactSettings({ overwrite: false });
+  const reactSettings = useReactSettings();
 
   return reactSettings.dark_mode ? darkColorScheme : lightColorScheme;
 }

--- a/src/common/hooks/useDataTablePreference.ts
+++ b/src/common/hooks/useDataTablePreference.ts
@@ -9,15 +9,14 @@
  */
 
 import { useAtomValue } from 'jotai';
-import { useUserChanges } from './useInjectUserChanges';
-import { TableFiltersPreference } from './useReactSettings';
+import { TableFiltersPreference, useReactSettings } from './useReactSettings';
 import { dataTableFiltersAtom } from './useStoreSessionTableFilters';
 
 interface Params {
   tableKey: string | undefined;
 }
 export function useDataTablePreference(params: Params) {
-  const user = useUserChanges();
+  const reactSettings = useReactSettings();
 
   const { tableKey } = params;
 
@@ -34,7 +33,7 @@ export function useDataTablePreference(params: Params) {
         : '';
     }
 
-    const tableFilters = user?.company_user?.react_settings.table_filters;
+    const tableFilters = reactSettings.table_filters;
 
     return tableFilters?.[tableKey]?.[filterKey]
       ? tableFilters[tableKey][filterKey]

--- a/src/common/hooks/useDataTablePreferences.ts
+++ b/src/common/hooks/useDataTablePreferences.ts
@@ -9,21 +9,20 @@
  */
 
 import { Dispatch, SetStateAction, useEffect, useRef } from 'react';
+import { useAtomValue } from 'jotai';
+import { reactSettingsAtom } from './useReactSettings';
 import { SelectOption } from '$app/components/datatables/Actions';
 import { useDataTablePreference } from './useDataTablePreference';
 import { PerPage } from '$app/components/DataTable';
-import { cloneDeep, isEqual, set } from 'lodash';
-import { User } from '../interfaces/user';
-import { $refetch } from './useRefetch';
-import { GenericSingleResourceResponse } from '../interfaces/generic-api-response';
-import { CompanyUser } from '../interfaces/company-user';
-import { endpoint } from '../helpers';
-import { request } from '../helpers/request';
-import { useDispatch } from 'react-redux';
-import { injectInChangesWithData, updateUser } from '../stores/slices/user';
+import { isEqual } from 'lodash';
 import { useStoreSessionTableFilters } from './useStoreSessionTableFilters';
 import { useCurrentUser } from './useCurrentUser';
 import { useLocation } from 'react-router-dom';
+import {
+  useReactSettings,
+  useSaveReactSettings,
+  useUpdateReactSettings,
+} from './useReactSettings';
 
 interface Params {
   apiEndpoint: URL;
@@ -46,9 +45,9 @@ interface Params {
 
 export function useDataTablePreferences(params: Params) {
   const user = useCurrentUser();
-  const dispatch = useDispatch();
-
-  const currentUserRef = useRef<User | undefined>();
+  const reactSettings = useReactSettings();
+  const updateSettings = useUpdateReactSettings();
+  const saveSettings = useSaveReactSettings();
 
   const {
     apiEndpoint,
@@ -72,20 +71,6 @@ export function useDataTablePreferences(params: Params) {
   const getPreference = useDataTablePreference({ tableKey });
   const storeSessionTableFilters = useStoreSessionTableFilters({ tableKey });
 
-  const handleUpdateUserPreferences = (updatedUser: User) => {
-    request(
-      'PUT',
-      endpoint('/api/v1/company_users/:id', { id: updatedUser.id }),
-      updatedUser
-    ).then((response: GenericSingleResourceResponse<CompanyUser>) => {
-      set(updatedUser, 'company_user', response.data.data);
-
-      $refetch(['company_users']);
-
-      currentUserRef.current = updatedUser;
-    });
-  };
-
   const handleUpdateTableFilters = (
     filter: string,
     sortedBy: string | undefined,
@@ -98,8 +83,7 @@ export function useDataTablePreferences(params: Params) {
       return;
     }
 
-    const currentTableFilters =
-      user?.company_user?.react_settings.table_filters?.[tableKey];
+    const currentTableFilters = reactSettings.table_filters?.[tableKey];
 
     const defaultFilters = {
       ...(customFilters && { customFilter: [] }),
@@ -118,14 +102,6 @@ export function useDataTablePreferences(params: Params) {
       ...(!withoutStoringPage && { currentPage }),
     };
 
-    if (currentTableFilters && withoutStoringPerPage) {
-      delete currentTableFilters.perPage;
-    }
-
-    if (currentTableFilters && withoutStoringPage) {
-      delete currentTableFilters.currentPage;
-    }
-
     storeSessionTableFilters(filter, currentPage);
 
     if (isEqual(defaultFilters, cleanedUpFilters) && !currentTableFilters) {
@@ -136,36 +112,43 @@ export function useDataTablePreferences(params: Params) {
       return;
     }
 
-    const updatedUser = cloneDeep(user) as User;
+    if (!user?.id) return;
 
-    if (updatedUser) {
-      // @Todo: This is a temporary solution for creating the table_filters object. It can be removed after some time.
-      const tableFilters =
-        updatedUser.company_user?.react_settings.table_filters || {};
-
-      Object.keys(tableFilters).forEach((key) => {
-        if (key.includes('/')) {
-          delete tableFilters[key];
-        }
-      });
-
-      set(
-        updatedUser,
-        `company_user.react_settings.table_filters.${tableKey}`,
-        cleanedUpFilters
-      );
-
-      handleUpdateUserPreferences(updatedUser as User);
-    }
+    // Legacy cleanup: prior versions used full URL paths as table_filters
+    // keys; strip those once before persisting.
+    const tableFilters = { ...(reactSettings.table_filters ?? {}) };
+    Object.keys(tableFilters).forEach((key) => {
+      if (key.includes('/')) {
+        delete tableFilters[key];
+      }
+    });
+    updateSettings('table_filters', tableFilters);
+    saveSettings(`table_filters.${tableKey}`, cleanedUpFilters);
   };
 
   const { pathname } = useLocation();
 
+  // Track whether we've already applied saved preferences for this table
+  // mount so the effect can re-run safely once the atom hydrates from null
+  // without clobbering user edits made after the initial apply. Resets
+  // when `tableKey` changes so a parent that reuses the hook across table
+  // routes correctly applies the new table's preferences.
+  const appliedRef = useRef<boolean>(false);
   useEffect(() => {
-    if (!isInitialConfiguration && !customFilter) {
-      // We wanna set filter only if we're on parent invoices page.
-      // Skip setting filter on other pages like client invoices.
+    appliedRef.current = false;
+  }, [tableKey]);
 
+  const rawAtom = useAtomValue(reactSettingsAtom);
+  const isHydrated = rawAtom !== null;
+
+  useEffect(() => {
+    // Hydration is synchronous (useLayoutEffect in useFetchReactSettings),
+    // so isHydrated is true by the time any table consumer's first
+    // effect fires. The check remains as a defence against an unmount race
+    // (logout while a table is mounted) where the atom is reset to null.
+    if (!isHydrated || appliedRef.current) return;
+
+    if (!isInitialConfiguration && !customFilter) {
       if (tableKey !== 'invoices') {
         setFilter((getPreference('filter') as string) || '');
       }
@@ -202,17 +185,9 @@ export function useDataTablePreferences(params: Params) {
       }
 
       setArePreferencesApplied(true);
+      appliedRef.current = true;
     }
-  }, [isInitialConfiguration]);
-
-  useEffect(() => {
-    return () => {
-      if (currentUserRef.current) {
-        dispatch(updateUser(currentUserRef.current));
-        dispatch(injectInChangesWithData(currentUserRef.current));
-      }
-    };
-  }, []);
+  }, [isInitialConfiguration, isHydrated]);
 
   return { handleUpdateTableFilters };
 }

--- a/src/common/hooks/useDataTablePreferences.ts
+++ b/src/common/hooks/useDataTablePreferences.ts
@@ -179,7 +179,7 @@ export function useDataTablePreferences(params: Params) {
       setArePreferencesApplied(true);
       appliedRef.current = true;
     }
-  }, [isInitialConfiguration, isHydrated]);
+  }, [isInitialConfiguration, isHydrated, tableKey]);
 
   return { handleUpdateTableFilters };
 }

--- a/src/common/hooks/useDataTablePreferences.ts
+++ b/src/common/hooks/useDataTablePreferences.ts
@@ -114,8 +114,7 @@ export function useDataTablePreferences(params: Params) {
 
     if (!user?.id) return;
 
-    // Legacy cleanup: prior versions used full URL paths as table_filters
-    // keys; strip those once before persisting.
+    // Strip legacy URL-shaped table filter keys before persisting.
     const tableFilters = { ...(reactSettings.table_filters ?? {}) };
     Object.keys(tableFilters).forEach((key) => {
       if (key.includes('/')) {
@@ -128,11 +127,7 @@ export function useDataTablePreferences(params: Params) {
 
   const { pathname } = useLocation();
 
-  // Track whether we've already applied saved preferences for this table
-  // mount so the effect can re-run safely once the atom hydrates from null
-  // without clobbering user edits made after the initial apply. Resets
-  // when `tableKey` changes so a parent that reuses the hook across table
-  // routes correctly applies the new table's preferences.
+  // Apply saved table preferences once per table key.
   const appliedRef = useRef<boolean>(false);
   useEffect(() => {
     appliedRef.current = false;
@@ -142,10 +137,7 @@ export function useDataTablePreferences(params: Params) {
   const isHydrated = rawAtom !== null;
 
   useEffect(() => {
-    // Hydration is synchronous (useLayoutEffect in useFetchReactSettings),
-    // so isHydrated is true by the time any table consumer's first
-    // effect fires. The check remains as a defence against an unmount race
-    // (logout while a table is mounted) where the atom is reset to null.
+    // Guards logout/unmount races where the atom has been reset to null.
     if (!isHydrated || appliedRef.current) return;
 
     if (!isInitialConfiguration && !customFilter) {

--- a/src/common/hooks/useHandleCollapseExpandSidebar.ts
+++ b/src/common/hooks/useHandleCollapseExpandSidebar.ts
@@ -14,9 +14,7 @@ export function useHandleCollapseExpandSidebar() {
   const save = useSaveReactSettings();
 
   return (value: boolean) => {
-    // Fire-and-forget; swallow the rejection so a transient network error
-    // doesn't surface as an unhandled promise rejection. The optimistic
-    // atom write already updated the UI; convergence on next save / reload.
+    // Fire-and-forget; the optimistic atom write already updated the UI.
     save('show_mini_sidebar', value).catch(() => undefined);
   };
 }

--- a/src/common/hooks/useHandleCollapseExpandSidebar.ts
+++ b/src/common/hooks/useHandleCollapseExpandSidebar.ts
@@ -8,30 +8,15 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
-import { useUpdateCompanyUser } from '$app/pages/settings/user/common/hooks/useUpdateCompanyUser';
-import { cloneDeep, set } from 'lodash';
-import { useHandleCurrentUserChangeProperty } from './useHandleCurrentUserChange';
-import { useInjectUserChanges } from './useInjectUserChanges';
+import { useSaveReactSettings } from './useReactSettings';
 
 export function useHandleCollapseExpandSidebar() {
-  const userChanges = useInjectUserChanges();
-
-  const updateCompanyUser = useUpdateCompanyUser();
-  const handleUserChange = useHandleCurrentUserChangeProperty();
+  const save = useSaveReactSettings();
 
   return (value: boolean) => {
-    handleUserChange('company_user.react_settings.show_mini_sidebar', value);
-
-    if (userChanges) {
-      const updatedUserChanges = cloneDeep(userChanges);
-
-      set(
-        updatedUserChanges,
-        'company_user.react_settings.show_mini_sidebar',
-        value
-      );
-
-      updateCompanyUser(updatedUserChanges);
-    }
+    // Fire-and-forget; swallow the rejection so a transient network error
+    // doesn't surface as an unhandled promise rejection. The optimistic
+    // atom write already updated the UI; convergence on next save / reload.
+    save('show_mini_sidebar', value).catch(() => undefined);
   };
 }

--- a/src/common/hooks/useHandleDarkLightMode.ts
+++ b/src/common/hooks/useHandleDarkLightMode.ts
@@ -8,26 +8,16 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
-import { useUpdateCompanyUser } from '$app/pages/settings/user/common/hooks/useUpdateCompanyUser';
-import { cloneDeep, set } from 'lodash';
-import { useHandleCurrentUserChangeProperty } from './useHandleCurrentUserChange';
-import { useInjectUserChanges } from './useInjectUserChanges';
+import { useSaveReactSettings } from './useReactSettings';
 
 export function useHandleDarkLightMode() {
-  const userChanges = useInjectUserChanges();
-
-  const updateCompanyUser = useUpdateCompanyUser();
-  const handleUserChange = useHandleCurrentUserChangeProperty();
+  const save = useSaveReactSettings();
 
   return (value: boolean) => {
-    handleUserChange('company_user.react_settings.dark_mode', value);
-
-    if (userChanges) {
-      const updatedUserChanges = cloneDeep(userChanges);
-
-      set(updatedUserChanges, 'company_user.react_settings.dark_mode', value);
-
-      updateCompanyUser(updatedUserChanges);
-    }
+    // Fire-and-forget; swallow the rejection so a transient network error
+    // doesn't surface as an unhandled promise rejection. The optimistic
+    // atom write already flipped the UI; convergence happens on the next
+    // successful save or page reload.
+    save('dark_mode', value).catch(() => undefined);
   };
 }

--- a/src/common/hooks/useHandleDarkLightMode.ts
+++ b/src/common/hooks/useHandleDarkLightMode.ts
@@ -14,10 +14,7 @@ export function useHandleDarkLightMode() {
   const save = useSaveReactSettings();
 
   return (value: boolean) => {
-    // Fire-and-forget; swallow the rejection so a transient network error
-    // doesn't surface as an unhandled promise rejection. The optimistic
-    // atom write already flipped the UI; convergence happens on the next
-    // successful save or page reload.
+    // Fire-and-forget; the optimistic atom write already flipped the UI.
     save('dark_mode', value).catch(() => undefined);
   };
 }

--- a/src/common/hooks/useOpenFeedbackSlider.ts
+++ b/src/common/hooks/useOpenFeedbackSlider.ts
@@ -1,87 +1,85 @@
 import { isFeedbackSliderVisible } from '$app/components/Feedback';
-import { useSetAtom } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
+import { useCallback, useEffect, useRef } from 'react';
 import { useCurrentUser } from './useCurrentUser';
-import { useReactSettings } from './useReactSettings';
+import {
+  reactSettingsAtom,
+  useSaveReactSettings,
+} from './useReactSettings';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
-import { request } from '../helpers/request';
-import { $refetch } from './useRefetch';
-import { GenericSingleResourceResponse } from '../interfaces/generic-api-response';
-import { CompanyUser } from '../interfaces/company-user';
-import { endpoint, isHosted } from '../helpers';
-import { cloneDeep, set } from 'lodash';
-import { resetChanges, updateUser } from '$app/common/stores/slices/user';
-import { useDispatch } from 'react-redux';
+import { isHosted } from '../helpers';
 
 dayjs.extend(utc);
 
 export function useOpenFeedbackSlider() {
-  const dispatch = useDispatch();
-
   const currentUser = useCurrentUser();
-  const reactSettings = useReactSettings();
+  // Subscribe to the raw atom so we can distinguish "not yet hydrated" from
+  // "hydrated with default-zero timestamps". Reading through
+  // `useReactSettings` would coalesce the null and bypass the
+  // do-not-ask-again opt-out for users whose preferences haven't loaded yet.
+  const reactSettings = useAtomValue(reactSettingsAtom);
+  const save = useSaveReactSettings();
 
   const setIsFeedbackSliderVisible = useSetAtom(isFeedbackSliderVisible);
 
-  const handleUpdateReactSettings = () => {
-    const currentUnixTime = dayjs().utc().unix();
+  // Track the pending setTimeout so it can be cancelled on unmount or on
+  // identity change. Without this, navigating away within the 1s window
+  // could flash the slider on a non-dashboard page and persist
+  // `feedback_slider_displayed_at` for a slider the user never saw.
+  const pendingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-    const updatedReactSettings = cloneDeep(reactSettings);
-
-    set(
-      updatedReactSettings,
-      'preferences.feedback_slider_displayed_at',
-      currentUnixTime
-    );
-
-    request(
-      'PUT',
-      endpoint('/api/v1/company_users/:id/preferences?include=company_user', {
-        id: currentUser?.id,
-      }),
-      {
-        react_settings: updatedReactSettings,
+  useEffect(() => {
+    return () => {
+      if (pendingTimeoutRef.current !== null) {
+        clearTimeout(pendingTimeoutRef.current);
+        pendingTimeoutRef.current = null;
       }
-    ).then((response: GenericSingleResourceResponse<CompanyUser>) => {
-      $refetch(['company_users']);
+    };
+  }, []);
 
-      dispatch(updateUser(response.data.data));
-      dispatch(resetChanges());
-    });
-  };
-
-  return () => {
+  return useCallback(() => {
     const isFeedbackFeatureDisabled =
       import.meta.env.VITE_DISABLE_FEEDBACK_FEATURE === 'true';
 
-    if (isHosted() && !isFeedbackFeatureDisabled) {
-      const isUserAccountOlderThan7Days =
-        currentUser &&
-        dayjs().diff(dayjs.unix(currentUser.created_at), 'days') > 7;
+    if (!isHosted() || isFeedbackFeatureDisabled) return;
 
-      const isHiddenByDoNotAskAgain =
-        reactSettings?.preferences.feedback_slider_displayed_at === -1;
+    // Bail until hydration. Anything else risks showing the slider to a
+    // user who already opted out.
+    if (reactSettings === null) return;
+    if (!currentUser) return;
 
-      const canShowSliderAgain =
-        !reactSettings?.preferences.feedback_slider_displayed_at ||
-        dayjs().diff(
-          dayjs.unix(reactSettings.preferences.feedback_slider_displayed_at),
-          'hours'
-        ) > 48;
+    const isUserAccountOlderThan7Days =
+      dayjs().diff(dayjs.unix(currentUser.created_at), 'days') > 7;
 
-      if (
-        !isHiddenByDoNotAskAgain &&
-        reactSettings &&
-        !reactSettings.preferences.feedback_given_at &&
-        canShowSliderAgain &&
-        isUserAccountOlderThan7Days
-      ) {
-        setTimeout(() => {
-          handleUpdateReactSettings();
+    const isHiddenByDoNotAskAgain =
+      reactSettings.preferences?.feedback_slider_displayed_at === -1;
 
-          setIsFeedbackSliderVisible(true);
-        }, 1000);
+    const canShowSliderAgain =
+      !reactSettings.preferences?.feedback_slider_displayed_at ||
+      dayjs().diff(
+        dayjs.unix(reactSettings.preferences.feedback_slider_displayed_at),
+        'hours'
+      ) > 48;
+
+    if (
+      !isHiddenByDoNotAskAgain &&
+      !reactSettings.preferences?.feedback_given_at &&
+      canShowSliderAgain &&
+      isUserAccountOlderThan7Days
+    ) {
+      // Cancel any prior pending schedule so we don't double-fire.
+      if (pendingTimeoutRef.current !== null) {
+        clearTimeout(pendingTimeoutRef.current);
       }
+      pendingTimeoutRef.current = setTimeout(() => {
+        pendingTimeoutRef.current = null;
+        save(
+          'preferences.feedback_slider_displayed_at',
+          dayjs().utc().unix()
+        );
+        setIsFeedbackSliderVisible(true);
+      }, 1000);
     }
-  };
+  }, [reactSettings, currentUser, save, setIsFeedbackSliderVisible]);
 }

--- a/src/common/hooks/useOpenFeedbackSlider.ts
+++ b/src/common/hooks/useOpenFeedbackSlider.ts
@@ -23,6 +23,12 @@ export function useOpenFeedbackSlider() {
 
   const setIsFeedbackSliderVisible = useSetAtom(isFeedbackSliderVisible);
 
+  const reactSettingsRef = useRef(reactSettings);
+  reactSettingsRef.current = reactSettings;
+
+  const currentUserRef = useRef(currentUser);
+  currentUserRef.current = currentUser;
+
   // Track the pending setTimeout so it can be cancelled on unmount or on
   // identity change. Without this, navigating away within the 1s window
   // could flash the slider on a non-dashboard page and persist
@@ -46,25 +52,25 @@ export function useOpenFeedbackSlider() {
 
     // Bail until hydration. Anything else risks showing the slider to a
     // user who already opted out.
-    if (reactSettings === null) return;
-    if (!currentUser) return;
+    if (reactSettingsRef.current === null) return;
+    if (!currentUserRef.current) return;
 
     const isUserAccountOlderThan7Days =
-      dayjs().diff(dayjs.unix(currentUser.created_at), 'days') > 7;
+      dayjs().diff(dayjs.unix(currentUserRef.current.created_at), 'days') > 7;
 
     const isHiddenByDoNotAskAgain =
-      reactSettings.preferences?.feedback_slider_displayed_at === -1;
+      reactSettingsRef.current.preferences?.feedback_slider_displayed_at === -1;
 
     const canShowSliderAgain =
-      !reactSettings.preferences?.feedback_slider_displayed_at ||
+      !reactSettingsRef.current.preferences?.feedback_slider_displayed_at ||
       dayjs().diff(
-        dayjs.unix(reactSettings.preferences.feedback_slider_displayed_at),
+        dayjs.unix(reactSettingsRef.current.preferences.feedback_slider_displayed_at),
         'hours'
       ) > 48;
 
     if (
       !isHiddenByDoNotAskAgain &&
-      !reactSettings.preferences?.feedback_given_at &&
+      !reactSettingsRef.current.preferences?.feedback_given_at &&
       canShowSliderAgain &&
       isUserAccountOlderThan7Days
     ) {
@@ -81,5 +87,5 @@ export function useOpenFeedbackSlider() {
         setIsFeedbackSliderVisible(true);
       }, 1000);
     }
-  }, [reactSettings, currentUser, save, setIsFeedbackSliderVisible]);
+  }, [save, setIsFeedbackSliderVisible]);
 }

--- a/src/common/hooks/usePreferences.tsx
+++ b/src/common/hooks/usePreferences.tsx
@@ -10,25 +10,21 @@
 
 import { Modal } from '$app/components/Modal';
 import { Button } from '$app/components/forms';
-import { ReactNode, useMemo, useState } from 'react';
+import { ReactNode, useCallback, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useInjectUserChanges } from './useInjectUserChanges';
-import { ReactSettings, useReactSettings } from './useReactSettings';
-import { useDispatch, useStore } from 'react-redux';
-import { resetChanges, updateChanges, updateUser } from '../stores/slices/user';
+import {
+  ReactSettings,
+  reactSettingsAtom,
+  rollbackReactSettingsPaths,
+  useFlushReactSettings,
+  useReactSettings,
+  useUpdateReactSettings,
+} from './useReactSettings';
+import { getDefaultStore, useSetAtom } from 'jotai';
 import { toast } from '../helpers/toast/toast';
-import { request } from '../helpers/request';
-import { endpoint } from '../helpers';
-import { ValidationBag } from '../interfaces/validation-bag';
-import { AxiosError } from 'axios';
-import { RootState } from '../stores/store';
-import { GenericSingleResourceResponse } from '../interfaces/generic-api-response';
-import { CompanyUser } from '../interfaces/company-user';
-import { $refetch } from './useRefetch';
-import { useCurrentUser } from './useCurrentUser';
-import { isEqual } from 'lodash';
 import { Gear } from '$app/components/icons/Gear';
 import { useColorScheme } from '../colors';
+import { cloneDeep, get as lodashGet, set as lodashSet } from 'lodash';
 
 type AutoCompleteKey<T, Prefix extends string = ''> = keyof T extends never
   ? Prefix
@@ -61,67 +57,131 @@ interface SaveOptions {
 }
 
 export function usePreferences() {
-  const currentUser = useCurrentUser();
-  const user = useInjectUserChanges({ overwrite: false });
+  const updateSettings = useUpdateReactSettings();
+  const flushSettings = useFlushReactSettings();
+  const setSettings = useSetAtom(reactSettingsAtom);
 
   const [t] = useTranslation();
 
   const colors = useColorScheme();
+  const settings = useReactSettings();
 
   const [isVisible, setIsVisible] = useState<boolean>(false);
-  const [errors, setErrors] = useState<ValidationBag | null>(null);
+  const [draftSettings, setDraftSettings] = useState<ReactSettings | null>(null);
+  const draftDirtyPathsRef = useRef<string[]>([]);
 
-  const dispatch = useDispatch();
-
-  const update: UpdateFn<ReactSettings> = (property, value) => {
-    return dispatch(
-      updateChanges({
-        property: `company_user.react_settings.${property}`,
-        value: value,
-      })
-    );
-  };
-
-  const { getState } = useStore<RootState>();
-
-  const save = async ({ silent }: SaveOptions) => {
-    if (
-      isEqual(
-        currentUser?.company_user?.react_settings,
-        getState().user.changes.company_user.react_settings
-      )
-    ) {
-      return;
+  const activeSettings = useMemo(() => {
+    if (draftSettings === null) {
+      return settings;
     }
 
-    !silent && toast.processing();
+    const merged = cloneDeep(settings);
+    for (const path of draftDirtyPathsRef.current) {
+      lodashSet(
+        merged as object,
+        path,
+        cloneDeep(lodashGet(draftSettings, path))
+      );
+    }
 
-    request(
-      'PUT',
-      endpoint(
-        `/api/v1/company_users/${user?.id}/preferences?include=company_user`
-      ),
-      {
-        react_settings: getState().user.changes.company_user.react_settings,
-      }
-    )
-      .then((response: GenericSingleResourceResponse<CompanyUser>) => {
-        !silent && toast.success('updated_user');
+    return merged;
+  }, [draftSettings, settings]);
 
-        $refetch(['company_users']);
+  const update: UpdateFn<ReactSettings> = useCallback(
+    (property, value) => {
+      const propertyPath = property as string;
 
-        dispatch(updateUser(response.data.data));
-        dispatch(resetChanges());
-        setIsVisible(false);
-      })
-      .catch((error: AxiosError<ValidationBag>) => {
-        silent && toast.dismiss();
-
-        if (error.response?.status === 412) {
-          setErrors(error.response.data);
+      if (draftSettings !== null) {
+        if (!draftDirtyPathsRef.current.includes(propertyPath)) {
+          draftDirtyPathsRef.current = [
+            ...draftDirtyPathsRef.current,
+            propertyPath,
+          ];
         }
-      });
-  };
+
+        setDraftSettings((current) => {
+          if (current === null) return current;
+
+          const next = cloneDeep(current);
+          lodashSet(next as object, propertyPath, value);
+          return next;
+        });
+        return;
+      }
+
+      updateSettings(propertyPath, value);
+    },
+    [draftSettings, updateSettings]
+  );
+
+  const openModal = useCallback(() => {
+    if (getDefaultStore().get(reactSettingsAtom) === null) return;
+
+    draftDirtyPathsRef.current = [];
+    setDraftSettings(cloneDeep(settings));
+    setIsVisible(true);
+  }, [settings]);
+
+  const closeModal = useCallback(() => {
+    draftDirtyPathsRef.current = [];
+    setDraftSettings(null);
+    setIsVisible(false);
+  }, []);
+
+  const save = useCallback(
+    async ({ silent }: SaveOptions) => {
+      !silent && toast.processing();
+
+      const draft = draftSettings;
+      const dirtyPaths = [...draftDirtyPathsRef.current];
+      const previous = getDefaultStore().get(reactSettingsAtom);
+      let nextSettings: ReactSettings | null = null;
+
+      try {
+        if (draft !== null) {
+          if (dirtyPaths.length === 0) {
+            !silent && toast.success('updated_user');
+            draftDirtyPathsRef.current = [];
+            setDraftSettings(null);
+            setIsVisible(false);
+            return;
+          }
+
+          nextSettings = cloneDeep(previous ?? draft);
+
+          for (const path of dirtyPaths) {
+            lodashSet(
+              nextSettings as object,
+              path,
+              cloneDeep(lodashGet(draft, path))
+            );
+          }
+
+          setSettings(nextSettings);
+        }
+
+        await flushSettings();
+        !silent && toast.success('updated_user');
+        draftDirtyPathsRef.current = [];
+        setDraftSettings(null);
+        setIsVisible(false);
+      } catch {
+        if (nextSettings !== null) {
+          setSettings(
+            rollbackReactSettingsPaths(
+              getDefaultStore().get(reactSettingsAtom),
+              nextSettings,
+              previous,
+              dirtyPaths
+            )
+          );
+        }
+
+        toast.dismiss();
+      }
+    },
+    [draftSettings, flushSettings, setSettings]
+  );
 
   const Preferences = useMemo(
     () =>
@@ -130,18 +190,20 @@ export function usePreferences() {
           <>
             <Modal
               visible={isVisible}
-              onClose={setIsVisible}
+              onClose={closeModal}
               title={t('preferences')}
               overflowVisible
             >
               {children}
 
-              <Button onClick={save}>{t('save')}</Button>
+              <Button onClick={() => save({ silent: false })}>
+                {t('save')}
+              </Button>
             </Modal>
 
             <div
               className="flex items-center justify-center p-2 cursor-pointer border rounded-md shadow-sm"
-              onClick={() => setIsVisible(true)}
+              onClick={openModal}
               style={{
                 backgroundColor: colors.$1,
                 borderColor: colors.$24,
@@ -152,10 +214,8 @@ export function usePreferences() {
           </>
         );
       },
-    [isVisible, errors]
+    [colors.$1, colors.$24, colors.$3, closeModal, isVisible, openModal, save, t]
   );
 
-  const settings = useReactSettings();
-
-  return { Preferences, update, preferences: settings.preferences, save };
+  return { Preferences, update, preferences: activeSettings.preferences, save };
 }

--- a/src/common/hooks/useReactSettings.ts
+++ b/src/common/hooks/useReactSettings.ts
@@ -243,7 +243,6 @@ export function useUpdateDraftOrReactSettings() {
       const draft = getDefaultStore().get(userDetailsDraftAtom);
       if (draft === null) {
         if (import.meta.env.DEV) {
-          // eslint-disable-next-line no-console
           console.warn(
             `[useUpdateDraftOrReactSettings] dropping write to "${property}" - no UserDetails draft is active`
           );
@@ -337,7 +336,6 @@ export function useUpdateReactSettings() {
       setSettings((prev) => {
         if (prev === null) {
           if (import.meta.env.DEV) {
-            // eslint-disable-next-line no-console
             console.warn(
               `[useUpdateReactSettings] dropping write to "${property}" - atom not yet hydrated`
             );

--- a/src/common/hooks/useReactSettings.ts
+++ b/src/common/hooks/useReactSettings.ts
@@ -9,14 +9,28 @@
  */
 
 import { RootState } from '$app/common/stores/store';
+import { atom, getDefaultStore, useAtomValue, useSetAtom } from 'jotai';
+import { selectAtom } from 'jotai/utils';
+import {
+  cloneDeep,
+  get as lodashGet,
+  has as lodashHas,
+  isEqual,
+  mergeWith,
+  set as lodashSet,
+  unset as lodashUnset,
+} from 'lodash';
+import { useCallback, useLayoutEffect, useMemo, useRef } from 'react';
 import { useSelector } from 'react-redux';
-import { useInjectUserChanges } from './useInjectUserChanges';
-import { cloneDeep, merge } from 'lodash';
+import { endpoint } from '../helpers';
+import { request } from '../helpers/request';
+import type { User } from '../interfaces/user';
 import { Record as ClientMapRecord } from '../constants/exports/client-map';
 import { Entity } from '$app/components/CommonActionsPreferenceModal';
 import { PerPage } from '$app/components/DataTable';
 import { ThemeColorField } from '$app/pages/settings/user/components/StatusColorTheme';
 import { ClientShowCard } from '$app/pages/clients/show/components/CardsCustomizationModal';
+import { useCurrentUser } from './useCurrentUser';
 
 export type ChartsDefaultView = 'day' | 'week' | 'month';
 
@@ -124,34 +138,359 @@ export const preferencesDefaults: Preferences = {
   price_increase_banner_dismissed_at: 0,
 };
 
-interface Options {
-  overwrite?: boolean;
-}
+// Committed `react_settings`, hydrated from the auth user payload.
+// `null` means there is no active user yet.
+export const reactSettingsAtom = atom<ReactSettings | null>(null);
 
-export function useReactSettings(options?: Options) {
-  const user = useInjectUserChanges({ overwrite: options?.overwrite });
+// UserDetails-scoped draft; keeps page edits out of unrelated immediate saves.
+export const userDetailsDraftAtom = atom<ReactSettings | null>(null);
+export const userDetailsDraftDirtyPathsAtom = atom<string[]>([]);
 
-  const reactSettings =
-    useSelector(
-      (state: RootState) => state.user.changes?.company_user?.react_settings
-    ) || {};
-
-  const previousReactTableColumns =
-    user?.company_user?.settings?.react_table_columns;
-
-  const settings: ReactSettings = {
+function withDefaults(settings: ReactSettings | null): ReactSettings {
+  const base: ReactSettings = {
     show_pdf_preview: true,
     react_notification_link: true,
-    // This is legacy fallback for old settings location. If you see this in 2 years, feel free to remove it.
-    react_table_columns: {
-      ...previousReactTableColumns,
-      ...reactSettings.react_table_columns,
-    },
+    react_table_columns: {} as Record<ReactTableColumns, string[]>,
     preferences: cloneDeep(preferencesDefaults),
   };
 
-  return merge<ReactSettings, ReactSettings>(
-    { ...settings },
-    { ...reactSettings }
+  // Replace arrays during default merge; lodash.merge would merge by index.
+  return mergeWith(
+    base,
+    (settings ?? {}) as ReactSettings,
+    (_objValue, srcValue) => (Array.isArray(srcValue) ? srcValue : undefined)
   );
+}
+
+export function rollbackReactSettingsPaths(
+  current: ReactSettings | null,
+  failed: ReactSettings,
+  previous: ReactSettings | null,
+  paths: string[]
+): ReactSettings | null {
+  if (current === null) {
+    return previous;
+  }
+
+  const rolledBack = cloneDeep(current);
+
+  for (const path of paths) {
+    if (!isEqual(lodashGet(current, path), lodashGet(failed, path))) {
+      continue;
+    }
+
+    if (previous !== null && lodashHas(previous, path)) {
+      lodashSet(
+        rolledBack as object,
+        path,
+        cloneDeep(lodashGet(previous, path))
+      );
+    } else {
+      lodashUnset(rolledBack as object, path);
+    }
+  }
+
+  return rolledBack;
+}
+
+export const reactSettingsWithDefaultsAtom = atom((get) =>
+  withDefaults(get(reactSettingsAtom))
+);
+
+export function useReactSettings() {
+  return useAtomValue(reactSettingsWithDefaultsAtom);
+}
+
+// Focused subscription for primitives that should ignore unrelated writes.
+export function useReactSettingsField<K extends keyof ReactSettings>(
+  key: K
+): ReactSettings[K] {
+  const fieldAtom = useMemo(
+    () => selectAtom(reactSettingsWithDefaultsAtom, (s) => s[key]),
+    [key]
+  );
+  return useAtomValue(fieldAtom);
+}
+
+// Shared derived atom so draft readers share one subscription/merge pass.
+export const draftOrCommittedReactSettingsAtom = atom((get) => {
+  const draft = get(userDetailsDraftAtom);
+  const committed = get(reactSettingsAtom);
+
+  if (draft === null) {
+    return withDefaults(committed);
+  }
+
+  const merged = cloneDeep(committed ?? draft);
+  for (const path of get(userDetailsDraftDirtyPathsAtom)) {
+    lodashSet(merged as object, path, cloneDeep(lodashGet(draft, path)));
+  }
+
+  return withDefaults(merged);
+});
+
+export function useDraftOrCommittedReactSettings(): ReactSettings {
+  return useAtomValue(draftOrCommittedReactSettingsAtom);
+}
+
+// Draft-only writer; refusing missing drafts prevents accidental committed writes.
+export function useUpdateDraftOrReactSettings() {
+  const setDraft = useSetAtom(userDetailsDraftAtom);
+  const setDirtyPaths = useSetAtom(userDetailsDraftDirtyPathsAtom);
+
+  return useMemo(
+    () => (property: string, value: unknown) => {
+      const draft = getDefaultStore().get(userDetailsDraftAtom);
+      if (draft === null) {
+        if (import.meta.env.DEV) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[useUpdateDraftOrReactSettings] dropping write to "${property}" - no UserDetails draft is active`
+          );
+        }
+        return;
+      }
+      setDirtyPaths((prev) =>
+        prev.includes(property) ? prev : [...prev, property]
+      );
+      setDraft((prev) => {
+        if (prev === null) return prev;
+        const next = cloneDeep(prev);
+        lodashSet(next as object, property, value);
+        return next;
+      });
+    },
+    [setDirtyPaths, setDraft]
+  );
+}
+
+export function useUserDetailsDraft() {
+  const setDraft = useSetAtom(userDetailsDraftAtom);
+  const setDirtyPaths = useSetAtom(userDetailsDraftDirtyPathsAtom);
+  const setReactSettings = useSetAtom(reactSettingsAtom);
+  const flush = useFlushReactSettings();
+
+  return useMemo(
+    () => ({
+      begin: () => {
+        const committed = getDefaultStore().get(reactSettingsAtom);
+        if (committed !== null) {
+          setDraft(cloneDeep(committed));
+          setDirtyPaths([]);
+        }
+      },
+      commit: async (): Promise<unknown> => {
+        const draft = getDefaultStore().get(userDetailsDraftAtom);
+        if (draft === null) return undefined;
+        const dirtyPaths = getDefaultStore().get(userDetailsDraftDirtyPathsAtom);
+        if (dirtyPaths.length === 0) {
+          setDraft(null);
+          setDirtyPaths([]);
+          return undefined;
+        }
+        const previous = getDefaultStore().get(reactSettingsAtom);
+        const nextSettings = cloneDeep(previous ?? draft);
+
+        for (const path of dirtyPaths) {
+          lodashSet(
+            nextSettings as object,
+            path,
+            cloneDeep(lodashGet(draft, path))
+          );
+        }
+
+        setReactSettings(nextSettings);
+        try {
+          await flush();
+          setDraft(null);
+          setDirtyPaths([]);
+          return undefined;
+        } catch (err) {
+          // Roll back only this draft's paths; concurrent immediate writes stay intact.
+          setReactSettings(
+            rollbackReactSettingsPaths(
+              getDefaultStore().get(reactSettingsAtom),
+              nextSettings,
+              previous,
+              dirtyPaths
+            )
+          );
+          throw err;
+        }
+      },
+      discard: () => {
+        setDraft(null);
+        setDirtyPaths([]);
+      },
+    }),
+    [setDirtyPaths, setDraft, setReactSettings, flush]
+  );
+}
+
+// Update the committed atom without a network request.
+// Cancelable controls should stay local/draft-only until Save.
+export function useUpdateReactSettings() {
+  const setSettings = useSetAtom(reactSettingsAtom);
+
+  return useMemo(
+    () => (property: string, value: unknown) => {
+      setSettings((prev) => {
+        if (prev === null) {
+          if (import.meta.env.DEV) {
+            // eslint-disable-next-line no-console
+            console.warn(
+              `[useUpdateReactSettings] dropping write to "${property}" - atom not yet hydrated`
+            );
+          }
+          return prev;
+        }
+        const next = cloneDeep(prev);
+        lodashSet(next as object, property, value);
+        return next;
+      });
+    },
+    [setSettings]
+  );
+}
+
+// Serialize PUTs; each queued request reads the atom when it fires.
+let inflight: Promise<unknown> = Promise.resolve();
+
+// Bumped on identity change so queued PUTs for a previous user abort.
+let identityEpoch = 0;
+
+export class ReactSettingsNotHydratedError extends Error {
+  constructor() {
+    super('react_settings atom is not hydrated yet');
+    this.name = 'ReactSettingsNotHydratedError';
+  }
+}
+
+export class ReactSettingsIdentityChangedError extends Error {
+  constructor() {
+    super('react_settings identity changed before PUT could fire');
+    this.name = 'ReactSettingsIdentityChangedError';
+  }
+}
+
+function resetInflight() {
+  inflight = Promise.resolve();
+}
+
+function flushAtom(userId: string): Promise<unknown> {
+  const capturedEpoch = identityEpoch;
+
+  const next = inflight
+    .catch(() => undefined)
+    .then(() => {
+      if (identityEpoch !== capturedEpoch) {
+        throw new ReactSettingsIdentityChangedError();
+      }
+
+      const payload = getDefaultStore().get(reactSettingsAtom);
+      if (payload === null) {
+        throw new ReactSettingsNotHydratedError();
+      }
+
+      return request(
+        'PUT',
+        endpoint(`/api/v1/company_users/${userId}/preferences`),
+        { react_settings: payload }
+      );
+    });
+
+  inflight = next;
+  return next;
+}
+
+// Hydrate from the auth user payload before paint; no separate GET is needed.
+export function useFetchReactSettings(): void {
+  const user = useCurrentUser();
+  const setSettings = useSetAtom(reactSettingsAtom);
+  const setUserDetailsDraft = useSetAtom(userDetailsDraftAtom);
+  const setUserDetailsDraftDirtyPaths = useSetAtom(
+    userDetailsDraftDirtyPathsAtom
+  );
+  const lastIdentityRef = useRef<string | null>(null);
+
+  useLayoutEffect(() => {
+    if (!user || !user.id) {
+      if (lastIdentityRef.current !== null) {
+        lastIdentityRef.current = null;
+        identityEpoch += 1;
+        resetInflight();
+        setUserDetailsDraft(null);
+        setUserDetailsDraftDirtyPaths([]);
+        setSettings(null);
+      }
+      return;
+    }
+
+    const identity = `${user.id}:${user.company_user?.company?.id ?? ''}`;
+    if (identity === lastIdentityRef.current) return;
+
+    // Abort any pending saves for the previous identity.
+    lastIdentityRef.current = identity;
+    identityEpoch += 1;
+    resetInflight();
+    setUserDetailsDraft(null);
+    setUserDetailsDraftDirtyPaths([]);
+
+    const serverSettings = (user.company_user?.react_settings ??
+      {}) as ReactSettings;
+
+    // Fold legacy table columns into the new location without writing an empty key.
+    const legacyTableColumns = (user.company_user?.settings as
+      | { react_table_columns?: Record<ReactTableColumns, string[]> }
+      | undefined)?.react_table_columns;
+
+    const mergedTableColumns = {
+      ...(legacyTableColumns ?? {}),
+      ...(serverSettings.react_table_columns ?? {}),
+    } as Record<ReactTableColumns, string[]>;
+
+    const hydrated: ReactSettings = { ...serverSettings };
+    if (Object.keys(mergedTableColumns).length > 0) {
+      hydrated.react_table_columns = mergedTableColumns;
+    }
+
+    setSettings(hydrated);
+  }, [user, setSettings, setUserDetailsDraft, setUserDetailsDraftDirtyPaths]);
+}
+
+// Optimistic committed write + sequenced PUT. Shared saves are latest-state-wins;
+// cancelable flows keep local/draft state and roll back only their dirty paths.
+export function useSaveReactSettings() {
+  const updateSettings = useUpdateReactSettings();
+  const userId = useSelector(
+    (state: RootState) => (state.user.user as User | undefined)?.id
+  );
+
+  return useCallback(
+    (property: string, value: unknown) => {
+      updateSettings(property, value);
+      if (!userId) return Promise.resolve();
+
+      return flushAtom(userId).catch((err) => {
+        if (err instanceof ReactSettingsNotHydratedError) return undefined;
+        throw err;
+      });
+    },
+    [updateSettings, userId]
+  );
+}
+
+// PUT the current atom snapshot without applying another local write.
+export function useFlushReactSettings() {
+  const userId = useSelector(
+    (state: RootState) => (state.user.user as User | undefined)?.id
+  );
+
+  return useCallback(() => {
+    if (!userId) return Promise.resolve();
+    return flushAtom(userId).catch((err) => {
+      if (err instanceof ReactSettingsNotHydratedError) return undefined;
+      throw err;
+    });
+  }, [userId]);
 }

--- a/src/common/hooks/useShowActionByPreferences.ts
+++ b/src/common/hooks/useShowActionByPreferences.ts
@@ -10,14 +10,14 @@
 
 import { Entity } from '$app/components/CommonActionsPreferenceModal';
 import { useEntityPageIdentifier } from './useEntityPageIdentifier';
-import { useCurrentUser } from './useCurrentUser';
+import { useReactSettings } from './useReactSettings';
 
 interface Params {
   commonActionsSection: boolean;
   entity: Entity;
 }
 export function useShowActionByPreferences(params: Params) {
-  const user = useCurrentUser();
+  const reactSettings = useReactSettings();
 
   const { commonActionsSection, entity } = params;
 
@@ -28,8 +28,7 @@ export function useShowActionByPreferences(params: Params) {
       return true;
     }
 
-    const commonActionsPreferences =
-      user?.company_user?.react_settings.common_actions;
+    const commonActionsPreferences = reactSettings.common_actions;
 
     if (!commonActionsSection && !commonActionsPreferences?.[entity]) {
       return true;

--- a/src/components/CommonActionsPreferenceModal.tsx
+++ b/src/components/CommonActionsPreferenceModal.tsx
@@ -8,21 +8,18 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
-import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import { Dispatch, SetStateAction, useEffect, useRef, useState } from 'react';
 import { Modal } from './Modal';
 import { Button, SelectField } from '$app/components/forms';
 import { useTranslation } from 'react-i18next';
 import { useAllCommonActions } from '$app/common/hooks/useCommonActions';
 import { useCurrentUser } from '$app/common/hooks/useCurrentUser';
-import { User } from '$app/common/interfaces/user';
-import { request } from '$app/common/helpers/request';
-import { endpoint } from '$app/common/helpers';
-import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-api-response';
-import { CompanyUser } from '$app/common/interfaces/company-user';
-import { cloneDeep, isEqual, set } from 'lodash';
-import { resetChanges, updateUser } from '$app/common/stores/slices/user';
-import { useDispatch } from 'react-redux';
-import { $refetch } from '$app/common/hooks/useRefetch';
+import { toast } from '$app/common/helpers/toast/toast';
+import { isEqual } from 'lodash';
+import {
+  useReactSettings,
+  useSaveReactSettings,
+} from '$app/common/hooks/useReactSettings';
 import {
   DragDropContext,
   Draggable,
@@ -57,15 +54,29 @@ export function CommonActionsPreferenceModal(props: Props) {
 
   const { entity, visible, setVisible } = props;
 
-  const dispatch = useDispatch();
-
   const user = useCurrentUser();
   const colors = useColorScheme();
   const commonActions = useAllCommonActions();
+  const reactSettings = useReactSettings();
+  const saveSettings = useSaveReactSettings();
 
   const [commonActionsPreferences, setCommonActionsPreferences] = useState<
     Partial<Record<Entity, string[]>> | undefined
-  >(user?.company_user?.react_settings?.common_actions);
+  >(reactSettings.common_actions);
+
+  // Sync local draft from the atom when it hydrates after mount (slow auth
+  // round-trip) or when the persisted value actually changes. `isEqual`
+  // (not reference equality) is required because `useUpdateReactSettings`
+  // deep-clones the whole atom on every write — unrelated writes (dark
+  // mode, sidebar collapse) would otherwise churn the reference and reset
+  // the user's in-progress edits.
+  const lastHydratedActionsRef = useRef(reactSettings.common_actions);
+  useEffect(() => {
+    if (!isEqual(reactSettings.common_actions, lastHydratedActionsRef.current)) {
+      lastHydratedActionsRef.current = reactSettings.common_actions;
+      setCommonActionsPreferences(reactSettings.common_actions);
+    }
+  }, [reactSettings.common_actions]);
 
   const [availableActions, setAvailableActions] = useState<CommonAction[]>([]);
 
@@ -74,10 +85,7 @@ export function CommonActionsPreferenceModal(props: Props) {
   const [selectedAction, setSelectedAction] = useState<string>('');
 
   const disableSaveButton = () => {
-    return isEqual(
-      user?.company_user?.react_settings.common_actions,
-      commonActionsPreferences
-    );
+    return isEqual(reactSettings.common_actions, commonActionsPreferences);
   };
 
   const getActionLabel = (actionKey: string) => {
@@ -87,26 +95,11 @@ export function CommonActionsPreferenceModal(props: Props) {
   };
 
   const handleUpdateUserDetails = () => {
-    const updatedUser = cloneDeep(user) as User;
-
-    set(
-      updatedUser,
-      'company_user.react_settings.common_actions',
-      commonActionsPreferences
-    );
-
-    request(
-      'PUT',
-      endpoint('/api/v1/company_users/:id', { id: updatedUser.id }),
-      updatedUser
-    ).then((response: GenericSingleResourceResponse<CompanyUser>) => {
-      set(updatedUser, 'company_user', response.data.data);
-
-      $refetch(['company_users']);
-
-      dispatch(updateUser(updatedUser));
-      dispatch(resetChanges());
-    });
+    if (!user?.id) return;
+    toast.processing();
+    saveSettings('common_actions', commonActionsPreferences)
+      .then(() => toast.success('updated_settings'))
+      .catch(() => toast.dismiss());
   };
 
   const handleRemoveAction = (actionKey: string) => {
@@ -146,8 +139,7 @@ export function CommonActionsPreferenceModal(props: Props) {
       current
         ? {
             ...current,
-            [entity]:
-              user?.company_user?.react_settings.common_actions?.[entity] || [],
+            [entity]: reactSettings.common_actions?.[entity] || [],
           }
         : {
             [entity]: [],
@@ -199,9 +191,7 @@ export function CommonActionsPreferenceModal(props: Props) {
       visible={visible}
       onClose={() => {
         setVisible(false);
-        setCommonActionsPreferences(
-          user?.company_user?.react_settings.common_actions
-        );
+        setCommonActionsPreferences(reactSettings.common_actions);
       }}
       overflowVisible
     >

--- a/src/components/CommonActionsPreferenceModal.tsx
+++ b/src/components/CommonActionsPreferenceModal.tsx
@@ -64,12 +64,7 @@ export function CommonActionsPreferenceModal(props: Props) {
     Partial<Record<Entity, string[]>> | undefined
   >(reactSettings.common_actions);
 
-  // Sync local draft from the atom when it hydrates after mount (slow auth
-  // round-trip) or when the persisted value actually changes. `isEqual`
-  // (not reference equality) is required because `useUpdateReactSettings`
-  // deep-clones the whole atom on every write — unrelated writes (dark
-  // mode, sidebar collapse) would otherwise churn the reference and reset
-  // the user's in-progress edits.
+  // Avoid re-seeding on atom reference churn from unrelated settings writes.
   const lastHydratedActionsRef = useRef(reactSettings.common_actions);
   useEffect(() => {
     if (!isEqual(reactSettings.common_actions, lastHydratedActionsRef.current)) {

--- a/src/components/CompanySwitcher.tsx
+++ b/src/components/CompanySwitcher.tsx
@@ -33,7 +33,7 @@ import { Plus } from './icons/Plus';
 import { Person } from './icons/Person';
 import { Exit } from './icons/Exit';
 import { useCurrentUser } from '$app/common/hooks/useCurrentUser';
-import { useInjectUserChanges } from '$app/common/hooks/useInjectUserChanges';
+import { useReactSettings } from '$app/common/hooks/useReactSettings';
 import { useColorScheme } from '$app/common/colors';
 import companySettings from '$app/common/constants/company-settings';
 
@@ -64,11 +64,9 @@ export function CompanySwitcher() {
   const { flushData } = useDocuNinjaActions();
 
   const currentUser = useCurrentUser();
-  const userChanges = useInjectUserChanges();
+  const reactSettings = useReactSettings();
 
-  const isMiniSidebar = Boolean(
-    userChanges?.company_user?.react_settings?.show_mini_sidebar
-  );
+  const isMiniSidebar = Boolean(reactSettings.show_mini_sidebar);
 
   const preventNavigation = usePreventNavigation();
 

--- a/src/components/DataTableColumnsPicker.tsx
+++ b/src/components/DataTableColumnsPicker.tsx
@@ -8,18 +8,9 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
-import { endpoint } from '$app/common/helpers';
-import { request } from '$app/common/helpers/request';
 import { toast } from '$app/common/helpers/toast/toast';
-import { CompanyUser } from '$app/common/interfaces/company-user';
-import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-api-response';
-import { User } from '$app/common/interfaces/user';
-import { resetChanges, updateUser } from '$app/common/stores/slices/user';
-import { RootState } from '$app/common/stores/store';
-import { cloneDeep, set } from 'lodash';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useDispatch, useSelector } from 'react-redux';
 import { Button, InputLabel, SelectField } from './forms';
 import { Inline } from './Inline';
 import { Modal } from './Modal';
@@ -33,9 +24,11 @@ import { arrayMoveImmutable } from 'array-move';
 import {
   ReactTableColumns,
   useReactSettings,
+  useSaveReactSettings,
+  useUpdateReactSettings,
 } from '$app/common/hooks/useReactSettings';
-import { useInjectUserChanges } from '$app/common/hooks/useInjectUserChanges';
-import { $refetch } from '$app/common/hooks/useRefetch';
+import { useCurrentUser } from '$app/common/hooks/useCurrentUser';
+import { isEqual } from 'lodash';
 import { createPortal } from 'react-dom';
 import { TableColumns } from './icons/TableColumns';
 import { useColorScheme } from '$app/common/colors';
@@ -49,70 +42,78 @@ interface Props {
 }
 
 export function DataTableColumnsPicker(props: Props) {
-  const currentUser = useSelector((state: RootState) => state.user.user) as
-    | User
-    | undefined;
+  const currentUser = useCurrentUser();
 
-  const dispatch = useDispatch();
+  const updateSettings = useUpdateReactSettings();
+  const saveSettings = useSaveReactSettings();
 
   const [t] = useTranslation();
   const { table, defaultColumns } = props;
 
-  useInjectUserChanges();
-
   const colors = useColorScheme();
   const reactSettings = useReactSettings();
 
-  const [filteredColumns, setFilteredColumns] = useState(props.columns);
-
-  const [currentColumns, setCurrentColumns] = useState<string[]>(
+  const initialColumns =
     reactSettings?.react_table_columns?.[table as ReactTableColumns] ||
-      defaultColumns
+    defaultColumns;
+
+  const getAvailableColumns = useCallback(
+    (selectedColumns: string[]) =>
+      props.columns.filter((column) => !selectedColumns.includes(column)),
+    [props.columns]
   );
+
+  const [currentColumns, setCurrentColumns] =
+    useState<string[]>(initialColumns);
+
+  const [filteredColumns, setFilteredColumns] = useState<string[]>(() =>
+    getAvailableColumns(initialColumns)
+  );
+
+  // Sync local state when the atom hydrates from `null` to populated, or
+  // when the saved columns change *materially* (another tab saved). Compare
+  // with `isEqual`, not reference equality, because `useUpdateReactSettings`
+  // deep-clones the whole atom on every write — an unrelated write (dark
+  // mode, sidebar collapse) churns the nested array reference and would
+  // otherwise wipe the user's in-progress column edits.
+  const savedColumns =
+    reactSettings?.react_table_columns?.[table as ReactTableColumns];
+  const lastSyncedColumnsRef = useRef(savedColumns);
+  useEffect(() => {
+    if (savedColumns && !isEqual(savedColumns, lastSyncedColumnsRef.current)) {
+      lastSyncedColumnsRef.current = savedColumns;
+      setCurrentColumns(savedColumns);
+    }
+  }, [savedColumns]);
 
   const [isModalVisible, setIsModalVisible] = useState(false);
 
   useEffect(() => {
-    setFilteredColumns((current) =>
-      current.filter((column) => !currentColumns.includes(column))
-    );
-  }, [currentColumns]);
+    setFilteredColumns(getAvailableColumns(currentColumns));
+  }, [currentColumns, getAvailableColumns]);
 
   const handleSelectChange = useCallback((value: string) => {
     value.length > 1 && setCurrentColumns((current) => [...current, value]);
   }, []);
 
   const onSave = () => {
-    const user = cloneDeep(currentUser) as User;
+    if (!currentUser?.id) return;
 
-    // Fix legacy data issue where react_table_columns was incorrectly stored as an array instead of an object. If you see this in 2 years, feel free to remove it.
-    if (Array.isArray(user.company_user?.react_settings.react_table_columns)) {
-      set(user, 'company_user.react_settings.react_table_columns', {});
+    // Legacy data fix: prior versions stored `react_table_columns` as an
+    // array rather than a record keyed by entity. Normalize before merging
+    // the new entry so the local write doesn't blow up on `lodash.set`.
+    if (Array.isArray(reactSettings.react_table_columns)) {
+      updateSettings('react_table_columns', {});
     }
-
-    set(
-      user,
-      `company_user.react_settings.react_table_columns.${table}`,
-      currentColumns
-    );
 
     toast.processing();
 
-    request(
-      'PUT',
-      endpoint('/api/v1/company_users/:id', { id: user.id }),
-      user
-    ).then((response: GenericSingleResourceResponse<CompanyUser>) => {
-      set(user, 'company_user', response.data.data);
-      setIsModalVisible(false);
-
-      $refetch(['company_users']);
-
-      dispatch(updateUser(user));
-      dispatch(resetChanges());
-
-      toast.success('saved_settings');
-    });
+    saveSettings(`react_table_columns.${table}`, currentColumns)
+      .then(() => {
+        setIsModalVisible(false);
+        toast.success('saved_settings');
+      })
+      .catch(() => toast.dismiss());
   };
 
   const handleDelete = (columnKey: string) => {
@@ -122,20 +123,18 @@ export function DataTableColumnsPicker(props: Props) {
 
     setCurrentColumns(updatedCurrentColumns);
 
-    const updatedFilteredColumns = props.columns.filter((column) =>
-      Boolean(
-        !updatedCurrentColumns.find((currentColumn) => currentColumn === column)
-      )
-    );
-
-    setFilteredColumns(updatedFilteredColumns);
+    setFilteredColumns(getAvailableColumns(updatedCurrentColumns));
   };
 
   const onDragEnd = (result: DropResult) => {
+    if (!result.destination) {
+      return;
+    }
+
     const sorted = arrayMoveImmutable(
       currentColumns,
       result.source.index,
-      result.destination?.index as unknown as number
+      result.destination.index
     );
 
     setCurrentColumns(sorted);
@@ -143,9 +142,8 @@ export function DataTableColumnsPicker(props: Props) {
 
   const handleReset = useCallback(() => {
     setCurrentColumns(defaultColumns);
-
-    setFilteredColumns(props.columns);
-  }, []);
+    setFilteredColumns(getAvailableColumns(defaultColumns));
+  }, [defaultColumns, getAvailableColumns]);
 
   return (
     <>

--- a/src/components/DataTableColumnsPicker.tsx
+++ b/src/components/DataTableColumnsPicker.tsx
@@ -70,12 +70,7 @@ export function DataTableColumnsPicker(props: Props) {
     getAvailableColumns(initialColumns)
   );
 
-  // Sync local state when the atom hydrates from `null` to populated, or
-  // when the saved columns change *materially* (another tab saved). Compare
-  // with `isEqual`, not reference equality, because `useUpdateReactSettings`
-  // deep-clones the whole atom on every write — an unrelated write (dark
-  // mode, sidebar collapse) churns the nested array reference and would
-  // otherwise wipe the user's in-progress column edits.
+  // Avoid re-seeding on atom reference churn from unrelated settings writes.
   const savedColumns =
     reactSettings?.react_table_columns?.[table as ReactTableColumns];
   const lastSyncedColumnsRef = useRef(savedColumns);
@@ -99,9 +94,7 @@ export function DataTableColumnsPicker(props: Props) {
   const onSave = () => {
     if (!currentUser?.id) return;
 
-    // Legacy data fix: prior versions stored `react_table_columns` as an
-    // array rather than a record keyed by entity. Normalize before merging
-    // the new entry so the local write doesn't blow up on `lodash.set`.
+    // Normalize legacy array-shaped table columns before writing this table.
     if (Array.isArray(reactSettings.react_table_columns)) {
       updateSettings('react_table_columns', {});
     }

--- a/src/components/DataTableFooterColumnsPicker.tsx
+++ b/src/components/DataTableFooterColumnsPicker.tsx
@@ -15,21 +15,15 @@ import { Modal } from './Modal';
 import { Button } from './forms';
 import Toggle from './forms/Toggle';
 import { Element } from './cards';
-import { ReactTableColumns } from '$app/common/hooks/useReactSettings';
-import { useHandleCurrentUserChangeProperty } from '$app/common/hooks/useHandleCurrentUserChange';
-import { request } from '$app/common/helpers/request';
-import { endpoint } from '$app/common/helpers';
-import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-api-response';
-import { cloneDeep, set } from 'lodash';
-import { $refetch } from '$app/common/hooks/useRefetch';
-import { resetChanges, updateUser } from '$app/common/stores/slices/user';
-import { useDispatch } from 'react-redux';
-import { CompanyUser } from '$app/common/interfaces/company-user';
-import { useInjectUserChanges } from '$app/common/hooks/useInjectUserChanges';
+import {
+  ReactTableColumns,
+  useReactSettings,
+  useSaveReactSettings,
+} from '$app/common/hooks/useReactSettings';
 import { toast } from '$app/common/helpers/toast/toast';
-import { User } from '$app/common/interfaces/user';
 import { TableColumns } from './icons/TableColumns';
 import { useColorScheme } from '$app/common/colors';
+import { useCurrentUser } from '$app/common/hooks/useCurrentUser';
 
 interface Props {
   table: ReactTableColumns;
@@ -41,66 +35,55 @@ export function DataTableFooterColumnsPicker(props: Props) {
 
   const { table, columns } = props;
 
-  const dispatch = useDispatch();
-  const handleCurrentUserChangeProperty = useHandleCurrentUserChangeProperty();
+  const saveSettings = useSaveReactSettings();
+  const currentUser = useCurrentUser();
+  const reactSettings = useReactSettings();
 
   const colors = useColorScheme();
-  const userChanges = useInjectUserChanges();
 
   const [isFormBusy, setIsFormBusy] = useState<boolean>(false);
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [draftColumns, setDraftColumns] = useState<string[]>([]);
+
+  const savedColumns = reactSettings.table_footer_columns?.[table] || [];
+
+  const openModal = () => {
+    setDraftColumns(savedColumns);
+    setIsModalOpen(true);
+  };
+
+  const closeModal = () => {
+    setDraftColumns([]);
+    setIsModalOpen(false);
+  };
 
   const isColumnChecked = (columnKey: string) => {
-    return Boolean(
-      userChanges?.company_user?.react_settings?.table_footer_columns?.[
-        table
-      ]?.includes(columnKey)
-    );
+    return (isModalOpen ? draftColumns : savedColumns).includes(columnKey);
   };
 
   const handleChange = (columnKey: string, value: boolean) => {
-    let currentList =
-      userChanges?.company_user?.react_settings.table_footer_columns?.[table] ||
-      [];
+    setDraftColumns((current) => {
+      if (value) {
+        return current.includes(columnKey) ? current : [...current, columnKey];
+      }
 
-    if (value) {
-      currentList = [...currentList, columnKey];
-    } else {
-      currentList = currentList.filter((column) => column !== columnKey);
-    }
-
-    handleCurrentUserChangeProperty(
-      `company_user.react_settings.table_footer_columns.${table}`,
-      currentList as keyof typeof userChanges
-    );
+      return current.filter((column) => column !== columnKey);
+    });
   };
 
   const handleSave = () => {
-    const updatedUser = cloneDeep(userChanges) as User;
+    if (!currentUser?.id || isFormBusy) return;
 
-    if (updatedUser && !isFormBusy) {
-      toast.processing();
-      setIsFormBusy(true);
+    toast.processing();
+    setIsFormBusy(true);
 
-      request(
-        'PUT',
-        endpoint('/api/v1/company_users/:id', { id: updatedUser.id }),
-        updatedUser
-      )
-        .then((response: GenericSingleResourceResponse<CompanyUser>) => {
-          toast.success('updated_settings');
-
-          set(updatedUser, 'company_user', response.data.data);
-
-          $refetch(['company_users']);
-
-          dispatch(updateUser(userChanges));
-          dispatch(resetChanges());
-
-          setIsModalOpen(false);
-        })
-        .finally(() => setIsFormBusy(false));
-    }
+    saveSettings(`table_footer_columns.${table}`, draftColumns)
+      .then(() => {
+        toast.success('updated_settings');
+        closeModal();
+      })
+      .catch(() => toast.dismiss())
+      .finally(() => setIsFormBusy(false));
   };
 
   return (
@@ -108,7 +91,7 @@ export function DataTableFooterColumnsPicker(props: Props) {
       <Button
         className="shadow-sm"
         type="secondary"
-        onClick={() => setIsModalOpen(true)}
+        onClick={openModal}
       >
         <div className="flex items-center space-x-2">
           <TableColumns size="1.3rem" color={colors.$3} />
@@ -122,7 +105,7 @@ export function DataTableFooterColumnsPicker(props: Props) {
       <Modal
         title={t('footer')}
         visible={isModalOpen}
-        onClose={() => setIsModalOpen(false)}
+        onClose={closeModal}
       >
         <div className="flex flex-col">
           {columns.map((column, index) => (
@@ -141,7 +124,7 @@ export function DataTableFooterColumnsPicker(props: Props) {
           ))}
         </div>
 
-        <Button behavior="button" onClick={handleSave}>
+        <Button behavior="button" onClick={handleSave} disabled={isFormBusy}>
           {t('save')}
         </Button>
       </Modal>

--- a/src/components/Feedback.tsx
+++ b/src/components/Feedback.tsx
@@ -13,14 +13,10 @@ import { endpoint } from '$app/common/helpers';
 import { toast } from '$app/common/helpers/toast/toast';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
-import { useReactSettings } from '$app/common/hooks/useReactSettings';
-import { cloneDeep, set } from 'lodash';
-import { useCurrentUser } from '$app/common/hooks/useCurrentUser';
-import { CompanyUser } from '$app/common/interfaces/company-user';
-import { $refetch } from '$app/common/hooks/useRefetch';
-import { resetChanges, updateUser } from '$app/common/stores/slices/user';
-import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-api-response';
-import { useDispatch } from 'react-redux';
+import {
+  useSaveReactSettings,
+  useUpdateReactSettings,
+} from '$app/common/hooks/useReactSettings';
 
 dayjs.extend(utc);
 
@@ -29,12 +25,10 @@ export const isFeedbackSliderVisible = atom<boolean>(false);
 export function Feedback() {
   const [t] = useTranslation();
 
-  const dispatch = useDispatch();
-
   const colors = useColorScheme();
-  const currentUser = useCurrentUser();
 
-  const reactSettings = useReactSettings();
+  const updateSettings = useUpdateReactSettings();
+  const saveSettings = useSaveReactSettings();
 
   const [isFormBusy, setIsFormBusy] = useState<boolean>(false);
   const [feedbackValue, setFeedbackValue] = useState<string>('');
@@ -60,29 +54,11 @@ export function Feedback() {
   const handleUpdateReactSettings = (isDoNotAskAgain: boolean = false) => {
     const currentUnixTime = dayjs().utc().unix();
 
-    const updatedReactSettings = cloneDeep(reactSettings);
-
-    set(updatedReactSettings, 'preferences.feedback_given_at', currentUnixTime);
-    set(
-      updatedReactSettings,
+    updateSettings('preferences.feedback_given_at', currentUnixTime);
+    saveSettings(
       'preferences.feedback_slider_displayed_at',
       isDoNotAskAgain ? -1 : currentUnixTime
-    );
-
-    request(
-      'PUT',
-      endpoint('/api/v1/company_users/:id/preferences?include=company_user', {
-        id: currentUser?.id,
-      }),
-      {
-        react_settings: updatedReactSettings,
-      }
-    ).then((response: GenericSingleResourceResponse<CompanyUser>) => {
-      $refetch(['company_users']);
-
-      dispatch(updateUser(response.data.data));
-      dispatch(resetChanges());
-    });
+    ).catch(() => undefined);
   };
 
   const handleFeedbackSubmit = (
@@ -117,25 +93,9 @@ export function Feedback() {
   const handleDoNotAskAgain = () => {
     setIsVisible(false);
     setShowFeedbackModal(false);
-
-    const updatedReactSettings = cloneDeep(reactSettings);
-
-    set(updatedReactSettings, 'preferences.feedback_slider_displayed_at', -1);
-
-    request(
-      'PUT',
-      endpoint('/api/v1/company_users/:id/preferences?include=company_user', {
-        id: currentUser?.id,
-      }),
-      {
-        react_settings: updatedReactSettings,
-      }
-    ).then((response: GenericSingleResourceResponse<CompanyUser>) => {
-      $refetch(['company_users']);
-
-      dispatch(updateUser(response.data.data));
-      dispatch(resetChanges());
-    });
+    saveSettings('preferences.feedback_slider_displayed_at', -1).catch(
+      () => undefined
+    );
   };
 
   if (isSubmitted) {

--- a/src/components/HelpSidebarIcons.tsx
+++ b/src/components/HelpSidebarIcons.tsx
@@ -26,7 +26,7 @@ import Toggle from './forms/Toggle';
 import { Modal } from './Modal';
 import { toast } from '$app/common/helpers/toast/toast';
 import { useColorScheme } from '$app/common/colors';
-import { useInjectUserChanges } from '$app/common/hooks/useInjectUserChanges';
+import { useCurrentUser } from '$app/common/hooks/useCurrentUser';
 import classNames from 'classnames';
 import { AboutModal } from './AboutModal';
 import { Icon } from './icons/Icon';
@@ -57,7 +57,7 @@ export function HelpSidebarIcons(props: Props) {
   const [t] = useTranslation();
 
   const colors = useColorScheme();
-  const user = useInjectUserChanges();
+  const user = useCurrentUser();
   const account = useCurrentAccount();
 
   const reactSettings = useReactSettings();
@@ -96,9 +96,7 @@ export function HelpSidebarIcons(props: Props) {
   const [isUpdateModalVisible, setIsUpdateModalVisible] =
     useState<boolean>(false);
 
-  const isMiniSidebar = Boolean(
-    user?.company_user?.react_settings.show_mini_sidebar
-  );
+  const isMiniSidebar = Boolean(reactSettings.show_mini_sidebar);
 
   const isUpdateAvailable =
     isSelfHosted() &&

--- a/src/components/QuickCreatePopover.tsx
+++ b/src/components/QuickCreatePopover.tsx
@@ -8,7 +8,7 @@ import { useQuickCreateActions } from '$app/common/hooks/entities/useQuickCreate
 import { isHosted, isSelfHosted } from '$app/common/helpers';
 import { useColorScheme } from '$app/common/colors';
 import { styled } from 'styled-components';
-import { useInjectUserChanges } from '$app/common/hooks/useInjectUserChanges';
+import { useReactSettings } from '$app/common/hooks/useReactSettings';
 import { usePreventNavigation } from '$app/common/hooks/usePreventNavigation';
 import { Icon } from './icons/Icon';
 
@@ -40,11 +40,9 @@ export function QuickCreatePopover() {
   const actions = useQuickCreateActions();
   const sections = useQuickCreateSections();
 
-  const user = useInjectUserChanges();
+  const reactSettings = useReactSettings();
 
-  const isMiniSidebar = Boolean(
-    user?.company_user?.react_settings.show_mini_sidebar
-  );
+  const isMiniSidebar = Boolean(reactSettings.show_mini_sidebar);
 
   return (
     <Popover className="relative">

--- a/src/components/banners/PriceIncrease.tsx
+++ b/src/components/banners/PriceIncrease.tsx
@@ -43,9 +43,7 @@ export function PriceIncreaseBanner() {
       dayjs().utc().unix()
     )
       .then(() => {
-        // Refresh the redux `companyUsers` mirror so the "any user already
-        // dismissed?" gate on next mount sees the updated value. The atom
-        // itself is already current — this is just for that ancillary check.
+        // Keep the redux `companyUsers` mirror in sync for the banner gate.
         refreshCompanyUsers();
       })
       .catch(() => undefined);

--- a/src/components/banners/PriceIncrease.tsx
+++ b/src/components/banners/PriceIncrease.tsx
@@ -10,21 +10,14 @@
 
 import { useTranslation } from 'react-i18next';
 import { useCurrentUser } from '$app/common/hooks/useCurrentUser';
-import { request } from '$app/common/helpers/request';
-import { endpoint, isHosted } from '$app/common/helpers';
-import { $refetch } from '$app/common/hooks/useRefetch';
+import { isHosted } from '$app/common/helpers';
 import dayjs from 'dayjs';
-import { cloneDeep, set } from 'lodash';
-import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-api-response';
-import { resetChanges, updateUser } from '$app/common/stores/slices/user';
-import { useDispatch } from 'react-redux';
-import { CompanyUser } from '$app/common/interfaces/company-user';
 import { useAdmin } from '$app/common/hooks/permissions/useHasPermission';
 import { Icon } from '../icons/Icon';
 import { MdClose } from 'react-icons/md';
 import { Link } from '../forms';
 import { useColorScheme } from '$app/common/colors';
-import { useReactSettings } from '$app/common/hooks/useReactSettings';
+import { useSaveReactSettings } from '$app/common/hooks/useReactSettings';
 import { useEffect, useState } from 'react';
 import { useCompanyUsers } from '$app/common/hooks/useCompanyUsers';
 import { useRefreshCompanyUsers } from '$app/common/hooks/useRefreshCompanyUsers';
@@ -32,46 +25,30 @@ import { useRefreshCompanyUsers } from '$app/common/hooks/useRefreshCompanyUsers
 export function PriceIncreaseBanner() {
   const [t] = useTranslation();
 
-  const dispatch = useDispatch();
   const refreshCompanyUsers = useRefreshCompanyUsers();
 
   const { isOwner } = useAdmin();
   const colors = useColorScheme();
   const currentUser = useCurrentUser();
   const companyUsers = useCompanyUsers();
-  const reactSettings = useReactSettings();
+  const saveSettings = useSaveReactSettings();
 
   const [shouldDisplayBanner, setShouldDisplayBanner] = useState<boolean>();
 
   const handleDismiss = () => {
     setShouldDisplayBanner(false);
 
-    const currentUnixTime = dayjs().utc().unix();
-
-    const updatedReactSettings = cloneDeep(reactSettings);
-
-    set(
-      updatedReactSettings,
+    saveSettings(
       'preferences.price_increase_banner_dismissed_at',
-      currentUnixTime
-    );
-
-    request(
-      'PUT',
-      endpoint('/api/v1/company_users/:id/preferences?include=company_user', {
-        id: currentUser?.id,
-      }),
-      {
-        react_settings: updatedReactSettings,
-      }
-    ).then((response: GenericSingleResourceResponse<CompanyUser>) => {
-      $refetch(['company_users']);
-
-      dispatch(updateUser(response.data.data));
-      dispatch(resetChanges());
-
-      refreshCompanyUsers();
-    });
+      dayjs().utc().unix()
+    )
+      .then(() => {
+        // Refresh the redux `companyUsers` mirror so the "any user already
+        // dismissed?" gate on next mount sees the updated value. The atom
+        // itself is already current — this is just for that ancillary check.
+        refreshCompanyUsers();
+      })
+      .catch(() => undefined);
   };
 
   const handleClick = () => {

--- a/src/components/forms/InputField.tsx
+++ b/src/components/forms/InputField.tsx
@@ -47,7 +47,7 @@ interface Props extends CommonProps {
 
 export function InputField(props: Props) {
   const colors = useColorScheme();
-  const reactSettings = useReactSettings({ overwrite: false });
+  const reactSettings = useReactSettings();
 
   const isInitialTypePassword = props.type === 'password';
 

--- a/src/components/forms/NumberInputField.tsx
+++ b/src/components/forms/NumberInputField.tsx
@@ -41,7 +41,7 @@ export function NumberInputField(props: Props) {
   const colors = useColorScheme();
   const company = useCurrentCompany();
 
-  const reactSettings = useReactSettings({ overwrite: false });
+  const reactSettings = useReactSettings();
 
   const [currentValue, setCurrentValue] = useState<number | undefined>(
     typeof props.value === 'number'

--- a/src/components/import/ImportTemplate.tsx
+++ b/src/components/import/ImportTemplate.tsx
@@ -11,18 +11,14 @@
 import { MdDelete } from 'react-icons/md';
 import { Element } from '../cards';
 import { Icon } from '../icons/Icon';
-import { request } from '$app/common/helpers/request';
-import { endpoint } from '$app/common/helpers';
-import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-api-response';
-import { CompanyUser } from '$app/common/interfaces/company-user';
-import { cloneDeep, set } from 'lodash';
+import { cloneDeep } from 'lodash';
 import { toast } from '$app/common/helpers/toast/toast';
-import { $refetch } from '$app/common/hooks/useRefetch';
-import { resetChanges, updateUser } from '$app/common/stores/slices/user';
-import { User } from '$app/common/interfaces/user';
 import { useState } from 'react';
-import { useUserChanges } from '$app/common/hooks/useInjectUserChanges';
-import { useDispatch } from 'react-redux';
+import { useCurrentUser } from '$app/common/hooks/useCurrentUser';
+import {
+  useReactSettings,
+  useSaveReactSettings,
+} from '$app/common/hooks/useReactSettings';
 import classNames from 'classnames';
 
 interface Props {
@@ -31,64 +27,51 @@ interface Props {
   onDeletedTemplate: () => void;
 }
 export function ImportTemplate(props: Props) {
-  const dispatch = useDispatch();
-
   const { name, entity, onDeletedTemplate } = props;
 
-  const user = useUserChanges();
+  const currentUser = useCurrentUser();
+  const reactSettings = useReactSettings();
+  const saveSettings = useSaveReactSettings();
 
   const [isFormBusy, setIsFormBusy] = useState<boolean>(false);
 
   const handleDeleteTemplate = () => {
-    if (!isFormBusy) {
+    if (!isFormBusy && currentUser) {
+      const importTemplates = cloneDeep(reactSettings?.import_templates ?? {});
+
+      const numberOfTemplates = Object.keys(
+        importTemplates?.[entity] || {}
+      ).length;
+
+      let nextTemplates: typeof importTemplates;
+      if (numberOfTemplates > 1) {
+        delete importTemplates?.[entity][name];
+        nextTemplates = importTemplates;
+      } else {
+        const numberOfEntities = Object.keys(importTemplates || {}).length;
+
+        if (numberOfEntities > 1) {
+          delete importTemplates?.[entity];
+          nextTemplates = importTemplates;
+        } else {
+          // Write an empty object rather than `undefined`: a `set` to
+          // `undefined` leaves the key on the object, then JSON.stringify
+          // omits it on the wire, so the server never receives a "delete"
+          // signal and the template silently resurrects on next hydration.
+          nextTemplates = {};
+        }
+      }
+
       toast.processing();
       setIsFormBusy(true);
 
-      const updatedUser = cloneDeep(user) as User;
-
-      if (updatedUser) {
-        const numberOfTemplates = Object.keys(
-          updatedUser?.company_user?.react_settings?.import_templates?.[
-            entity
-          ] || {}
-        ).length;
-
-        if (numberOfTemplates > 1) {
-          delete updatedUser?.company_user?.react_settings?.import_templates?.[
-            entity
-          ][name];
-        } else {
-          const numberOfEntities = Object.keys(
-            updatedUser?.company_user?.react_settings?.import_templates || {}
-          ).length;
-
-          if (numberOfEntities > 1) {
-            delete updatedUser?.company_user?.react_settings
-              ?.import_templates?.[entity];
-          } else {
-            delete updatedUser?.company_user?.react_settings?.import_templates;
-          }
-        }
-
-        request(
-          'PUT',
-          endpoint('/api/v1/company_users/:id', { id: updatedUser.id }),
-          updatedUser
-        )
-          .then((response: GenericSingleResourceResponse<CompanyUser>) => {
-            toast.success('updated_settings');
-
-            set(updatedUser, 'company_user', response.data.data);
-
-            $refetch(['company_users']);
-
-            dispatch(updateUser(updatedUser));
-            dispatch(resetChanges());
-
-            onDeletedTemplate();
-          })
-          .finally(() => setIsFormBusy(false));
-      }
+      saveSettings('import_templates', nextTemplates)
+        .then(() => {
+          toast.success('updated_settings');
+          onDeletedTemplate();
+        })
+        .catch(() => toast.dismiss())
+        .finally(() => setIsFormBusy(false));
     }
   };
 

--- a/src/components/import/ImportTemplate.tsx
+++ b/src/components/import/ImportTemplate.tsx
@@ -54,10 +54,7 @@ export function ImportTemplate(props: Props) {
           delete importTemplates?.[entity];
           nextTemplates = importTemplates;
         } else {
-          // Write an empty object rather than `undefined`: a `set` to
-          // `undefined` leaves the key on the object, then JSON.stringify
-          // omits it on the wire, so the server never receives a "delete"
-          // signal and the template silently resurrects on next hydration.
+          // `undefined` is omitted on the wire; `{}` persists the delete.
           nextTemplates = {};
         }
       }

--- a/src/components/import/ImportTemplateModal.tsx
+++ b/src/components/import/ImportTemplateModal.tsx
@@ -12,19 +12,14 @@ import { useTranslation } from 'react-i18next';
 import { Button, InputField } from '../forms';
 import { ImportMap } from './UploadImport';
 import { useState } from 'react';
-import { useReactSettings } from '$app/common/hooks/useReactSettings';
-import { cloneDeep, isEqual, set } from 'lodash';
+import {
+  useReactSettings,
+  useSaveReactSettings,
+} from '$app/common/hooks/useReactSettings';
+import { cloneDeep, isEqual } from 'lodash';
 import { Modal } from '../Modal';
 import { toast } from '$app/common/helpers/toast/toast';
-import { request } from '$app/common/helpers/request';
-import { endpoint } from '$app/common/helpers';
-import { $refetch } from '$app/common/hooks/useRefetch';
-import { resetChanges, updateUser } from '$app/common/stores/slices/user';
-import { useDispatch } from 'react-redux';
-import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-api-response';
-import { CompanyUser } from '$app/common/interfaces/company-user';
-import { User } from '$app/common/interfaces/user';
-import { useUserChanges } from '$app/common/hooks/useInjectUserChanges';
+import { useCurrentUser } from '$app/common/hooks/useCurrentUser';
 import { useNavigate } from 'react-router-dom';
 
 interface Props {
@@ -34,13 +29,13 @@ interface Props {
 }
 export function ImportTemplateModal(props: Props) {
   const [t] = useTranslation();
-  const dispatch = useDispatch();
   const navigate = useNavigate();
 
   const { onImport, importMap, entity } = props;
 
-  const user = useUserChanges();
+  const currentUser = useCurrentUser();
   const reactSettings = useReactSettings();
+  const saveSettings = useSaveReactSettings();
 
   const [isSaveTemplateModalOpen, setIsSaveTemplateModalOpen] =
     useState<boolean>(false);
@@ -103,63 +98,42 @@ export function ImportTemplateModal(props: Props) {
   };
 
   const handleSaveTemplate = () => {
-    if (!isFormBusy && templateName) {
+    if (!isFormBusy && templateName && currentUser) {
+      const currentEntityImportTemplates = (cloneDeep(
+        reactSettings?.import_templates?.[props.entity]
+      ) || {}) as Record<string, Record<number, string>>;
+
+      const updatedEntityImportTemplates: Record<string, (string | null)[]> =
+        {};
+
+      if (!Array.isArray(currentEntityImportTemplates)) {
+        Object.entries(currentEntityImportTemplates).forEach(
+          ([key, value]) => {
+            if (!key || !value || !Array.isArray(value)) return;
+
+            updatedEntityImportTemplates[key] = value;
+          }
+        );
+      }
+
+      updatedEntityImportTemplates[templateName] = Object.values(
+        importMap.column_map?.[props.entity]?.mapping
+      ).map((column) => column || '') as string[];
+
       toast.processing();
       setIsFormBusy(true);
 
-      const updatedUser = cloneDeep(user) as User;
-
-      if (updatedUser) {
-        const currentEntityImportTemplates = (cloneDeep(
-          updatedUser.company_user?.react_settings.import_templates?.[
-            props.entity
-          ]
-        ) || {}) as Record<string, Record<number, string>>;
-
-        const updatedEntityImportTemplates: Record<string, (string | null)[]> =
-          {};
-
-        if (!Array.isArray(currentEntityImportTemplates)) {
-          Object.entries(currentEntityImportTemplates).forEach(
-            ([key, value]) => {
-              if (!key || !value || !Array.isArray(value)) return;
-
-              updatedEntityImportTemplates[key] = value;
-            }
-          );
-        }
-
-        updatedEntityImportTemplates[templateName] = Object.values(
-          importMap.column_map?.[props.entity]?.mapping
-        ).map((column) => column || '') as string[];
-
-        set(
-          updatedUser,
-          `company_user.react_settings.import_templates.${props.entity}`,
-          updatedEntityImportTemplates
-        );
-
-        request(
-          'PUT',
-          endpoint('/api/v1/company_users/:id', { id: updatedUser.id }),
-          updatedUser
-        )
-          .then((response: GenericSingleResourceResponse<CompanyUser>) => {
-            toast.success('updated_settings');
-
-            set(updatedUser, 'company_user', response.data.data);
-
-            $refetch(['company_users']);
-
-            dispatch(updateUser(updatedUser));
-            dispatch(resetChanges());
-
-            handleOnClose();
-
-            navigate(`/${entity}s`);
-          })
-          .finally(() => setIsFormBusy(false));
-      }
+      saveSettings(
+        `import_templates.${props.entity}`,
+        updatedEntityImportTemplates
+      )
+        .then(() => {
+          toast.success('updated_settings');
+          handleOnClose();
+          navigate(`/${entity}s`);
+        })
+        .catch(() => toast.dismiss())
+        .finally(() => setIsFormBusy(false));
     }
   };
 

--- a/src/components/layouts/Default.tsx
+++ b/src/components/layouts/Default.tsx
@@ -33,7 +33,8 @@ import { ActivateCompany } from '../banners/ActivateCompany';
 import { VerifyPhone } from '../banners/VerifyPhone';
 import { useColorScheme } from '$app/common/colors';
 import { Search } from '$app/pages/dashboard/components/Search';
-import { useInjectUserChanges } from '$app/common/hooks/useInjectUserChanges';
+import { useCurrentUser } from '$app/common/hooks/useCurrentUser';
+import { useReactSettings } from '$app/common/hooks/useReactSettings';
 import { useAtomValue } from 'jotai';
 import { usePreventNavigation } from '$app/common/hooks/usePreventNavigation';
 import { Notifications } from '../Notifications';
@@ -74,12 +75,11 @@ export function Default(props: Props) {
 
   const preventNavigation = usePreventNavigation();
 
-  const user = useInjectUserChanges();
+  const user = useCurrentUser();
   const companyUser = useCurrentCompanyUser();
+  const reactSettings = useReactSettings();
 
-  const isMiniSidebar = Boolean(
-    user?.company_user?.react_settings.show_mini_sidebar
-  );
+  const isMiniSidebar = Boolean(reactSettings.show_mini_sidebar);
   const shouldShowUnlockButton =
     !isDemo() && (useUnlockButtonForHosted() || useUnlockButtonForSelfHosted());
 

--- a/src/components/layouts/components/DesktopSidebar.tsx
+++ b/src/components/layouts/components/DesktopSidebar.tsx
@@ -13,7 +13,7 @@ import { HelpSidebarIcons } from '$app/components/HelpSidebarIcons';
 import { SidebarItem } from './SidebarItem';
 import { useColorScheme } from '$app/common/colors';
 import { Tooltip } from '$app/components/Tooltip';
-import { useInjectUserChanges } from '$app/common/hooks/useInjectUserChanges';
+import { useReactSettings } from '$app/common/hooks/useReactSettings';
 import classNames from 'classnames';
 
 interface SubNavigationItem {
@@ -50,11 +50,9 @@ interface Props {
 }
 
 export function DesktopSidebar(props: Props) {
-  const user = useInjectUserChanges();
+  const reactSettings = useReactSettings();
 
-  const isMiniSidebar = Boolean(
-    user?.company_user?.react_settings.show_mini_sidebar
-  );
+  const isMiniSidebar = Boolean(reactSettings.show_mini_sidebar);
 
   const colors = useColorScheme();
 

--- a/src/components/layouts/components/MobileSidebar.tsx
+++ b/src/components/layouts/components/MobileSidebar.tsx
@@ -15,7 +15,7 @@ import { X } from 'react-feather';
 import { NavigationItem } from './DesktopSidebar';
 import { SidebarItem } from './SidebarItem';
 import { useColorScheme } from '$app/common/colors';
-import { useInjectUserChanges } from '$app/common/hooks/useInjectUserChanges';
+import { useReactSettings } from '$app/common/hooks/useReactSettings';
 import { HelpSidebarIcons } from '$app/components/HelpSidebarIcons';
 
 interface Props {
@@ -26,11 +26,9 @@ interface Props {
 
 export function MobileSidebar(props: Props) {
   const colors = useColorScheme();
-  const user = useInjectUserChanges();
+  const reactSettings = useReactSettings();
 
-  const isMiniSidebar = Boolean(
-    user?.company_user?.react_settings.show_mini_sidebar
-  );
+  const isMiniSidebar = Boolean(reactSettings.show_mini_sidebar);
 
   return (
     <Transition.Root show={props.sidebarOpen} as={Fragment}>

--- a/src/components/layouts/components/SidebarItem.tsx
+++ b/src/components/layouts/components/SidebarItem.tsx
@@ -11,7 +11,7 @@
 import { NavigationItem } from './DesktopSidebar';
 import { styled } from 'styled-components';
 import { useColorScheme } from '$app/common/colors';
-import { useInjectUserChanges } from '$app/common/hooks/useInjectUserChanges';
+import { useReactSettings } from '$app/common/hooks/useReactSettings';
 import { useThemeColorScheme } from '$app/pages/settings/user/components/StatusColorTheme';
 import classNames from 'classnames';
 import { Link } from '$app/components/forms';
@@ -40,12 +40,10 @@ export function SidebarItem(props: Props) {
   const { item } = props;
 
   const colors = useColorScheme();
-  const user = useInjectUserChanges();
+  const reactSettings = useReactSettings();
   const themeColors = useThemeColorScheme();
 
-  const isMiniSidebar = Boolean(
-    user?.company_user?.react_settings.show_mini_sidebar
-  );
+  const isMiniSidebar = Boolean(reactSettings.show_mini_sidebar);
 
   const [areSubOptionsVisible, setAreSubOptionsVisible] =
     useState<boolean>(false);

--- a/src/pages/clients/show/components/CardsCustomizationModal.tsx
+++ b/src/pages/clients/show/components/CardsCustomizationModal.tsx
@@ -10,23 +10,14 @@
 
 import { useColorScheme } from '$app/common/colors';
 import { useCurrentUser } from '$app/common/hooks/useCurrentUser';
-import { User } from '$app/common/interfaces/user';
 import { Button, SelectField } from '$app/components/forms';
 import { CircleXMark } from '$app/components/icons/CircleXMark';
-import { set } from 'lodash';
 import { Gear } from '$app/components/icons/Gear';
 import { Modal } from '$app/components/Modal';
-import { cloneDeep } from 'lodash';
-import { useEffect, useState } from 'react';
+import { cloneDeep, isEqual } from 'lodash';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
-import { request } from '$app/common/helpers/request';
-import { endpoint } from '$app/common/helpers';
-import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-api-response';
-import { CompanyUser } from '$app/common/interfaces/company-user';
-import { $refetch } from '$app/common/hooks/useRefetch';
-import { resetChanges, updateUser } from '$app/common/stores/slices/user';
-import { useDispatch } from 'react-redux';
 import { toast } from '$app/common/helpers/toast/toast';
 import {
   DragDropContext,
@@ -36,6 +27,10 @@ import {
 } from '@hello-pangea/dnd';
 import { arrayMoveImmutable } from 'array-move';
 import { GridDotsVertical } from '$app/components/icons/GridDotsVertical';
+import {
+  useReactSettings,
+  useSaveReactSettings,
+} from '$app/common/hooks/useReactSettings';
 
 const Box = styled.div`
   background-color: ${(props) => props.theme.backgroundColor};
@@ -56,99 +51,90 @@ export type ClientShowCard =
   | 'public_notes'
   | 'private_notes';
 
-const ALL_CARDS: ClientShowCard[] = [
+const DEFAULT_CARDS: ClientShowCard[] = [
   'details',
   'address',
   'contacts',
   'standing',
+];
+
+const ALL_CARDS: ClientShowCard[] = [
+  ...DEFAULT_CARDS,
   'gateways',
   'public_notes',
   'private_notes',
 ];
 
+const normalizeCards = (cards: ClientShowCard[] | undefined) => {
+  return cloneDeep(
+    (cards ?? DEFAULT_CARDS).filter((card) => card !== 'email_history')
+  );
+};
+
 export function CardsCustomizationModal() {
   const [t] = useTranslation();
 
   const user = useCurrentUser();
+  const reactSettings = useReactSettings();
+  const saveSettings = useSaveReactSettings();
   const colors = useColorScheme();
-
-  const dispatch = useDispatch();
 
   const [isVisible, setIsVisible] = useState<boolean>(false);
   const [isFormBusy, setIsFormBusy] = useState<boolean>(false);
-  const [currentCards, setCurrentCards] = useState<ClientShowCard[]>([]);
+  const [currentCards, setCurrentCards] = useState<ClientShowCard[]>(() =>
+    normalizeCards(reactSettings?.client_show_cards)
+  );
 
   const handleDelete = (card: ClientShowCard) => {
     setCurrentCards((current) => current.filter((c) => c !== card));
   };
 
   const handleClose = () => {
-    if (user?.company_user?.react_settings?.client_show_cards) {
-      setCurrentCards(
-        cloneDeep(user.company_user.react_settings.client_show_cards)
-      );
-    } else {
-      setCurrentCards(['details', 'address', 'contacts', 'standing']);
-    }
+    setCurrentCards(normalizeCards(reactSettings?.client_show_cards));
 
     setIsVisible(false);
   };
 
   const handleUpdateUserDetails = () => {
-    if (!isFormBusy) {
+    if (!isFormBusy && user) {
       toast.processing();
       setIsFormBusy(true);
 
-      const updatedUser = cloneDeep(user) as User;
-
-      set(
-        updatedUser,
-        'company_user.react_settings.client_show_cards',
-        currentCards
-      );
-
-      request(
-        'PUT',
-        endpoint('/api/v1/company_users/:id', { id: updatedUser.id }),
-        updatedUser
-      )
-        .then((response: GenericSingleResourceResponse<CompanyUser>) => {
-          set(updatedUser, 'company_user', response.data.data);
-
-          $refetch(['company_users']);
-
-          dispatch(updateUser(updatedUser));
-          dispatch(resetChanges());
-
+      saveSettings('client_show_cards', currentCards)
+        .then(() => {
           toast.success();
-
           setIsVisible(false);
         })
+        .catch(() => toast.dismiss())
         .finally(() => {
           setIsFormBusy(false);
         });
     }
   };
 
+  // Re-seed when persisted value materially changes. `isEqual` (not
+  // reference equality) is required because `useUpdateReactSettings`
+  // deep-clones the whole atom on every write — unrelated writes would
+  // otherwise churn this array reference and wipe in-progress drag edits.
+  const lastSyncedCardsRef = useRef<ClientShowCard[] | undefined>();
   useEffect(() => {
-    if (user?.company_user?.react_settings?.client_show_cards) {
-      setCurrentCards(
-        cloneDeep(
-          user.company_user.react_settings.client_show_cards.filter(
-            (card) => card !== 'email_history'
-          )
-        )
-      );
-    } else {
-      setCurrentCards(['details', 'address', 'contacts', 'standing']);
+    if (isEqual(reactSettings?.client_show_cards, lastSyncedCardsRef.current)) {
+      return;
     }
-  }, [user?.company_user?.react_settings?.client_show_cards]);
+
+    lastSyncedCardsRef.current = reactSettings?.client_show_cards;
+    setCurrentCards(normalizeCards(reactSettings?.client_show_cards));
+  }, [reactSettings?.client_show_cards]);
 
   const onDragEnd = (result: DropResult) => {
+    if (!result.destination) {
+      return;
+    }
+
     const filtered = arrayMoveImmutable(
       currentCards,
       result.source.index,
-      result.destination?.index as unknown as number
+      result.destination.index
     );
 
     setCurrentCards(filtered);

--- a/src/pages/clients/show/components/CardsCustomizationModal.tsx
+++ b/src/pages/clients/show/components/CardsCustomizationModal.tsx
@@ -112,10 +112,7 @@ export function CardsCustomizationModal() {
     }
   };
 
-  // Re-seed when persisted value materially changes. `isEqual` (not
-  // reference equality) is required because `useUpdateReactSettings`
-  // deep-clones the whole atom on every write — unrelated writes would
-  // otherwise churn this array reference and wipe in-progress drag edits.
+  // Avoid re-seeding on atom reference churn from unrelated settings writes.
   const lastSyncedCardsRef = useRef<ClientShowCard[] | undefined>();
   useEffect(() => {
     if (isEqual(reactSettings?.client_show_cards, lastSyncedCardsRef.current)) {

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -32,9 +32,7 @@ export default function Dashboard() {
   const [t] = useTranslation();
   const enabled = useEnabled();
   const openFeedbackSlider = useOpenFeedbackSlider();
-  // The opener bails when the atom is null (otherwise default-zero
-  // timestamps would bypass do-not-ask-again). We want to fire it once
-  // *after* hydration, even if the dashboard mounted first.
+  // Try opening feedback once after settings hydrate.
   const isReactSettingsHydrated = useAtomValue(reactSettingsAtom) !== null;
   const feedbackTriedRef = useRef<boolean>(false);
 

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -22,7 +22,9 @@ import { useEnabled } from '$app/common/guards/guards/enabled';
 import { ModuleBitmask } from '../settings';
 import { UpcomingRecurringInvoices } from './components/UpcomingRecurringInvoices';
 import { useOpenFeedbackSlider } from '$app/common/hooks/useOpenFeedbackSlider';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
+import { useAtomValue } from 'jotai';
+import { reactSettingsAtom } from '$app/common/hooks/useReactSettings';
 
 export default function Dashboard() {
   useTitle('dashboard');
@@ -30,10 +32,17 @@ export default function Dashboard() {
   const [t] = useTranslation();
   const enabled = useEnabled();
   const openFeedbackSlider = useOpenFeedbackSlider();
+  // The opener bails when the atom is null (otherwise default-zero
+  // timestamps would bypass do-not-ask-again). We want to fire it once
+  // *after* hydration, even if the dashboard mounted first.
+  const isReactSettingsHydrated = useAtomValue(reactSettingsAtom) !== null;
+  const feedbackTriedRef = useRef<boolean>(false);
 
   useEffect(() => {
+    if (!isReactSettingsHydrated || feedbackTriedRef.current) return;
+    feedbackTriedRef.current = true;
     openFeedbackSlider();
-  }, []);
+  }, [isReactSettingsHydrated, openFeedbackSlider]);
 
   return (
     <Default title={t('dashboard')} breadcrumbs={[]}>

--- a/src/pages/dashboard/components/DashboardCardSelector.tsx
+++ b/src/pages/dashboard/components/DashboardCardSelector.tsx
@@ -213,12 +213,7 @@ export function DashboardCardSelector() {
     fieldsRef.current = fields;
   }, [fields]);
 
-  // Seed local draft on the modal-open transition, and only re-seed mid-open
-  // if the persisted value materially changed (e.g. cross-tab save).
-  // `isEqual` (not reference equality) is required because
-  // `useUpdateReactSettings` deep-clones the whole atom on every write —
-  // unrelated writes would otherwise churn this array reference and wipe
-  // in-progress edits.
+  // Avoid re-seeding on atom reference churn from unrelated settings writes.
   const lastSeededFieldsRef = useRef<string[] | undefined>(undefined);
   useEffect(() => {
     if (!manageOpen || !currentUser) {

--- a/src/pages/dashboard/components/DashboardCardSelector.tsx
+++ b/src/pages/dashboard/components/DashboardCardSelector.tsx
@@ -9,9 +9,8 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { isEqual } from 'lodash';
 import { useTranslation } from 'react-i18next';
-import { useDispatch } from 'react-redux';
-import { cloneDeep, set } from 'lodash';
 import classNames from 'classnames';
 import {
   DragDropContext,
@@ -23,20 +22,17 @@ import { arrayMoveImmutable } from 'array-move';
 import { CgOptions } from 'react-icons/cg';
 import { MdClose, MdDragIndicator } from 'react-icons/md';
 import { IoWarning } from 'react-icons/io5';
-import { CompanyUser } from '$app/common/interfaces/company-user';
 import {
   decodeDashboardField,
   encodeDashboardField,
 } from '$app/common/helpers/react-settings';
-import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-api-response';
 import { useCurrentUser } from '$app/common/hooks/useCurrentUser';
 import { useColorScheme } from '$app/common/colors';
-import { useReactSettings } from '$app/common/hooks/useReactSettings';
-import { request } from '$app/common/helpers/request';
-import { endpoint } from '$app/common/helpers';
+import {
+  useReactSettings,
+  useSaveReactSettings,
+} from '$app/common/hooks/useReactSettings';
 import { toast } from '$app/common/helpers/toast/toast';
-import { resetChanges, updateUser } from '$app/common/stores/slices/user';
-import { $refetch } from '$app/common/hooks/useRefetch';
 import { Button, InputField } from '$app/components/forms';
 import { Icon } from '$app/components/icons/Icon';
 import { Modal } from '$app/components/Modal';
@@ -194,11 +190,11 @@ function DragItem({ decoded, onRemove }: DragItemProps) {
 
 export function DashboardCardSelector() {
   const [t] = useTranslation();
-  const dispatch = useDispatch();
 
   const colors = useColorScheme();
   const currentUser = useCurrentUser();
-  const reactSettings = useReactSettings({ overwrite: false });
+  const reactSettings = useReactSettings();
+  const saveSettings = useSaveReactSettings();
 
   const fieldsRef = useRef<string[]>([]);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -217,19 +213,33 @@ export function DashboardCardSelector() {
     fieldsRef.current = fields;
   }, [fields]);
 
+  // Seed local draft on the modal-open transition, and only re-seed mid-open
+  // if the persisted value materially changed (e.g. cross-tab save).
+  // `isEqual` (not reference equality) is required because
+  // `useUpdateReactSettings` deep-clones the whole atom on every write —
+  // unrelated writes would otherwise churn this array reference and wipe
+  // in-progress edits.
+  const lastSeededFieldsRef = useRef<string[] | undefined>(undefined);
   useEffect(() => {
-    if (manageOpen && currentUser) {
-      setFields(
-        currentUser.company_user?.react_settings.dashboard_fields ?? []
-      );
-
-      setSearchQuery('');
-      setSelectedField('');
-      setPeriod('current');
-      setCalculate('sum');
-      setFormat('money');
+    if (!manageOpen || !currentUser) {
+      lastSeededFieldsRef.current = undefined;
+      return;
     }
-  }, [manageOpen, currentUser]);
+    if (
+      lastSeededFieldsRef.current !== undefined &&
+      isEqual(reactSettings.dashboard_fields, lastSeededFieldsRef.current)
+    ) {
+      return;
+    }
+    lastSeededFieldsRef.current = reactSettings.dashboard_fields;
+    setFields(reactSettings.dashboard_fields ?? []);
+
+    setSearchQuery('');
+    setSelectedField('');
+    setPeriod('current');
+    setCalculate('sum');
+    setFormat('money');
+  }, [manageOpen, currentUser, reactSettings.dashboard_fields]);
 
   const filteredFields = useMemo(
     () =>
@@ -262,40 +272,21 @@ export function DashboardCardSelector() {
   );
 
   const handleSave = useCallback(() => {
-    const updated = cloneDeep(currentUser);
-
-    if (!updated || isFormBusy) {
+    if (!currentUser || isFormBusy) {
       return;
     }
 
     toast.processing();
     setIsFormBusy(true);
 
-    set(
-      updated,
-      'company_user.react_settings.dashboard_fields',
-      fieldsRef.current
-    );
-
-    request(
-      'PUT',
-      endpoint('/api/v1/company_users/:id', { id: updated.id }),
-      updated
-    )
-      .then((response: GenericSingleResourceResponse<CompanyUser>) => {
+    saveSettings('dashboard_fields', fieldsRef.current)
+      .then(() => {
         toast.success('updated_settings');
-
-        set(updated, 'company_user', response.data.data);
-
-        $refetch(['company_users']);
-
-        dispatch(updateUser(updated));
-        dispatch(resetChanges());
-
         setManageOpen(false);
       })
+      .catch(() => toast.dismiss())
       .finally(() => setIsFormBusy(false));
-  }, [currentUser, isFormBusy, dispatch]);
+  }, [currentUser, isFormBusy, saveSettings]);
 
   const handleAdd = useCallback(() => {
     if (!selectedField || isDuplicate) {

--- a/src/pages/dashboard/components/PreferenceCardsGrid.tsx
+++ b/src/pages/dashboard/components/PreferenceCardsGrid.tsx
@@ -8,17 +8,6 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
-import { useEffect, useState } from 'react';
-import { useDispatch } from 'react-redux';
-import { cloneDeep, set } from 'lodash';
-import { CompanyUser } from '$app/common/interfaces/company-user';
-import { useCurrentUser } from '$app/common/hooks/useCurrentUser';
-import { useReactSettings } from '$app/common/hooks/useReactSettings';
-import { request } from '$app/common/helpers/request';
-import { endpoint } from '$app/common/helpers';
-import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-api-response';
-import { resetChanges, updateUser } from '$app/common/stores/slices/user';
-import { $refetch } from '$app/common/hooks/useRefetch';
 import { DashboardCard } from './DashboardCard';
 
 interface Props {
@@ -37,91 +26,13 @@ export function PreferenceCardsGrid({
   endDate,
   currencyId,
 }: Props) {
-  //const [t] = useTranslation();
-  const dispatch = useDispatch();
-
-  const user = useCurrentUser();
-  const reactSettings = useReactSettings();
-
-  //const pendingRef = useRef<number>(0);
-
-  const [refreshKey, setRefreshKey] = useState<number>(0);
-  //const [isRefreshing, setIsRefreshing] = useState<boolean>(false);
-  const [order, setOrder] = useState<string[]>(currentDashboardFields);
-  //const [lastRefreshedAt, setLastRefreshedAt] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!user) {
-      return;
-    }
-
-    if (
-      JSON.stringify(reactSettings.dashboard_fields) === JSON.stringify(order)
-    ) {
-      return;
-    }
-
-    const updated = cloneDeep(user);
-
-    set(updated, 'company_user.react_settings.dashboard_fields', order);
-
-    request(
-      'PUT',
-      endpoint('/api/v1/company_users/:id', { id: updated.id }),
-      updated
-    ).then((response: GenericSingleResourceResponse<CompanyUser>) => {
-      set(updated, 'company_user', response.data.data);
-
-      $refetch(['company_users']);
-
-      dispatch(updateUser(updated));
-      dispatch(resetChanges());
-    });
-  }, [order]);
-
-  // const handleRefresh = useCallback(() => {
-  //   pendingRef.current = currentDashboardFields.length;
-
-  //   setIsRefreshing(true);
-  //   setRefreshKey((prev) => prev + 1);
-  // }, [currentDashboardFields.length]);
-
-  // const handleCardSettled = useCallback(() => {
-  //   pendingRef.current -= 1;
-
-  //   if (pendingRef.current <= 0) {
-  //     setLastRefreshedAt(dayjs().format('HH:mm'));
-  //     setIsRefreshing(false);
-
-  //     pendingRef.current = 0;
-  //   }
-  // }, []);
+  // `dashboard_fields` ordering/composition is owned by `DashboardCardSelector`
+  // — that component reads from and writes to `reactSettings.dashboard_fields`
+  // via `useSaveReactSettings`. This grid only renders the current list.
+  const refreshKey = 0;
 
   return (
     <div>
-      {/* <div className="flex justify-end items-center mb-2 gap-3">
-        {lastRefreshedAt && (
-          <span style={{ fontSize: '0.75rem', color: colors.$17 }}>
-            {t('last_updated')}: {lastRefreshedAt}
-          </span>
-        )}
-
-        <button
-          className={`flex items-center justify-center p-1 rounded-md border ${
-            isRefreshing ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'
-          }`}
-          onClick={handleRefresh}
-          disabled={isRefreshing}
-          style={{
-            borderColor: colors.$24,
-            backgroundColor: colors.$1,
-            color: colors.$3,
-          }}
-        >
-          <MdRefresh size={18} className={isRefreshing ? 'animate-spin' : ''} />
-        </button>
-      </div> */}
-
       <div className="grid grid-cols-4 gap-4 w-full">
         {currentDashboardFields.map((key, index) => (
           <div key={`${key}-${index}`} style={{ height: '130px' }}>
@@ -132,7 +43,6 @@ export function PreferenceCardsGrid({
               endDate={endDate}
               currencyId={currencyId}
               refreshKey={refreshKey}
-              //onSettled={handleCardSettled}
             />
           </div>
         ))}

--- a/src/pages/dashboard/components/Totals.tsx
+++ b/src/pages/dashboard/components/Totals.tsx
@@ -122,7 +122,7 @@ export function Totals() {
   const [t] = useTranslation();
 
   const formatMoney = useFormatMoney();
-  const { Preferences, update } = usePreferences();
+  const { Preferences, update, preferences } = usePreferences();
 
   const colors = useColorScheme();
   const company = useCurrentCompany();
@@ -134,17 +134,12 @@ export function Totals() {
   const [currencies, setCurrencies] = useState<Currency[]>([]);
   const [totalsData, setTotalsData] = useState<TotalsRecord[]>([]);
 
-  const chartScale =
-    settings?.preferences?.dashboard_charts?.default_view || 'month';
-  const currency = settings?.preferences?.dashboard_charts?.currency || 1;
-  const dateRange =
-    settings?.preferences?.dashboard_charts?.range || 'this_month';
-  const includeDrafts =
-    settings?.preferences?.dashboard_charts?.include_drafts || false;
-  const customStartDate =
-    settings?.preferences?.dashboard_charts?.custom_start_date;
-  const customEndDate =
-    settings?.preferences?.dashboard_charts?.custom_end_date;
+  const chartScale = preferences.dashboard_charts.default_view || 'month';
+  const currency = preferences.dashboard_charts.currency || 1;
+  const dateRange = preferences.dashboard_charts.range || 'this_month';
+  const includeDrafts = preferences.dashboard_charts.include_drafts || false;
+  const customStartDate = preferences.dashboard_charts.custom_start_date;
+  const customEndDate = preferences.dashboard_charts.custom_end_date;
   const currentDashboardFields = settings?.dashboard_fields ?? [];
 
   const resolvedRange = useMemo(() => {

--- a/src/pages/dashboard/components/Totals.tsx
+++ b/src/pages/dashboard/components/Totals.tsx
@@ -134,12 +134,12 @@ export function Totals() {
   const [currencies, setCurrencies] = useState<Currency[]>([]);
   const [totalsData, setTotalsData] = useState<TotalsRecord[]>([]);
 
-  const chartScale = preferences.dashboard_charts.default_view || 'month';
-  const currency = preferences.dashboard_charts.currency || 1;
-  const dateRange = preferences.dashboard_charts.range || 'this_month';
-  const includeDrafts = preferences.dashboard_charts.include_drafts || false;
-  const customStartDate = preferences.dashboard_charts.custom_start_date;
-  const customEndDate = preferences.dashboard_charts.custom_end_date;
+  const chartScale = preferences.dashboard_charts?.default_view || 'month';
+  const currency = preferences.dashboard_charts?.currency || 1;
+  const dateRange = preferences.dashboard_charts?.range || 'this_month';
+  const includeDrafts = preferences.dashboard_charts?.include_drafts || false;
+  const customStartDate = preferences.dashboard_charts?.custom_start_date;
+  const customEndDate = preferences.dashboard_charts?.custom_end_date;
   const currentDashboardFields = settings?.dashboard_fields ?? [];
 
   const resolvedRange = useMemo(() => {

--- a/src/pages/invoices/edit/components/CommonActions.tsx
+++ b/src/pages/invoices/edit/components/CommonActions.tsx
@@ -16,7 +16,7 @@ import {
 import { useEffect, useState } from 'react';
 import { useActions as useInvoiceActions } from './Actions';
 import { ResourceAction } from '$app/components/DataTable';
-import { useCurrentUser } from '$app/common/hooks/useCurrentUser';
+import { useReactSettings } from '$app/common/hooks/useReactSettings';
 import { useTranslation } from 'react-i18next';
 import { Tooltip } from '$app/components/Tooltip';
 import { Credit } from '$app/common/interfaces/credit';
@@ -41,7 +41,7 @@ export function CommonActions(props: Props) {
 
   const { resource, entity } = props;
 
-  const user = useCurrentUser();
+  const reactSettings = useReactSettings();
   const colors = useColorScheme();
 
   const quoteActions = useQuoteActions({ dropdown: false });
@@ -92,8 +92,7 @@ export function CommonActions(props: Props) {
   };
 
   useEffect(() => {
-    const currentActions =
-      user?.company_user?.react_settings?.common_actions?.[entity];
+    const currentActions = reactSettings.common_actions?.[entity];
 
     if (currentActions) {
       const selected = actions()
@@ -113,7 +112,7 @@ export function CommonActions(props: Props) {
 
       setSelectedActions(selected as ResourceAction<Resource>[]);
     }
-  }, [user, resource]);
+  }, [reactSettings, resource]);
 
   return (
     <>

--- a/src/pages/settings/user/UserDetails.tsx
+++ b/src/pages/settings/user/UserDetails.tsx
@@ -20,7 +20,7 @@ import {
 import { RootState } from '$app/common/stores/store';
 import { PasswordConfirmation } from '$app/components/PasswordConfirmation';
 import { Tabs } from '$app/components/Tabs';
-import { useEffect, useState } from 'react';
+import { useEffect, useLayoutEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { Outlet } from 'react-router-dom';
@@ -32,8 +32,11 @@ import { toast } from '$app/common/helpers/toast/toast';
 import { useInjectCompanyChanges } from '$app/common/hooks/useInjectCompanyChanges';
 import { ValidationBag } from '$app/common/interfaces/validation-bag';
 import { useAdmin } from '$app/common/hooks/permissions/useHasPermission';
-import { useAtom } from 'jotai';
-import { usePreferences } from '$app/common/hooks/usePreferences';
+import { useAtom, useAtomValue } from 'jotai';
+import {
+  reactSettingsAtom,
+  useUserDetailsDraft,
+} from '$app/common/hooks/useReactSettings';
 import { TwoFactorAuthenticationModals } from './common/components/TwoFactorAuthenticationModals';
 import { hasLanguageChanged as hasLanguageChangedAtom } from '$app/pages/settings/localization/common/atoms';
 import { $refetch } from '$app/common/hooks/useRefetch';
@@ -73,8 +76,24 @@ export function UserDetails() {
   const [isFormBusy, setIsFormBusy] = useState<boolean>(false);
 
   const userState = useSelector((state: RootState) => state.user);
+  const rawReactSettings = useAtomValue(reactSettingsAtom);
+  const isReactSettingsHydrated = rawReactSettings !== null;
+  const userDetailsDraft = useUserDetailsDraft();
 
-  const { save } = usePreferences();
+  useLayoutEffect(() => {
+    if (isReactSettingsHydrated) {
+      userDetailsDraft.begin();
+    }
+
+    return () => {
+      userDetailsDraft.discard();
+    };
+  }, [user?.id, isReactSettingsHydrated, userDetailsDraft]);
+
+  const resetUserDetailsDraft = () => {
+    userDetailsDraft.discard();
+    userDetailsDraft.begin();
+  };
 
   const onSave = (password: string, passwordIsRequired: boolean) => {
     if (isFormBusy) {
@@ -86,17 +105,24 @@ export function UserDetails() {
     toast.processing();
     setErrors(undefined);
 
-    const requests = [
+    // `react_settings` is owned by the dedicated `/preferences` endpoint.
+    const userChanges = { ...userState.changes };
+    if (userChanges.company_user) {
+      userChanges.company_user = { ...userChanges.company_user };
+      delete userChanges.company_user.react_settings;
+    }
+
+    const userRequests = [
       request(
         'PUT',
         endpoint('/api/v1/users/:id?include=company_user', { id: user!.id }),
-        userState.changes,
+        userChanges,
         { headers: { 'X-Api-Password': password } }
       ),
     ];
 
     if (isAdmin) {
-      requests.push(
+      userRequests.push(
         request(
           'PUT',
           endpoint('/api/v1/companies/:id', { id: company?.id }),
@@ -105,10 +131,21 @@ export function UserDetails() {
       );
     }
 
-    axios
-      .all(requests)
+    let preferencesFlushed = true;
+
+    userDetailsDraft
+      .commit()
+      .catch(() => {
+        preferencesFlushed = false;
+      })
+      .then(() => axios.all(userRequests))
       .then((response) => {
-        toast.success('updated_settings');
+        if (preferencesFlushed) {
+          toast.success('updated_settings');
+          userDetailsDraft.begin();
+        } else {
+          toast.error();
+        }
 
         $refetch(['users']);
 
@@ -117,15 +154,17 @@ export function UserDetails() {
           setHasLanguageIdChanged(false);
         }
 
+        const userResponse = response[0];
+
         if (
-          response[0].data.data.phone !== user?.phone &&
+          userResponse.data.data.phone !== user?.phone &&
           user?.google_2fa_secret &&
-          !response[0].data.data.verified_phone_number
+          !userResponse.data.data.verified_phone_number
         ) {
           setCheckVerification(true);
         }
 
-        dispatch(updateUser(response[0].data.data));
+        dispatch(updateUser(userResponse.data.data));
         dispatch(resetChanges());
 
         window.dispatchEvent(new CustomEvent('user.updated'));
@@ -150,8 +189,6 @@ export function UserDetails() {
         }
       })
       .finally(() => setIsFormBusy(false));
-
-    save({ silent: true });
   };
 
   useEffect(() => {
@@ -162,7 +199,10 @@ export function UserDetails() {
     <>
       <Settings
         onSaveClick={() => setPasswordConfirmModalOpen(true)}
-        onCancelClick={() => dispatch(resetChanges())}
+        onCancelClick={() => {
+          dispatch(resetChanges());
+          resetUserDetailsDraft();
+        }}
         title={t('user_details')}
         breadcrumbs={pages}
         docsLink="en/basic-settings/#user_details"

--- a/src/pages/settings/user/components/Preferences.tsx
+++ b/src/pages/settings/user/components/Preferences.tsx
@@ -10,14 +10,12 @@
 
 import Toggle from '$app/components/forms/Toggle';
 import { useTranslation } from 'react-i18next';
-import { useDispatch } from 'react-redux';
 import { Element } from '../../../../components/cards';
-import { updateChanges } from '$app/common/stores/slices/user';
 import {
   preferencesDefaults,
-  useReactSettings,
+  useDraftOrCommittedReactSettings,
+  useUpdateDraftOrReactSettings,
 } from '$app/common/hooks/useReactSettings';
-import { usePreferences } from '$app/common/hooks/usePreferences';
 import { get } from 'lodash';
 import { ReactNode } from 'react';
 import { StatusColorTheme } from './StatusColorTheme';
@@ -28,18 +26,15 @@ import { CircleXMark } from '$app/components/icons/CircleXMark';
 
 export function Preferences() {
   const [t] = useTranslation();
-  const dispatch = useDispatch();
 
   const colors = useColorScheme();
-  const reactSettings = useReactSettings();
+  const reactSettings = useDraftOrCommittedReactSettings();
+  const updateSettings = useUpdateDraftOrReactSettings();
 
+  // UserDetails owns an explicit page-level draft. These controls should not
+  // write to the committed global atom until the user presses Save.
   const handleChange = (property: string, value: string | number | boolean) => {
-    dispatch(
-      updateChanges({
-        property: property,
-        value: value,
-      })
-    );
+    updateSettings(property.replace(/^company_user\.react_settings\./, ''), value);
   };
 
   return (
@@ -229,7 +224,8 @@ interface PreferenceCardProps {
 
 function PreferenceCard({ title, children, path }: PreferenceCardProps) {
   const colors = useColorScheme();
-  const { preferences } = usePreferences();
+  const reactSettings = useDraftOrCommittedReactSettings();
+  const preferences = reactSettings.preferences;
 
   if (
     JSON.stringify(get(preferencesDefaults, path)) ===
@@ -263,7 +259,9 @@ interface PreferenceProps {
 
 function Preference({ path }: PreferenceProps) {
   const colors = useColorScheme();
-  const { preferences, update } = usePreferences();
+  const reactSettings = useDraftOrCommittedReactSettings();
+  const updateSettings = useUpdateDraftOrReactSettings();
+  const preferences = reactSettings.preferences;
   const { t } = useTranslation();
 
   const translations = {
@@ -287,9 +285,7 @@ function Preference({ path }: PreferenceProps) {
       <div
         className="hover:opacity-75 cursor-pointer"
         onClick={() =>
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
-          update(`preferences.${path}`, get(preferencesDefaults, path))
+          updateSettings(`preferences.${path}`, get(preferencesDefaults, path))
         }
       >
         <CircleXMark

--- a/src/pages/settings/user/components/Preferences.tsx
+++ b/src/pages/settings/user/components/Preferences.tsx
@@ -31,8 +31,6 @@ export function Preferences() {
   const reactSettings = useDraftOrCommittedReactSettings();
   const updateSettings = useUpdateDraftOrReactSettings();
 
-  // UserDetails owns an explicit page-level draft. These controls should not
-  // write to the committed global atom until the user presses Save.
   const handleChange = (property: string, value: string | number | boolean) => {
     updateSettings(property.replace(/^company_user\.react_settings\./, ''), value);
   };

--- a/src/pages/settings/user/components/StatusColorTheme.tsx
+++ b/src/pages/settings/user/components/StatusColorTheme.tsx
@@ -8,8 +8,10 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
-import { useHandleCurrentUserChangeProperty } from '$app/common/hooks/useHandleCurrentUserChange';
-import { useReactSettings } from '$app/common/hooks/useReactSettings';
+import {
+  useDraftOrCommittedReactSettings,
+  useUpdateDraftOrReactSettings,
+} from '$app/common/hooks/useReactSettings';
 import { Modal } from '$app/components/Modal';
 import { Element } from '$app/components/cards';
 import { Button, InputField, SelectField } from '$app/components/forms';
@@ -20,8 +22,6 @@ import { MdDone } from 'react-icons/md';
 import hexColorRegex from 'hex-color-regex';
 import { toast } from '$app/common/helpers/toast/toast';
 import { cloneDeep } from 'lodash';
-import { useDispatch } from 'react-redux';
-import { updateChanges } from '$app/common/stores/slices/user';
 import { useColorScheme } from '$app/common/colors';
 import { CircleXMark } from '$app/components/icons/CircleXMark';
 
@@ -185,7 +185,7 @@ export function useIsColorValid() {
 }
 
 export function useStatusThemeColorScheme() {
-  const reactSettings = useReactSettings();
+  const reactSettings = useDraftOrCommittedReactSettings();
 
   const colors = {
     $1: '',
@@ -205,7 +205,7 @@ export function useStatusThemeColorScheme() {
 }
 
 export function useThemeColorScheme() {
-  const reactSettings = useReactSettings();
+  const reactSettings = useDraftOrCommittedReactSettings();
 
   const colors = {
     $1: '',
@@ -228,10 +228,12 @@ export function useThemeColorScheme() {
 export function StatusColorTheme() {
   const [t] = useTranslation();
 
-  const reactSettings = useReactSettings();
+  const reactSettings = useDraftOrCommittedReactSettings();
+  const updateSettings = useUpdateDraftOrReactSettings();
 
-  const dispatch = useDispatch();
-  const handleUserChange = useHandleCurrentUserChangeProperty();
+  const handleUserChange = (path: string, value: unknown) => {
+    updateSettings(path.replace(/^company_user\.react_settings\./, ''), value);
+  };
 
   const handleExportColors = () => {
     let value = '';
@@ -261,12 +263,7 @@ export function StatusColorTheme() {
         updatedColorTheme[fieldKey] = '';
       });
 
-      dispatch(
-        updateChanges({
-          property: 'company_user.react_settings.color_theme',
-          value: updatedColorTheme,
-        })
-      );
+      updateSettings('color_theme', updatedColorTheme);
     }
   };
 
@@ -335,9 +332,12 @@ interface Props {
 export function CustomColorField(props: Props) {
   const { fieldKey } = props;
 
-  const reactSettings = useReactSettings();
+  const reactSettings = useDraftOrCommittedReactSettings();
+  const updateSettings = useUpdateDraftOrReactSettings();
 
-  const handleUserChange = useHandleCurrentUserChangeProperty();
+  const handleUserChange = (path: string, value: unknown) => {
+    updateSettings(path.replace(/^company_user\.react_settings\./, ''), value);
+  };
 
   return (
     <div className="flex space-x-20">
@@ -366,10 +366,14 @@ export function DefaultColorPickerModal(props: ModalProps) {
   const { fieldKey } = props;
 
   const colors = useColorScheme();
-  const reactSettings = useReactSettings();
+  const reactSettings = useDraftOrCommittedReactSettings();
+  const updateSettings = useUpdateDraftOrReactSettings();
 
   const isColorValid = useIsColorValid();
-  const handleUserChange = useHandleCurrentUserChangeProperty();
+
+  const handleUserChange = (path: string, value: unknown) => {
+    updateSettings(path.replace(/^company_user\.react_settings\./, ''), value);
+  };
 
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [selectedColor, setSelectedColor] = useState<string>('');


### PR DESCRIPTION
This PR reduces unnecessary rerenders caused by changes to `react_settings`.

Previously, `react_settings` lived inside the Redux user state. Any update to preferences could churn the larger user/change tree and cause unrelated consumers to rerender. This PR moves committed `react_settings` into a dedicated Jotai atom, with more focused access patterns for consumers that only need specific settings.

## Persistence Model

This changes the persistence model for `react_settings`.

Updates are now written optimistically to the local atom and persisted via the dedicated preferences endpoint. On a successful HTTP response, the frontend treats the local atom as the source of truth and does not rehydrate it from the PUT response.

The assumption is that a successful response means the submitted settings were accepted by the API. Avoiding response-based rehydration prevents stale server response payloads from overwriting newer local changes that may have occurred while a save request was in flight.

Queued saves re-read the atom at send time, so later saves persist the latest committed local state rather than an older captured snapshot.

## Draft Handling

This PR also separates committed settings from draft settings.

Cancelable flows, such as preferences modals and User Details preference edits, keep changes in local or draft state until the user explicitly saves. Cancel/discard flows can therefore drop dirty edits without mutating the committed atom or accidentally persisting those edits through an unrelated save.

For User Details, draft commits patch only the dirty paths into the committed atom. If persistence fails, only those paths are rolled back, preserving any concurrent immediate settings changes such as sidebar collapse or dark mode.
