### PR TITLE
Invalidate invoices after payment schedule mutation

### DIFF
--- a/src/pages/invoices/edit/components/PaymentSchedule.tsx
+++ b/src/pages/invoices/edit/components/PaymentSchedule.tsx
@@ -31,8 +31,8 @@ import { endpoint } from '$app/common/helpers';
 import { toast } from '$app/common/helpers/toast/toast';
 import { ValidationBag } from '$app/common/interfaces/validation-bag';
 import { AxiosError } from 'axios';
-import { useQueryClient } from 'react-query';
 import { History as HistoryIcon } from '$app/components/icons/History';
+import { $refetch } from '$app/common/hooks/useRefetch';
 
 const ScheduleBox = styled.div`
   background-color: ${(props) => props.theme.backgroundColor};
@@ -58,7 +58,6 @@ function PaymentSchedule() {
   const { invoice } = context;
 
   const colors = useColorScheme();
-  const queryClient = useQueryClient();
 
   const formatMoney = useFormatMoney();
 
@@ -302,8 +301,7 @@ function PaymentSchedule() {
         })
         .finally(() => {
           setIsCreatingSchedule(false);
-          queryClient.invalidateQueries({ queryKey: ['/api/v1/invoices', invoice?.id] });
-          
+          $refetch(['invoices']);
         });
     }
   };
@@ -352,7 +350,7 @@ function PaymentSchedule() {
         })
         .finally(() => {
           setIsCreatingSchedule(false);
-          queryClient.invalidateQueries({ queryKey: ['/api/v1/invoices', invoice?.id] });
+          $refetch(['invoices']);
         });
     }
   };
@@ -395,6 +393,7 @@ function PaymentSchedule() {
         })
         .finally(() => {
           setIsRemovingSchedule(false);
+          $refetch(['invoices']);
         });
     }
   };

--- a/src/pages/settings/schedules/create/Create.tsx
+++ b/src/pages/settings/schedules/create/Create.tsx
@@ -97,6 +97,10 @@ export function Create() {
 
           $refetch(['task_schedulers']);
 
+          if (schedule.template === 'payment_schedule') {
+            $refetch(['invoices']);
+          }
+
           navigate(
             route('/settings/schedules/:id/edit', {
               id: response.data.data.id,

--- a/src/pages/settings/schedules/edit/Edit.tsx
+++ b/src/pages/settings/schedules/edit/Edit.tsx
@@ -69,6 +69,10 @@ export function Edit() {
           toast.success('updated_schedule');
 
           $refetch(['task_schedulers']);
+
+          if (schedule.template === 'payment_schedule') {
+            $refetch(['invoices']);
+          }
         })
         .catch((error: AxiosError<ValidationBag>) => {
           if (error.response?.status === 422) {


### PR DESCRIPTION
Invalidate the invoices queries after a payment schedule has been created/removed, to ensure the latest invoice state is returned.