### PR TITLE
Fixes for calendar connection interface

### DIFF
--- a/src/common/interfaces/calendar-event.ts
+++ b/src/common/interfaces/calendar-event.ts
@@ -8,6 +8,7 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
+import dayjs from 'dayjs';
 import type { CalendarProvider } from './user';
 
 export interface CalendarEvent {
@@ -40,6 +41,18 @@ const CALENDAR_EVENT_DATE_TIME =
 export const calendarEventDateKey = (
   eventOrStart: CalendarEvent | string
 ): string => {
+  // Timed events are a UTC instant but are rendered — and logged onto tasks —
+  // in the browser's local timezone. Their calendar day must therefore be
+  // derived AFTER converting to local time, otherwise an event late in the UTC
+  // day lands on the wrong day for users with a positive offset (e.g.
+  // 2026-05-27T17:00Z is 2026-05-28 03:00 at UTC+10), splitting the day from
+  // the clock time displayed alongside it.
+  if (typeof eventOrStart !== 'string' && !eventOrStart.all_day) {
+    return dayjs(eventOrStart.start).format('YYYY-MM-DD');
+  }
+
+  // All-day events (and bare strings) carry a floating wall-clock date that
+  // must NOT be shifted by timezone — extract the date portion verbatim.
   const value =
     typeof eventOrStart === 'string' ? eventOrStart : eventOrStart.start;
   const match = value.match(CALENDAR_EVENT_DATE_TIME);

--- a/src/common/interfaces/search.ts
+++ b/src/common/interfaces/search.ts
@@ -31,4 +31,5 @@ export interface SearchRecord {
   id: string;
   path: string;
   heading: string;
+  keywords?: string;
 }

--- a/src/common/interfaces/user.ts
+++ b/src/common/interfaces/user.ts
@@ -27,7 +27,11 @@ interface ReferralMeta {
   pro: number;
   free: number;
   enterprise: number;
-  calendar_connection?: CalendarConnection;
+}
+
+interface UserSettings {
+  calendar_connection?: CalendarConnection | null;
+  [key: string]: unknown;
 }
 
 export interface User extends Timestamps {
@@ -55,4 +59,5 @@ export interface User extends Timestamps {
   user_logged_in_notification: boolean;
   referral_code?: string;
   referral_meta?: ReferralMeta;
+  settings?: UserSettings;
 }

--- a/src/pages/dashboard/components/Search.tsx
+++ b/src/pages/dashboard/components/Search.tsx
@@ -75,7 +75,8 @@ export function Search$() {
                   label: record.name,
                   value: record.id,
                   resource: record,
-                  searchable: `${t(key)}: ${record.name}`,
+                  searchable: `${t(key)}: ${record.name} ${record.keywords ?? ''}`,
+                  // searchable: `${t(key)}: ${record.name}`,
                   eventType: 'external',
                 });
               });

