### PR TITLE
Fixes for performance in report previews + multi column sorting

### DIFF
--- a/src/common/colors.ts
+++ b/src/common/colors.ts
@@ -8,7 +8,7 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
-import { useReactSettings } from './hooks/useReactSettings';
+import { useReactSettingsField } from './hooks/useReactSettings';
 
 // export const $1 = {
 //   name: 'invoiceninja.dark',
@@ -85,7 +85,7 @@ export const lightColorScheme = {
 };
 
 export function useColorScheme() {
-  const reactSettings = useReactSettings();
+  const darkMode = useReactSettingsField('dark_mode');
 
-  return reactSettings.dark_mode ? darkColorScheme : lightColorScheme;
+  return darkMode ? darkColorScheme : lightColorScheme;
 }

--- a/src/pages/reports/common/components/EnhancedPreview.tsx
+++ b/src/pages/reports/common/components/EnhancedPreview.tsx
@@ -11,7 +11,6 @@
 import { useColorScheme } from '$app/common/colors';
 import { Button, InputField } from '$app/components/forms';
 import { Table, Tbody, Td, Th, Thead, Tr } from '$app/components/tables';
-import { cloneDeep } from 'lodash';
 import { useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -34,10 +33,10 @@ interface EnhancedPreviewProps {
   enableGrouping?: boolean;
 }
 
-export function EnhancedPreview({ 
+export function EnhancedPreview({
   enableMultiSort = true,
   enableNaturalSort = true,
-  enableGrouping = false 
+  enableGrouping = false,
 }: EnhancedPreviewProps) {
   const [t] = useTranslation();
 
@@ -47,8 +46,18 @@ export function EnhancedPreview({
 
   const [sortConfigs, setSortConfigs] = useState<SortConfig[]>([]);
   const [filterValues, setFilterValues] = useState<Record<string, string>>({});
-  const [sortTypeOverrides, setSortTypeOverrides] = useState<Record<string, SortType>>({});
+  const [sortTypeOverrides, setSortTypeOverrides] = useState<
+    Record<string, SortType>
+  >({});
   const [groupByColumn, setGroupByColumn] = useState<string | null>(null);
+
+  const activeFilters = useMemo(
+    () =>
+      Object.entries(filterValues)
+        .filter(([, value]) => value.trim() !== '')
+        .map(([column, value]) => ({ column, search: value.toLowerCase() })),
+    [filterValues]
+  );
 
   // Apply cumulative filters to the original data
   const filtered = useMemo(() => {
@@ -56,55 +65,48 @@ export function EnhancedPreview({
     if (!preview) {
       return { columns: [], rows: [] };
     }
-    
-    // Always start with the preview data
-    const copy = cloneDeep(preview);
-    
+
+    let rows = preview.rows;
+
     // Apply filters only if there are any active filters with values
-    const hasActiveFilters = Object.values(filterValues).some(value => value.trim() !== '');
-    
-    if (hasActiveFilters) {
-      copy.rows = copy.rows.filter((row) => {
+    if (activeFilters.length > 0) {
+      rows = rows.filter((row) =>
         // Row must match ALL filters
-        return Object.entries(filterValues).every(([column, value]) => {
-          if (!value || value.trim() === '') return true; // Skip empty filters
-          
+        activeFilters.every(({ column, search }) => {
           const cell = row.find((item) => item.identifier === column);
           if (!cell) return false;
-          
-          const searchValue = value.toLowerCase();
-          
-          if (typeof cell.display_value === 'number') {
-            return cell.display_value
-              .toString()
-              .toLowerCase()
-              .includes(searchValue);
+
+          const value = cell.display_value;
+
+          if (typeof value === 'number') {
+            return value.toString().toLowerCase().includes(search);
           }
-          
-          if (typeof cell.display_value === 'string') {
-            return cell.display_value.toLowerCase().includes(searchValue);
+
+          if (typeof value === 'string') {
+            return value.toLowerCase().includes(search);
           }
-          
-          if (typeof cell.display_value === 'object' && cell.display_value?.props?.children) {
-            const childContent = typeof cell.display_value.props.children === 'string' 
-              ? cell.display_value.props.children
-              : String(cell.display_value.props.children || '');
-            return childContent.toLowerCase().includes(searchValue);
+
+          if (typeof value === 'object' && value?.props?.children) {
+            const childContent =
+              typeof value.props.children === 'string'
+                ? value.props.children
+                : String(value.props.children || '');
+            return childContent.toLowerCase().includes(search);
           }
-          
+
           return false;
-        });
-      });
+        })
+      );
     }
-    
+
     // Apply sorting after filtering
     if (sortConfigs.length > 0) {
-      copy.rows = sortRows(copy.rows, sortConfigs);
+      rows = sortRows(rows, sortConfigs);
     }
-    
-    return copy;
-  }, [preview, filterValues, sortConfigs]); // Dependencies ensure re-computation when any change
-  
+
+    return { columns: preview.columns, rows };
+  }, [preview, activeFilters, sortConfigs]); // Dependencies ensure re-computation when any change
+
   const columnTotals = useMemo(() => {
     const summable = new Set<string>();
     const sums: Record<string, number> = {};
@@ -147,44 +149,44 @@ export function EnhancedPreview({
   if (!preview) {
     return null;
   }
-  
+
   const filter = (column: string, value: string) => {
-    setFilterValues(prev => ({
+    setFilterValues((prev) => ({
       ...prev,
-      [column]: value
+      [column]: value,
     }));
   };
 
-  const handleSort = (column: string, shiftKey: boolean = false) => {
+  const handleSort = (column: string) => {
     let newConfigs: SortConfig[];
-    
-    const existingConfig = sortConfigs.find(config => config.column === column);
+
+    const existingConfig = sortConfigs.find(
+      (config) => config.column === column
+    );
     const direction = existingConfig?.direction === 'asc' ? 'desc' : 'asc';
-    
+
     // Detect sort type based on first non-empty value
     const dataToSort = filtered;
-    const firstRow = dataToSort.rows.find(row => {
-      const cell = row.find(c => c.identifier === column);
+    const firstRow = dataToSort.rows.find((row) => {
+      const cell = row.find((c) => c.identifier === column);
       return cell && cell.display_value !== '' && cell.display_value !== null;
     });
-    
-    const firstCell = firstRow?.find(c => c.identifier === column);
-    const detectedType = firstCell ? detectSortType(column, String(firstCell.display_value)) : 'case-insensitive';
+
+    const firstCell = firstRow?.find((c) => c.identifier === column);
+    const detectedType = firstCell
+      ? detectSortType(column, String(firstCell.display_value))
+      : 'case-insensitive';
     const sortType = sortTypeOverrides[column] || detectedType;
 
-    if (enableMultiSort && shiftKey) {
-      // Multi-column sort with Shift key
+    if (enableMultiSort) {
       if (existingConfig) {
-        newConfigs = sortConfigs.map(config =>
-          config.column === column
-            ? { ...config, direction, sortType }
-            : config
+        newConfigs = sortConfigs.map((config) =>
+          config.column === column ? { ...config, direction, sortType } : config
         );
       } else {
         newConfigs = [...sortConfigs, { column, direction, sortType }];
       }
     } else {
-      // Single column sort
       newConfigs = [{ column, direction, sortType }];
     }
 
@@ -192,7 +194,7 @@ export function EnhancedPreview({
   };
 
   const removeSortColumn = (column: string) => {
-    const newConfigs = sortConfigs.filter(config => config.column !== column);
+    const newConfigs = sortConfigs.filter((config) => config.column !== column);
     setSortConfigs(newConfigs);
   };
 
@@ -207,7 +209,7 @@ export function EnhancedPreview({
     if (!data || !data.rows || data.rows.length === 0) {
       return;
     }
-    
+
     const rows = [
       preview.columns.map((column) => column.display_value).join(','),
     ];
@@ -227,7 +229,7 @@ export function EnhancedPreview({
               return 'No';
             }
 
-            return `"${displayStr || ""}"`; 
+            return `"${displayStr || ''}"`;
           })
           .join(',')
       );
@@ -245,10 +247,10 @@ export function EnhancedPreview({
 
   const renderGroupedData = () => {
     if (!groupByColumn) return renderNormalData();
-    
+
     const groups = groupRows(data.rows, groupByColumn);
     const elements: JSX.Element[] = [];
-    
+
     groups.forEach((rows, groupName) => {
       elements.push(
         <Tr key={`group-${groupName}`} style={{ backgroundColor: colors.$5 }}>
@@ -257,7 +259,7 @@ export function EnhancedPreview({
           </Td>
         </Tr>
       );
-      
+
       rows.forEach((row, i) => {
         elements.push(
           <Tr
@@ -272,17 +274,13 @@ export function EnhancedPreview({
         );
       });
     });
-    
+
     return elements;
   };
 
   const renderNormalData = () => {
     return data.rows.map((row, i) => (
-      <Tr
-        key={i}
-        className="border-b"
-        style={{ borderColor: colors.$20 }}
-      >
+      <Tr key={i} className="border-b" style={{ borderColor: colors.$20 }}>
         {row.map((cell, j) => (
           <Td key={j}>{cell.display_value}</Td>
         ))}
@@ -306,7 +304,7 @@ export function EnhancedPreview({
               onChange={(e) => setGroupByColumn(e.target.value || null)}
             >
               <option value="">No grouping</option>
-              {preview.columns.map(col => (
+              {preview.columns.map((col) => (
                 <option key={col.identifier} value={col.identifier}>
                   Group by {col.display_value}
                 </option>
@@ -322,15 +320,19 @@ export function EnhancedPreview({
       <Table>
         <Thead>
           {preview.columns.map((column, i) => {
-            const sortConfig = sortConfigs.find(config => config.column === column.identifier);
-            const sortIndex = sortConfig ? sortConfigs.indexOf(sortConfig) + 1 : null;
-            
+            const sortConfig = sortConfigs.find(
+              (config) => config.column === column.identifier
+            );
+            const sortIndex = sortConfig
+              ? sortConfigs.indexOf(sortConfig) + 1
+              : null;
+
             return (
               <Th
                 key={i}
                 style={{ borderBottom: `1px solid ${colors.$20}` }}
                 isCurrentlyUsed={!!sortConfig}
-                onColumnClick={(e: React.MouseEvent) => handleSort(column.identifier, e.shiftKey)}
+                onClick={() => handleSort(column.identifier)}
               >
                 <div className="flex items-center justify-between gap-2">
                   <span>{column.display_value}</span>
@@ -362,10 +364,7 @@ export function EnhancedPreview({
         </Thead>
 
         <Tbody>
-          <Tr
-            className="border-b"
-            style={{ borderColor: colors.$20 }}
-          >
+          <Tr className="border-b" style={{ borderColor: colors.$20 }}>
             {preview.columns.map((column, i) => (
               <Td key={i}>
                 <InputField
@@ -404,14 +403,13 @@ export function EnhancedPreview({
 
           {enableGrouping && groupByColumn
             ? renderGroupedData()
-            : renderNormalData()
-          }
+            : renderNormalData()}
         </Tbody>
       </Table>
-      
+
       {enableMultiSort && (
         <div className="mt-2 text-sm text-gray-600">
-          {t('tip')}: Hold Shift while clicking to sort by multiple columns
+          {t('tip')}: Click another column to add it to the sort order
         </div>
       )}
     </div>

--- a/src/pages/reports/common/components/Preview.tsx
+++ b/src/pages/reports/common/components/Preview.tsx
@@ -15,7 +15,11 @@ import { atom, useAtom } from 'jotai';
 import { cloneDeep } from 'lodash';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { compareValues, detectSortType, extractDisplayValue } from '../utils/sortingUtils';
+import {
+  compareValues,
+  detectSortType,
+  extractDisplayValue,
+} from '../utils/sortingUtils';
 
 export const previewAtom = atom<Preview | null>(null);
 
@@ -66,21 +70,31 @@ export function usePreview() {
       return;
     }
 
-    const copy = cloneDeep(preview);
+    const hasReplacements = preview.columns.some((column) =>
+      replacements.some((r) => r.identifier === column.identifier)
+    );
 
-    copy.rows.map((row) => {
-      row.map((cell) => {
-        const replacement = replacements.find(
-          (replacement) => replacement.identifier === cell.identifier
-        );
+    if (!hasReplacements) {
+      setProcessed(preview);
+      return;
+    }
 
-        if (replacement) {
-          cell.display_value = replacement.format(cell);
-        }
-      });
+    const replacementByIdentifier = new Map(
+      replacements.map((replacement) => [replacement.identifier, replacement])
+    );
+
+    setProcessed({
+      columns: preview.columns,
+      rows: preview.rows.map((row) =>
+        row.map((cell) => {
+          const replacement = replacementByIdentifier.get(cell.identifier);
+
+          return replacement
+            ? { ...cell, display_value: replacement.format(cell) }
+            : cell;
+        })
+      ),
     });
-
-    setProcessed(copy);
   }, [preview]);
 
   return processed;
@@ -139,8 +153,11 @@ export function Preview() {
 
     // Detect the sort type from the first non-empty cell in this column
     const sampleCell = copy.rows
-      .map(row => row.find(cell => cell.identifier === column))
-      .find(cell => cell && cell.display_value !== '' && cell.display_value !== null);
+      .map((row) => row.find((cell) => cell.identifier === column))
+      .find(
+        (cell) =>
+          cell && cell.display_value !== '' && cell.display_value !== null
+      );
 
     const sortType = sampleCell
       ? detectSortType(column, extractDisplayValue(sampleCell))

--- a/src/pages/reports/common/components/SortableColumns.tsx
+++ b/src/pages/reports/common/components/SortableColumns.tsx
@@ -249,6 +249,8 @@ export function Column({
 interface Props {
   report: Identifier;
   columns: string[];
+  draftColumns?: Record[][] | null;
+  onColumnsChange?: (columns: Record[][]) => void;
 }
 
 const positions = [
@@ -319,33 +321,49 @@ export function useColumns({ report, columns }: Props) {
   return { data, defaultColumns };
 }
 
-export function SortableColumns({ report, columns }: Props) {
+export function SortableColumns({
+  report,
+  columns,
+  draftColumns,
+  onColumnsChange,
+}: Props) {
   const [t] = useTranslation();
 
   const colors = useColorScheme();
-
-  const { update, preferences } = usePreferences();
 
   const { data: persistedData, defaultColumns } = useColumns({
     report,
     columns,
   });
 
-  const [localData, setLocalData] = useState<Record[][]>(persistedData);
+  const [localData, setLocalData] = useState<Record[][]>(
+    draftColumns ?? persistedData
+  );
 
   useEffect(() => {
-    setLocalData(persistedData);
-  }, [report]);
+    setLocalData(draftColumns ?? persistedData);
+  }, [draftColumns, persistedData, report]);
 
-  const syncToPreferences = useCallback(
-    (newData: Record[][]) => {
-      if (Array.isArray(preferences.reports.columns)) {
-        update('preferences.reports.columns', {});
-      }
+  const cloneColumnData = useCallback(
+    (data: Record[][], indexes?: number[]) => {
+      const next = [...data];
+      const indexesToClone = indexes ?? data.map((_, index) => index);
 
-      update(`preferences.reports.columns.${report}`, [...newData]);
+      Array.from(new Set(indexesToClone)).forEach((index) => {
+        next[index] = [...(data[index] ?? [])];
+      });
+
+      return next;
     },
-    [report, update, preferences.reports.columns]
+    []
+  );
+
+  const applyColumnChange = useCallback(
+    (newData: Record[][]) => {
+      setLocalData(newData);
+      onColumnsChange?.(newData);
+    },
+    [onColumnsChange]
   );
 
   const onDragEnd = useCallback(
@@ -356,69 +374,64 @@ export function SortableColumns({ report, columns }: Props) {
 
       try {
         const sourceIndex = parseInt(result.source.droppableId);
-        const destinationIndex = parseInt(result.destination!.droppableId);
-        const destinationIndexPosition = result.destination!.index;
+        const destinationIndex = parseInt(result.destination.droppableId);
+        const destinationIndexPosition = result.destination.index;
+        const newData = cloneColumnData(localData, [
+          sourceIndex,
+          destinationIndex,
+        ]);
+        const word = newData[sourceIndex]?.[result.source.index];
 
-        setLocalData((current) => {
-          const newData = [...current];
-          newData[sourceIndex] = [...current[sourceIndex]];
-          newData[destinationIndex] = [...current[destinationIndex]];
+        if (!word || !newData[destinationIndex]) {
+          return;
+        }
 
-          const word = newData[sourceIndex][result.source.index];
-          newData[sourceIndex].splice(result.source.index, 1);
-          newData[destinationIndex].splice(destinationIndexPosition, 0, word);
+        newData[sourceIndex].splice(result.source.index, 1);
+        newData[destinationIndex].splice(destinationIndexPosition, 0, word);
 
-          syncToPreferences(newData);
-          return newData;
-        });
+        applyColumnChange(newData);
       } catch (e) {
-        setLocalData(defaultColumns);
-        syncToPreferences(defaultColumns);
+        applyColumnChange(cloneColumnData(defaultColumns));
       }
     },
-    [defaultColumns, syncToPreferences]
+    [applyColumnChange, cloneColumnData, defaultColumns, localData]
   );
 
   const onRemove = useCallback(
     (record: Record) => {
       const index = positions.indexOf(record.map as (typeof positions)[number]);
 
-      setLocalData((current) => {
-        const newData = [...current];
-        newData[reportColumn] = [...current[reportColumn]];
-        newData[index] = [...current[index]];
+      if (index === -1) {
+        return;
+      }
 
-        newData[reportColumn] = newData[reportColumn].filter(
-          (r) => r.value !== record.value
-        );
+      const newData = cloneColumnData(localData, [reportColumn, index]);
 
-        newData[index].push(record);
+      newData[reportColumn] = newData[reportColumn].filter(
+        (r) => r.value !== record.value
+      );
 
-        syncToPreferences(newData);
-        return newData;
-      });
+      newData[index].push(record);
+
+      applyColumnChange(newData);
     },
-    [syncToPreferences]
+    [applyColumnChange, cloneColumnData, localData]
   );
 
   const onRemoveAll = useCallback(() => {
-    setLocalData(defaultColumns);
-    syncToPreferences(defaultColumns);
-  }, [defaultColumns, syncToPreferences]);
+    applyColumnChange(cloneColumnData(defaultColumns));
+  }, [applyColumnChange, cloneColumnData, defaultColumns]);
 
   const handleAddAll = useCallback(
     (index: number) => {
-      setLocalData((current) => {
-        const newData = [...current];
-        newData[reportColumn] = [...current[reportColumn]];
-        newData[index] = [...current[index]];
-        newData[reportColumn] = [...newData[reportColumn], ...newData[index]];
-        newData[index] = [];
-        syncToPreferences(newData);
-        return newData;
-      });
+      const newData = cloneColumnData(localData, [reportColumn, index]);
+
+      newData[reportColumn] = [...newData[reportColumn], ...newData[index]];
+      newData[index] = [];
+
+      applyColumnChange(newData);
     },
-    [syncToPreferences]
+    [applyColumnChange, cloneColumnData, localData]
   );
 
   const reportColumnsLabel = `${t('report')} ${t('columns')}`;

--- a/src/pages/reports/common/hooks/useScheduleReport.ts
+++ b/src/pages/reports/common/hooks/useScheduleReport.ts
@@ -28,10 +28,19 @@ export function useScheduleReport() {
 
   const setScheduleParameters = useSetAtom(scheduleParametersAtom);
 
-  return (report: Report, showCustomColumns: boolean) => {
+  return (
+    report: Report,
+    showCustomColumns: boolean,
+    customReportKeys?: string[]
+  ) => {
     let reportKeys: string[] = [];
 
-    if (report.identifier in preferences.reports.columns && showCustomColumns) {
+    if (showCustomColumns && customReportKeys) {
+      reportKeys = customReportKeys;
+    } else if (
+      showCustomColumns &&
+      report.identifier in preferences.reports.columns
+    ) {
       reportKeys = collect(
         preferences.reports.columns[report.identifier][reportColumn]
       )

--- a/src/pages/reports/index/Reports.tsx
+++ b/src/pages/reports/index/Reports.tsx
@@ -21,7 +21,7 @@ import { Page } from '$app/components/Breadcrumbs';
 import { ClientSelector } from '$app/components/clients/ClientSelector';
 import Toggle from '$app/components/forms/Toggle';
 import { Default } from '$app/components/layouts/Default';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   SortableColumns,
@@ -29,7 +29,6 @@ import {
 } from '../common/components/SortableColumns';
 import { Identifier, Payload, Report, useReports } from '../common/useReports';
 import { usePreferences } from '$app/common/hooks/usePreferences';
-import collect from 'collect.js';
 import { useQueryClient } from 'react-query';
 import { useAtom } from 'jotai';
 import {
@@ -62,6 +61,7 @@ import { cloneDeep } from 'lodash';
 import { ActivitySelector } from '$app/components/layouts/ActivitySelector';
 import { TemplateSelector } from '../common/components/TemplateSelector';
 import { useGroupByOptions } from '../common/hooks/useGroupByOptions';
+import type { Record as ReportColumnRecord } from '$app/common/constants/exports/client-map';
 
 interface Range {
   identifier: string;
@@ -209,13 +209,16 @@ export default function Reports() {
   const queryClient = useQueryClient();
 
   const scheduleReport = useScheduleReport();
-  const { save, preferences } = usePreferences();
+  const { save, preferences, update } = usePreferences();
   const numericFormatter = useNumericFormatter();
 
   const [report, setReport] = useState<Report>(reports[0]);
   const [isPendingExport, setIsPendingExport] = useState(false);
   const [errors, setErrors] = useState<ValidationBag>();
   const [showCustomColumns, setShowCustomColumns] = useState(false);
+  const customColumnsDraftsRef = useRef<
+    Partial<Record<Identifier, ReportColumnRecord[][]>>
+  >({});
 
   const [preview, setPreview] = useAtom(previewAtom);
 
@@ -270,6 +273,54 @@ export default function Reports() {
     }));
   };
 
+  const resolveReportColumnData = useCallback(() => {
+    if (!showCustomColumns) {
+      return null;
+    }
+
+    const customColumnsDraft =
+      customColumnsDraftsRef.current[report.identifier];
+
+    if (customColumnsDraft) {
+      return customColumnsDraft;
+    }
+
+    if (report.identifier in preferences.reports.columns) {
+      return preferences.reports.columns[report.identifier];
+    }
+
+    return null;
+  }, [preferences.reports.columns, report.identifier, showCustomColumns]);
+
+  const resolveReportKeys = useCallback(() => {
+    const columns = resolveReportColumnData();
+
+    return columns?.[reportColumn]?.map((record) => record.value) ?? [];
+  }, [resolveReportColumnData]);
+
+  const commitCustomColumnsDraft = useCallback(() => {
+    const customColumnsDraft =
+      customColumnsDraftsRef.current[report.identifier];
+
+    if (!showCustomColumns || !customColumnsDraft) {
+      return;
+    }
+
+    if (Array.isArray(preferences.reports.columns)) {
+      update('preferences.reports.columns', {});
+    }
+
+    update(
+      `preferences.reports.columns.${report.identifier}`,
+      customColumnsDraft.map((group) => [...group])
+    );
+  }, [
+    preferences.reports.columns,
+    report.identifier,
+    showCustomColumns,
+    update,
+  ]);
+
   const handleExport = () => {
     toast.processing();
 
@@ -283,15 +334,8 @@ export default function Reports() {
         ? { ...report.payload, client_id: client_id || null }
         : report.payload;
 
-    let reportKeys: string[] = [];
-
-    if (report.identifier in preferences.reports.columns && showCustomColumns) {
-      reportKeys = collect(
-        preferences.reports.columns[report.identifier][reportColumn]
-      )
-        .pluck('value')
-        .toArray() as string[];
-    }
+    const reportKeys = resolveReportKeys();
+    commitCustomColumnsDraft();
 
     updatedPayload = { ...updatedPayload, report_keys: reportKeys };
 
@@ -397,15 +441,8 @@ export default function Reports() {
         ? { ...report.payload, client_id: client_id || null }
         : report.payload;
 
-    let reportKeys: string[] = [];
-
-    if (report.identifier in preferences.reports.columns && showCustomColumns) {
-      reportKeys = collect(
-        preferences.reports.columns[report.identifier][reportColumn]
-      )
-        .pluck('value')
-        .toArray() as string[];
-    }
+    const reportKeys = resolveReportKeys();
+    commitCustomColumnsDraft();
 
     updatedPayload = { ...updatedPayload, report_keys: reportKeys };
 
@@ -475,7 +512,12 @@ export default function Reports() {
 
           <DropdownElement
             icon={<Icon element={MdSchedule} />}
-            onClick={() => scheduleReport(report, showCustomColumns)}
+            onClick={() => {
+              const reportKeys = resolveReportKeys();
+
+              commitCustomColumnsDraft();
+              scheduleReport(report, showCustomColumns, reportKeys);
+            }}
           >
             {t('schedule')}
           </DropdownElement>
@@ -776,7 +818,9 @@ export default function Reports() {
             <Element leftSide={`${t('customize')} ${t('columns')}`}>
               <Toggle
                 checked={showCustomColumns}
-                onValueChange={(value) => setShowCustomColumns(Boolean(value))}
+                onValueChange={(value) => {
+                  setShowCustomColumns(Boolean(value));
+                }}
               />
             </Element>
           )}
@@ -787,6 +831,12 @@ export default function Reports() {
         <SortableColumns
           report={report.identifier}
           columns={report.custom_columns}
+          draftColumns={
+            customColumnsDraftsRef.current[report.identifier] ?? null
+          }
+          onColumnsChange={(columns) => {
+            customColumnsDraftsRef.current[report.identifier] = columns;
+          }}
         />
       )}
 


### PR DESCRIPTION
This pr addresses performance issues when generating large preview reports and then attempting to sort/add/remove columns from the initial report columns.

Each draggable causes an update to the reactsettings atom which then causes a cascading impact on all of the previews table rows, mainly due to the heavy read on the colors prop in react settings.

- Now, local edits to sortablecolumn does not bubble up and convert into a write until the user clicks Preview, Export or Schedule.
- useColorScheme() no longer subscribes to the entire settings object, now we focus only to the dark_mode prop.
- Drop deep clone, and consider the data as immutable arrays

Also, included a small change to make multi sort the default option when sorting the previews.