### PR TITLE
[Cleanup] Increasing Debounce For Data Table Field

### DIFF
--- a/src/components/datatables/Actions.tsx
+++ b/src/components/datatables/Actions.tsx
@@ -411,7 +411,7 @@ export function Actions(props: Props) {
             onValueChange={(value) =>
               props.onFilterChange && props.onFilterChange(value)
             }
-            debounceTimeout={300}
+            debounceTimeout={500}
             clearable
           />
         </div>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes increasing the debounce from 300 to 500 ms for the filter data table field. Let me know your thoughts.