### PR TITLE
add Resume button to extend last timelog entry (fixes #3064)

### DIFF
--- a/src/pages/tasks/common/components/TaskDetails.tsx
+++ b/src/pages/tasks/common/components/TaskDetails.tsx
@@ -22,6 +22,7 @@ import { UserSelector } from '$app/components/users/UserSelector';
 import { TaskStatusSelector } from '$app/components/task-statuses/TaskStatusSelector';
 import { TaskStatus as TaskStatusBadge } from './TaskStatus';
 import { useStart } from '../hooks/useStart';
+import { useResume, canResumeLastEntry } from '../hooks/useResume';
 import { useStop } from '../hooks/useStop';
 import { isTaskRunning } from '../helpers/calculate-entity-state';
 import { formatTime, TaskClock } from '../../kanban/components/TaskClock';
@@ -30,7 +31,7 @@ import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission
 import { useEntityAssigned } from '$app/common/hooks/useEntityAssigned';
 import { route } from '$app/common/helpers/route';
 import { Icon } from '$app/components/icons/Icon';
-import { MdLaunch } from 'react-icons/md';
+import { MdLaunch, MdPlayCircle } from 'react-icons/md';
 import { useColorScheme } from '$app/common/colors';
 import { ClientActionButtons } from '$app/pages/invoices/common/components/ClientActionButtons';
 import { NumberInputField } from '$app/components/forms/NumberInputField';
@@ -66,6 +67,7 @@ export function TaskDetails(props: Props) {
 
   const stop = useStop();
   const start = useStart();
+  const resume = useResume();
 
   const calculation = calculateTime(task.time_log, {
     inSeconds: true,
@@ -110,8 +112,21 @@ export function TaskDetails(props: Props) {
                     color={colors.$1}
                     filledColor={colors.$1}
                   />
-
                   <span style={{ color: colors.$1 }}>{t('start')}</span>
+                </div>
+              </Button>
+            )}
+
+            {!isTaskRunning(task) && !task.invoice_id && canResumeLastEntry(task) && (
+              <Button
+                behavior="button"
+                onClick={() => resume(task)}
+                disableWithoutIcon
+                disabled={!hasPermission('edit_task') && !entityAssigned(task)}
+              >
+                <div className="flex items-center gap-2">
+                  <Icon element={MdPlayCircle} size={18} color={colors.$1} />
+                  <span style={{ color: colors.$1 }}>{t('resume')}</span>
                 </div>
               </Button>
             )}
@@ -129,7 +144,6 @@ export function TaskDetails(props: Props) {
                     filledColor={colors.$1}
                     size="1.1rem"
                   />
-
                   <span style={{ color: colors.$1 }}>{t('stop')}</span>
                 </div>
               </Button>
@@ -177,8 +191,23 @@ export function TaskDetails(props: Props) {
                       color={colors.$1}
                       filledColor={colors.$1}
                     />
-
                     <span style={{ color: colors.$1 }}>{t('start')}</span>
+                  </div>
+                </Button>
+              )}
+
+              {!isTaskRunning(task) && !task.invoice_id && canResumeLastEntry(task) && (
+                <Button
+                  behavior="button"
+                  onClick={() => resume(task)}
+                  disableWithoutIcon
+                  disabled={
+                    !hasPermission('edit_task') && !entityAssigned(task)
+                  }
+                >
+                  <div className="flex items-center gap-2">
+                    <Icon element={MdPlayCircle} size={18} color={colors.$1} />
+                    <span style={{ color: colors.$1 }}>{t('resume')}</span>
                   </div>
                 </Button>
               )}
@@ -198,7 +227,6 @@ export function TaskDetails(props: Props) {
                       filledColor={colors.$1}
                       size="1.1rem"
                     />
-
                     <span style={{ color: colors.$1 }}>{t('stop')}</span>
                   </div>
                 </Button>

--- a/src/pages/tasks/common/hooks/useResume.ts
+++ b/src/pages/tasks/common/hooks/useResume.ts
@@ -1,0 +1,82 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { endpoint } from '$app/common/helpers';
+import { request } from '$app/common/helpers/request';
+import { toast } from '$app/common/helpers/toast/toast';
+import { Task } from '$app/common/interfaces/task';
+import { useQueryClient } from 'react-query';
+import { useAtomValue } from 'jotai';
+import { invalidationQueryAtom } from '$app/common/atoms/data-table';
+import { parseTimeLog } from '../helpers/calculate-time';
+import { $refetch } from '$app/common/hooks/useRefetch';
+
+export function useResume() {
+  const queryClient = useQueryClient();
+  const invalidateQueryValue = useAtomValue(invalidationQueryAtom);
+
+  return (task: Task) => {
+    toast.processing();
+
+    const logs = parseTimeLog(task.time_log);
+
+    if (logs.length === 0) {
+      toast.error('no_timelog_entry');
+      return;
+    }
+
+    const lastEntry = logs[logs.length - 1];
+
+    if (lastEntry[1] === 0) {
+      toast.error('task_already_running');
+      return;
+    }
+
+    // Reopen the last entry by clearing its end time
+    logs[logs.length - 1][1] = 0;
+
+    const updatedTask = {
+      ...task,
+      time_log: JSON.stringify(logs),
+    };
+
+    request(
+      'PUT',
+      endpoint('/api/v1/tasks/:id?start=true', { id: task.id }),
+      updatedTask
+    ).then(() => {
+      toast.success('started_task');
+
+      $refetch(['tasks']);
+
+      invalidateQueryValue &&
+        queryClient.invalidateQueries([invalidateQueryValue]);
+    });
+  };
+}
+
+/**
+ * Returns true if the task has a recently stopped entry (within 60 min)
+ */
+export function canResumeLastEntry(task: Task): boolean {
+  const logs = parseTimeLog(task.time_log);
+
+  if (logs.length === 0) return false;
+
+  const lastEntry = logs[logs.length - 1];
+  const lastEndTime = lastEntry[1];
+
+  if (!lastEndTime || lastEndTime === 0) return false;
+
+  const now = Math.floor(Date.now() / 1000);
+  const minutesSinceStopped = (now - lastEndTime) / 60;
+
+  return minutesSinceStopped <= 60;
+}


### PR DESCRIPTION
## Summary

Fixes #3064

When a user stops a task timer and needs to resume it shortly after 
(e.g. a client calls back), the current UI forces a brand new timelog 
entry instead of continuing the last one. This PR adds a Resume button 
that reopens the last stopped entry by clearing its end time.

## Changes

### New file: `src/pages/tasks/common/hooks/useResume.ts`
1- `useResume()` hook — clears the `end_time` of the last timelog entry 
  and calls `?start=true` to reopen it instead of creating a new entry
2-`canResumeLastEntry()` helper — returns `true` only when the last 
  entry was stopped within the past 60 minutes (avoids showing Resume 
  on old tasks)

### Modified: `src/pages/tasks/common/components/TaskDetails.tsx`
1-Added Resume button next to the Start button in both desktop and 
  mobile layouts
2- Resume button only appears when `canResumeLastEntry()` is true

## Behavior

1- Stop a task timer
2- Within 60 minutes, open the task edit page
3- A **Resume** button appears next to Start
4- Clicking Resume extends the last entry instead of creating a new one
5- After 60 minutes, only the regular Start button is shown

## Testing

1- Create a task and start the timer
2- Stop the timer
3- Go to edit the task — Resume button should appear
4- Click Resume — verify the last timelog entry's end time is cleared 
   (not a new row added)