--- a/src/pages/invoices/common/components/InvoicePreview.tsx
+++ b/src/pages/invoices/common/components/InvoicePreview.tsx
@@ -156,18 +156,20 @@ export function InvoicePreview(props: Props) {
   ) {
     return (
       <div className="flex flex-col space-y-3">
-        <InvoiceViewer
-          link={previewEndpoint(
-            '/api/v1/live_preview/purchase_order?entity=:entity&entity_id=:id',
-            {
-              entity: props.entity,
-              id: debouncedResource?.id,
-            }
-          )}
-          resource={debouncedResource}
-          method="POST"
-          enabled={props.observable ? isIntersecting : true}
-        />
+        <div ref={divRef}>
+          <InvoiceViewer
+            link={previewEndpoint(
+              '/api/v1/live_preview/purchase_order?entity=:entity&entity_id=:id',
+              {
+                entity: props.entity,
+                id: debouncedResource?.id,
+              }
+            )}
+            resource={debouncedResource}
+            method="POST"
+            enabled={props.observable ? isIntersecting : true}
+          />
+        </div>
 
         {props.withRemoveLogoCTA && <RemoveLogoCTA />}
       </div>

--- a/src/pages/tasks/calendar/Calendar.tsx
+++ b/src/pages/tasks/calendar/Calendar.tsx
@@ -73,7 +73,7 @@ export default function Calendar() {
   const calendarConnectionAvailable = isCalendarConnectionAvailable();
   const calendarConnected =
     calendarConnectionAvailable &&
-    user?.referral_meta?.calendar_connection?.status === 'CONNECTED';
+    user?.settings?.calendar_connection?.status === 'CONNECTED';
 
   const hideEvents = searchParams.get('hide_events') === '1';
   const toggleHideEvents = () => {

--- a/src/pages/tasks/calendar/Complete.tsx
+++ b/src/pages/tasks/calendar/Complete.tsx
@@ -35,13 +35,10 @@ type Phase = 'completing' | 'failed';
 export function markCalendarConnected(user: User): User {
   return {
     ...user,
-    referral_meta: {
-      pro: 0,
-      free: 0,
-      enterprise: 0,
-      ...(user.referral_meta ?? {}),
+    settings: {
+      ...(user.settings ?? {}),
       calendar_connection: {
-        ...(user.referral_meta?.calendar_connection ?? {}),
+        ...(user.settings?.calendar_connection ?? {}),
         status: 'CONNECTED',
       },
     },

--- a/src/pages/tasks/calendar/Complete.tsx
+++ b/src/pages/tasks/calendar/Complete.tsx
@@ -32,7 +32,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 // collapses into a single failure the user has to acknowledge.
 type Phase = 'completing' | 'failed';
 
-export function markCalendarConnected(user: User): User {
+export function markCalendarConnected(user: User, email?: string): User {
   return {
     ...user,
     settings: {
@@ -40,9 +40,20 @@ export function markCalendarConnected(user: User): User {
       calendar_connection: {
         ...(user.settings?.calendar_connection ?? {}),
         status: 'CONNECTED',
+        ...(email ? { email } : {}),
       },
     },
   };
+}
+
+function completeResponseEmail(response: unknown): string | undefined {
+  const email = (
+    response as {
+      data?: { data?: { calendar_connection?: { email?: unknown } } };
+    }
+  )?.data?.data?.calendar_connection?.email;
+
+  return typeof email === 'string' ? email : undefined;
 }
 
 export default function Complete() {
@@ -99,11 +110,15 @@ export default function Complete() {
 
     complete
       .mutateAsync({ provider: parsedProvider, handoff })
-      .then(() => {
+      .then((response) => {
         const currentUser = userRef.current;
 
         if (currentUser?.id) {
-          dispatch(updateUser(markCalendarConnected(currentUser)));
+          dispatch(
+            updateUser(
+              markCalendarConnected(currentUser, completeResponseEmail(response))
+            )
+          );
         }
 
         $refetch(['users']);

--- a/src/pages/tasks/common/components/CalendarConnectCta.tsx
+++ b/src/pages/tasks/common/components/CalendarConnectCta.tsx
@@ -46,7 +46,7 @@ export function CalendarConnectCta() {
   const calendarConnectionAvailable = isCalendarConnectionAvailable();
   const isPaid = useIsPaid();
   const isConnected =
-    user?.referral_meta?.calendar_connection?.status === 'CONNECTED';
+    user?.settings?.calendar_connection?.status === 'CONNECTED';
   const canConnect =
     calendarConnectionAvailable && !isConnected && (isPaid || devCalendar);
   const showPlanAlert = hosted && !isConnected && !isPaid && !devCalendar;
@@ -88,8 +88,8 @@ export function CalendarConnectCta() {
           dispatch(
             updateUser({
               ...user,
-              referral_meta: {
-                ...(user.referral_meta ?? {}),
+              settings: {
+                ...(user.settings ?? {}),
                 calendar_connection: { status: 'DISCONNECTED' },
               },
             })
@@ -141,7 +141,9 @@ export function CalendarConnectCta() {
           }}
         >
           <FaCalendarCheck size={14} color={colors.$3} />
-          <span style={{ color: colors.$3 }}>{user?.referral_meta?.calendar_connection?.email ?? t('disconnect')}</span>
+          <span style={{ color: colors.$3 }}>
+            {user?.settings?.calendar_connection?.email ?? t('disconnect')}
+          </span>
 
           <button
             type="button"

--- a/src/pages/tasks/common/components/CalendarConnectCta.tsx
+++ b/src/pages/tasks/common/components/CalendarConnectCta.tsx
@@ -95,7 +95,7 @@ export function CalendarConnectCta() {
             })
           );
         }
-        toast.success('disconnect_calendar');
+        toast.success('disconnected');
         setDisconnectVisible(false);
       },
       onError: () => {

--- a/src/pages/tasks/common/components/ConvertCalendarEventModal.tsx
+++ b/src/pages/tasks/common/components/ConvertCalendarEventModal.tsx
@@ -48,8 +48,14 @@ const buildTimeLog = (event: CalendarEvent): string => {
   // All-day events carry no clock times. Anchor a 1h placeholder at 09:00
   // local on the event date so the task at least records the day it happened.
   // The user can edit it after conversion.
+  //
+  // Derive the date from calendarEventDateKey() — the same wall-clock
+  // YYYY-MM-DD used for the task's `date` field below. Parsing the raw
+  // provider string (e.g. Microsoft's midnight-UTC "...T00:00:00Z") through
+  // dayjs() would shift it into the browser timezone first, rolling the day
+  // backwards for users west of UTC and anchoring the task on the wrong date.
   if (event.all_day) {
-    const anchor = dayjs(event.start).startOf('day').hour(9);
+    const anchor = dayjs(calendarEventDateKey(event)).startOf('day').hour(9);
     return JSON.stringify([
       [anchor.unix(), anchor.add(1, 'hour').unix(), '', true],
     ]);


### PR DESCRIPTION
Change required to move calendar connection onto its own prop via user.settings, rather than overload referral_meta.
Small fix to ensure Purchase Order preview interceptor is passed in.
Change to ensure that browser time is used when presenting a task in the calendar rather than UTC.