### PR TITLE
[Cleanup] Adding Entity Number To Schedule Template Name

### DIFF
--- a/src/pages/settings/schedules/common/components/ScheduleForm.tsx
+++ b/src/pages/settings/schedules/common/components/ScheduleForm.tsx
@@ -25,6 +25,7 @@ import { EmailReport } from './EmailReport';
 import { useColorScheme } from '$app/common/colors';
 import { InvoiceOutstandingTasks } from './InvoiceOutstandingTasks';
 import { PaymentSchedule } from './PaymentSchedule';
+import { useEntityNumber } from '../hooks/useEntityNumber';
 
 interface Props {
   schedule: Schedule;
@@ -56,15 +57,29 @@ export function ScheduleForm(props: Props) {
     template: schedule.template as Template,
   });
 
+  const entityNumber = useEntityNumber({
+    entity:
+      schedule.template === Templates.EMAIL_RECORD
+        ? schedule.parameters.entity
+        : undefined,
+    entityId:
+      schedule.template === Templates.EMAIL_RECORD
+        ? schedule.parameters.entity_id
+        : undefined,
+    enabled: Boolean(schedule && page === 'edit' && !schedule.name),
+  });
+
   const getTemplateNameValue = () => {
     if (page === 'create') {
       return '';
     }
 
     if (schedule.template === Templates.EMAIL_RECORD) {
-      return `${t(schedule.template as string)}: ${t(
+      const base = `${t(schedule.template as string)}: ${t(
         schedule.parameters.entity
       )}`;
+
+      return entityNumber ? `${base} #${entityNumber}` : base;
     }
 
     if (schedule.template === Templates.EMAIL_REPORT) {

--- a/src/pages/settings/schedules/common/components/ScheduleName.tsx
+++ b/src/pages/settings/schedules/common/components/ScheduleName.tsx
@@ -1,0 +1,72 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { Schedule } from '$app/common/interfaces/schedule';
+import { useTranslation } from 'react-i18next';
+import { useEntityNumber } from '../hooks/useEntityNumber';
+import { Templates } from './ScheduleForm';
+
+interface Props {
+  schedule: Schedule;
+}
+
+export function ScheduleName({ schedule }: Props) {
+  const [t] = useTranslation();
+
+  const entityNumber = useEntityNumber({
+    entity:
+      schedule.template === Templates.EMAIL_RECORD
+        ? schedule.parameters.entity
+        : undefined,
+    entityId:
+      schedule.template === Templates.EMAIL_RECORD
+        ? schedule.parameters.entity_id
+        : undefined,
+    enabled: Boolean(schedule && !schedule.name),
+  });
+
+  if (schedule.name) {
+    return <>{schedule.name}</>;
+  }
+
+  if (schedule.template === Templates.EMAIL_RECORD) {
+    const base = `${t(schedule.template as string)}: ${t(
+      schedule.parameters.entity
+    )}`;
+
+    return <>{entityNumber ? `${base} #${entityNumber}` : base}</>;
+  }
+
+  if (schedule.template === Templates.EMAIL_REPORT) {
+    return (
+      <>
+        {`${t(schedule.template as string)}: ${t(
+          schedule.parameters.report_name
+        )} | ${t(schedule.parameters.date_range)}`}
+      </>
+    );
+  }
+
+  if (schedule.template === Templates.PAYMENT_SCHEDULE) {
+    return <>{schedule.name}</>;
+  }
+
+  if (schedule.template === Templates.INVOICE_OUTSTANDING_TASKS) {
+    return <>{schedule.name}</>;
+  }
+
+  return (
+    <>
+      {`${t(schedule.template as string)}: ${t(
+        schedule.parameters.date_range
+      )}`}
+    </>
+  );
+}

--- a/src/pages/settings/schedules/common/hooks/useEntityNumber.ts
+++ b/src/pages/settings/schedules/common/hooks/useEntityNumber.ts
@@ -1,0 +1,44 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { endpoint } from '$app/common/helpers';
+import { request } from '$app/common/helpers/request';
+import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-api-response';
+import { Parameters } from '$app/common/interfaces/schedule';
+import { useQuery } from 'react-query';
+
+interface Params {
+  entity: Parameters['entity'] | undefined;
+  entityId: string | undefined;
+  enabled: boolean;
+}
+
+interface EntityWithNumber {
+  number: string;
+}
+
+export function useEntityNumber({ entity, entityId, enabled }: Params) {
+  const { data: entityResponse } = useQuery<EntityWithNumber>(
+    [`/api/v1/${entity}s/:id`, entityId, 'schedule_entity_number'],
+    () =>
+      request(
+        'GET',
+        endpoint(`/api/v1/${entity}s/:id`, {
+          id: entityId,
+        })
+      ).then(
+        (response: GenericSingleResourceResponse<EntityWithNumber>) =>
+          response.data.data
+      ),
+    { staleTime: Infinity, enabled: Boolean(entity && entityId && enabled) }
+  );
+
+  return entityResponse?.number || '';
+}

--- a/src/pages/settings/schedules/common/hooks/useFormatSchedulePayload.tsx
+++ b/src/pages/settings/schedules/common/hooks/useFormatSchedulePayload.tsx
@@ -17,14 +17,16 @@ interface Params {
 
 const TemplateProperties = {
   email_statement: [
+    'name',
     'template',
     'next_run',
     'frequency_id',
     'remaining_cycles',
     'parameters',
   ],
-  email_record: ['template', 'next_run', 'parameters', 'template'],
+  email_record: ['name', 'template', 'next_run', 'parameters', 'template'],
   email_report: [
+    'name',
     'template',
     'next_run',
     'frequency_id',
@@ -32,12 +34,13 @@ const TemplateProperties = {
     'parameters',
   ],
   invoice_outstanding_tasks: [
+    'name',
     'template',
     'next_run',
     'frequency_id',
     'parameters',
   ],
-  payment_schedule: ['template', 'next_run', 'parameters'],
+  payment_schedule: ['name', 'template', 'next_run', 'parameters'],
 };
 
 const NullableProperties = ['vendors', 'projects', 'categories', 'tag_ids'];

--- a/src/pages/settings/schedules/common/hooks/useScheduleColumns.tsx
+++ b/src/pages/settings/schedules/common/hooks/useScheduleColumns.tsx
@@ -12,7 +12,7 @@ import { Schedule } from '$app/common/interfaces/schedule';
 import { DataTableColumns } from '$app/components/DataTable';
 import { useTranslation } from 'react-i18next';
 import frequencies from '$app/common/constants/frequency';
-import { Templates } from '$app/pages/settings/schedules/common/components/ScheduleForm';
+import { ScheduleName } from '$app/pages/settings/schedules/common/components/ScheduleName';
 
 export function useScheduleColumns() {
   const [t] = useTranslation();
@@ -21,35 +21,7 @@ export function useScheduleColumns() {
     {
       id: 'name',
       label: t('name'),
-      format: (value, schedule) => {
-        if (value) {
-          return value;
-        }
-
-        if (schedule.template === Templates.EMAIL_RECORD) {
-          return `${t(schedule.template as string)}: ${t(
-            schedule.parameters.entity
-          )}`;
-        }
-
-        if (schedule.template === Templates.EMAIL_REPORT) {
-          return `${t(schedule.template as string)}: ${t(
-            schedule.parameters.report_name
-          )} | ${t(schedule.parameters.date_range)}`;
-        }
-
-        if (schedule.template === Templates.PAYMENT_SCHEDULE) {
-          return schedule.name;
-        }
-
-        if (schedule.template === Templates.INVOICE_OUTSTANDING_TASKS) {
-          return schedule.name;
-        }
-
-        return `${t(schedule.template as string)}: ${t(
-          schedule.parameters.date_range
-        )}`;
-      },
+      format: (_, schedule) => <ScheduleName schedule={schedule} />,
     },
     {
       id: 'next_run',

--- a/src/pages/settings/schedules/create/Create.tsx
+++ b/src/pages/settings/schedules/create/Create.tsx
@@ -130,6 +130,7 @@ export function Create() {
           handleChange={handleChange}
           errors={errors}
           setErrors={setErrors}
+          page="create"
         />
       ) : (
         <Spinner />


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of adding an entity number to the schedule template name if it is not already specifically entered. Screenshots:

<img width="738" height="445" alt="Screenshot 2026-06-02 at 20 55 52" src="https://github.com/user-attachments/assets/53b681be-c317-4541-8db9-493a94b5c5d4" />

<img width="973" height="445" alt="Screenshot 2026-06-02 at 20 56 02" src="https://github.com/user-attachments/assets/b3b4da36-b9c5-4e19-99dd-a7e680deaee0" />

Let me know your thoughts.