### PR TITLE
[Cleanup] Reports Info Toaster For Large Reports

### DIFF
--- a/src/common/helpers/toast/toast.ts
+++ b/src/common/helpers/toast/toast.ts
@@ -10,6 +10,8 @@
 
 import { trans } from '$app/common/helpers';
 import { t } from 'i18next';
+import React from 'react';
+import { MdInfoOutline } from 'react-icons/md';
 import { toast as helper } from 'react-hot-toast';
 
 class Toast {
@@ -33,6 +35,19 @@ class Toast {
 
   error(message = 'error_title'): Toast {
     this.currentId = helper.error(t(message), { id: this.currentId });
+
+    return this;
+  }
+
+  info(message: string, replaceable = {}, duration = 8000): Toast {
+    this.currentId = helper(trans(message, replaceable), {
+      id: this.currentId,
+      duration,
+      icon: React.createElement(MdInfoOutline, {
+        size: 20,
+        color: '#3b82f6',
+      }),
+    });
 
     return this;
   }

--- a/src/common/helpers/toast/toast.ts
+++ b/src/common/helpers/toast/toast.ts
@@ -40,8 +40,11 @@ class Toast {
   }
 
   info(message: string, replaceable = {}, duration = 8000): Toast {
+    if (this.currentId) {
+      helper.dismiss(this.currentId);
+    }
+
     this.currentId = helper(trans(message, replaceable), {
-      id: this.currentId,
       duration,
       icon: React.createElement(MdInfoOutline, {
         size: 20,

--- a/src/pages/reports/index/Reports.tsx
+++ b/src/pages/reports/index/Reports.tsx
@@ -30,7 +30,7 @@ import {
 import { Identifier, Payload, Report, useReports } from '../common/useReports';
 import { usePreferences } from '$app/common/hooks/usePreferences';
 import collect from 'collect.js';
-import { useQueryClient } from 'react-query';
+import { isCancelledError, useQueryClient } from 'react-query';
 import { useAtom } from 'jotai';
 import {
   Cell,
@@ -55,7 +55,6 @@ import { useShowReportField } from '../common/hooks/useShowReportField';
 import { proPlan } from '$app/common/guards/guards/pro-plan';
 import { enterprisePlan } from '$app/common/guards/guards/enterprise-plan';
 import { ReportsPlanAlert } from '../common/components/ReportsPlanAlert';
-import { useNumericFormatter } from '$app/common/hooks/useNumericFormatter';
 import { extractTextFromHTML } from '$app/common/helpers/html-string';
 import { sanitizeHTML } from '$app/common/helpers/html-string';
 import { cloneDeep } from 'lodash';
@@ -68,6 +67,9 @@ interface Range {
   label: string;
   scheduleIdentifier: string;
 }
+
+const PREVIEW_POLL_RETRIES = 10;
+const PREVIEW_POLL_DELAY_MS = import.meta.env.DEV ? 1000 : 5000;
 
 export const ranges: Range[] = [
   { identifier: 'all', label: 'all', scheduleIdentifier: 'all' },
@@ -210,7 +212,6 @@ export default function Reports() {
 
   const scheduleReport = useScheduleReport();
   const { save, preferences } = usePreferences();
-  const numericFormatter = useNumericFormatter();
 
   const [report, setReport] = useState<Report>(reports[0]);
   const [isPendingExport, setIsPendingExport] = useState(false);
@@ -224,6 +225,8 @@ export default function Reports() {
 
   const handleReportChange = (identifier: Identifier) => {
     const report = reports.find((report) => report.identifier === identifier);
+
+    queryClient.cancelQueries(['reports']);
 
     setShowCustomColumns(false);
 
@@ -390,6 +393,8 @@ export default function Reports() {
     setErrors(undefined);
     setPreview(null);
 
+    queryClient.cancelQueries(['reports']);
+
     toast.processing();
 
     const { client_id } = report.payload;
@@ -422,8 +427,8 @@ export default function Reports() {
               request('POST', endpoint(`/api/v1/reports/preview/${hash}`)).then(
                 (response) => response.data
               ),
-            retry: 10,
-            retryDelay: import.meta.env.DEV ? 1000 : 5000,
+            retry: PREVIEW_POLL_RETRIES,
+            retryDelay: PREVIEW_POLL_DELAY_MS,
           })
           .then((response) => {
             const { columns, ...rows } = response;
@@ -440,15 +445,19 @@ export default function Reports() {
 
             toast.success();
 
-            requestAnimationFrame(() => {
+            setTimeout(() => {
               document.getElementById('preview-table')?.scrollIntoView({
                 behavior: 'smooth',
-                block: 'center',
+                block: 'start',
               });
-            });
+            }, 100);
           })
-          .catch((e) => {
-            console.error(e);
+          .catch((error) => {
+            if (isCancelledError(error)) {
+              return;
+            }
+
+            console.error(error);
 
             toast.info('report_too_large_to_preview');
           });

--- a/src/pages/reports/index/Reports.tsx
+++ b/src/pages/reports/index/Reports.tsx
@@ -390,6 +390,8 @@ export default function Reports() {
     setErrors(undefined);
     setPreview(null);
 
+    toast.processing();
+
     const { client_id } = report.payload;
 
     let updatedPayload =
@@ -409,8 +411,8 @@ export default function Reports() {
 
     updatedPayload = { ...updatedPayload, report_keys: reportKeys };
 
-    request('POST', endpoint(report.preview), updatedPayload, {}).then(
-      (response) => {
+    request('POST', endpoint(report.preview), updatedPayload, {})
+      .then((response) => {
         const hash = response.data.message as string;
 
         queryClient
@@ -437,9 +439,23 @@ export default function Reports() {
             });
 
             toast.success();
+
+            requestAnimationFrame(() => {
+              document.getElementById('preview-table')?.scrollIntoView({
+                behavior: 'smooth',
+                block: 'center',
+              });
+            });
+          })
+          .catch((e) => {
+            console.error(e);
+
+            toast.info('report_too_large_to_preview');
           });
-      }
-    );
+      })
+      .catch(() => {
+        toast.dismiss();
+      });
   };
 
   useEffect(() => {


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of an info toaster as a notification when the preview of the report could not be displayed because the report is too large. Also, I've added a scroll to the start of the preview table when the response has been returned. Screenshot:

<img width="856" height="596" alt="Screenshot 2026-06-03 at 23 20 09" src="https://github.com/user-attachments/assets/a1c47a0b-b4d2-427e-9902-f30f4da847f3" />

`Note`: In the toaster, I've used the `report_too_large_to_preview` translation keyword. If you agree with it, please just add it to the files.

Let me know your thoughts.