### PR TITLE
Improve templates UX

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "28.06.2025.1",
       "dependencies": {
         "@azure/msal-browser": "^3.28.1",
-        "@docuninja/builder2.0": "^0.0.96",
+        "@docuninja/builder2.0": "^0.0.99",
         "@emotion/styled": "^11.14.0",
         "@excalidraw/excalidraw": "^0.18.0",
         "@fontsource/alex-brush": "^5.2.6",
@@ -670,9 +670,9 @@
       }
     },
     "node_modules/@docuninja/builder2.0": {
-      "version": "0.0.96",
-      "resolved": "https://registry.npmjs.org/@docuninja/builder2.0/-/builder2.0-0.0.96.tgz",
-      "integrity": "sha512-RYfCH4W8/sHrfanScVGdfc7dens3P2tMT3TTBCXvcjvNPwMbEkyTIHVtNnHS1IUYr1FQO7UfChoHsciE+UCLmw==",
+      "version": "0.0.99",
+      "resolved": "https://registry.npmjs.org/@docuninja/builder2.0/-/builder2.0-0.0.99.tgz",
+      "integrity": "sha512-xS34+gr7J83orL0DGY2w4IPBIwm2/8i6tBU+2uGUk9EkAOPSY5Qko6O8ihPUwjQ+JiwJQrH65Sw/rx/1ddikhg==",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@azure/msal-browser": "^3.28.1",
-    "@docuninja/builder2.0": "^0.0.96",
+    "@docuninja/builder2.0": "^0.0.99",
     "@emotion/styled": "^11.14.0",
     "@excalidraw/excalidraw": "^0.18.0",
     "@fontsource/alex-brush": "^5.2.6",

--- a/src/pages/documents/builder/Builder.tsx
+++ b/src/pages/documents/builder/Builder.tsx
@@ -32,7 +32,7 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MdSend } from 'react-icons/md';
 import { useMediaQuery } from 'react-responsive';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { DocumentStatus } from '$app/common/interfaces/docuninja/api';
 import {
   SignatorySelector,
@@ -130,6 +130,8 @@ function Builder() {
   const colors = useColorScheme();
 
   const docuninjaAccount = useAtomValue(docuNinjaAtom);
+
+  const navigate = useNavigate();
 
   const [entity, setEntity] = useState<Document | null>(null);
   const [isDocumentSaving, setIsDocumentSaving] = useState<boolean>(false);
@@ -259,6 +261,12 @@ function Builder() {
       setIsDocumentSaving(false);
     };
 
+    const handleSingleSignatorySent = () => {
+      toast.success('document_queued_for_sending');
+
+      navigate('/docuninja');
+    };
+
     window.addEventListener(
       'refetch.docuninja.document',
       refetchDocuninjaDocument
@@ -279,6 +287,11 @@ function Builder() {
     window.addEventListener(
       'builder:document.updated',
       refetchDocuninjaDocument
+    );
+
+    window.addEventListener(
+      'builder:single-signatory-sent',
+      handleSingleSignatorySent
     );
 
     return () => {
@@ -302,6 +315,11 @@ function Builder() {
       window.removeEventListener(
         'builder:document.updated',
         refetchDocuninjaDocument
+      );
+
+      window.removeEventListener(
+        'builder:single-signatory-sent',
+        handleSingleSignatorySent
       );
     };
   }, []);

--- a/src/pages/documents/builder/Builder.tsx
+++ b/src/pages/documents/builder/Builder.tsx
@@ -143,6 +143,7 @@ function Builder() {
   useBuilderStore((state) => state.rectangles);
   const [isDocumentSaving, setIsDocumentSaving] = useState<boolean>(false);
   const [isDocumentSending, setIsDocumentSending] = useState<boolean>(false);
+  const [hasBeenSent, setHasBeenSent] = useState<boolean>(false);
 
   const isSmallScreen = useMediaQuery({ query: '(max-width: 640px)' });
 
@@ -270,6 +271,7 @@ function Builder() {
       )
         .then(() => {
           setIsDocumentSending(false);
+          setHasBeenSent(true);
 
           window.dispatchEvent(
             new CustomEvent('builder:document.sent', {
@@ -494,7 +496,7 @@ function Builder() {
               behavior="button"
               onClick={handleSend}
               disabled={
-                isDocumentSaving || isDocumentSending || !hasRealSignatories()
+                isDocumentSaving || isDocumentSending || hasBeenSent || !hasRealSignatories()
               }
               disableWithoutIcon
               className="builder-send-button"

--- a/src/pages/documents/builder/Builder.tsx
+++ b/src/pages/documents/builder/Builder.tsx
@@ -10,7 +10,9 @@
 
 import { docuNinjaAtom } from '$app/common/atoms/docuninja';
 import { useColorScheme } from '$app/common/colors';
+import { docuNinjaEndpoint } from '$app/common/helpers';
 import { route, routeWithOrigin } from '$app/common/helpers/route';
+import { request } from '$app/common/helpers/request';
 import { toast } from '$app/common/helpers/toast/toast';
 import { $refetch } from '$app/common/hooks/useRefetch';
 import { Page } from '$app/components/Breadcrumbs';
@@ -26,6 +28,7 @@ import {
   Document,
   SendDialogButtonProps,
   SendDialogProps,
+  useBuilderStore,
 } from '@docuninja/builder2.0';
 import { useAtomValue } from 'jotai';
 import { useEffect, useState } from 'react';
@@ -134,6 +137,8 @@ function Builder() {
   const navigate = useNavigate();
 
   const [entity, setEntity] = useState<Document | null>(null);
+
+  useBuilderStore((state) => state.rectangles);
   const [isDocumentSaving, setIsDocumentSaving] = useState<boolean>(false);
   const [isDocumentSending, setIsDocumentSending] = useState<boolean>(false);
 
@@ -196,24 +201,83 @@ function Builder() {
   };
 
   const handleSend = () => {
-    window.dispatchEvent(new CustomEvent('builder:open.send.confirmation'));
+    if (!hasRealSignatories() || !entity?.id) {
+      return;
+    }
+
+    toast.processing();
+    setIsDocumentSaving(true);
+
+    const onSaveSuccess = () => {
+      window.removeEventListener(
+        'builder:document.successfully.saved',
+        onSaveSuccess,
+      );
+      window.removeEventListener('builder:save.error', onSaveError);
+
+      setIsDocumentSaving(false);
+      setIsDocumentSending(true);
+
+      request(
+        'POST',
+        docuNinjaEndpoint(`/api/documents/${entity.id}/send`),
+        {},
+        {
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem('X-DOCU-NINJA-TOKEN')}`,
+          },
+        },
+      )
+        .then(() => {
+          setIsDocumentSending(false);
+
+          window.dispatchEvent(
+            new CustomEvent('builder:document.sent', {
+              detail: { documentId: entity.id },
+            }),
+          );
+
+          toast.success('document_queued_for_sending');
+          $refetch(['docuninja_documents', 'docuninja_document_timeline']);
+        })
+        .catch(() => {
+          setIsDocumentSending(false);
+          toast.error('something_went_wrong');
+
+          window.dispatchEvent(new CustomEvent('builder:send.error'));
+        });
+    };
+
+    const onSaveError = () => {
+      window.removeEventListener(
+        'builder:document.successfully.saved',
+        onSaveSuccess,
+      );
+      window.removeEventListener('builder:save.error', onSaveError);
+
+      setIsDocumentSaving(false);
+    };
+
+    window.addEventListener('builder:document.successfully.saved', onSaveSuccess);
+    window.addEventListener('builder:save.error', onSaveError);
+    window.dispatchEvent(new CustomEvent('builder:save'));
   };
 
   const doesDocumentHaveSignatories = () => {
-    const rectangles =
-      entity?.files?.flatMap((file) => file.metadata?.rectangles ?? []) ?? [];
+    const storeState = useBuilderStore.getState();
+    const rectangles = Object.values(storeState.rectangles).flat();
 
     return rectangles.length > 0;
   };
 
   const hasRealSignatories = () => {
-    const rectangles =
-      entity?.files?.flatMap((file) => file.metadata?.rectangles ?? []) ?? [];
+    const storeState = useBuilderStore.getState();
+    const rectangles = Object.values(storeState.rectangles).flat();
 
     return rectangles.every(
       (rectangle: any) =>
         rectangle.signatory_id &&
-        !rectangle.signatory_id.startsWith('blueprint|')
+        !rectangle.signatory_id.startsWith('blueprint')
     );
   };
 
@@ -261,6 +325,14 @@ function Builder() {
       setIsDocumentSaving(false);
     };
 
+    const handleDocumentSent = () => {
+      setIsDocumentSending(false);
+    };
+
+    const handleSendError = () => {
+      setIsDocumentSending(false);
+    };
+
     const handleSingleSignatorySent = () => {
       toast.success('document_queued_for_sending');
 
@@ -294,6 +366,9 @@ function Builder() {
       handleSingleSignatorySent
     );
 
+    window.addEventListener('builder:document.sent', handleDocumentSent);
+    window.addEventListener('builder:send.error', handleSendError);
+
     return () => {
       window.removeEventListener(
         'refetch.docuninja.document',
@@ -320,6 +395,16 @@ function Builder() {
       window.removeEventListener(
         'builder:single-signatory-sent',
         handleSingleSignatorySent
+      );
+
+      window.removeEventListener(
+        'builder:document.sent',
+        handleDocumentSent
+      );
+
+      window.removeEventListener(
+        'builder:send.error',
+        handleSendError
       );
     };
   }, []);
@@ -387,7 +472,7 @@ function Builder() {
             disableWithoutIcon
             className="builder-save-button"
           >
-            {t('save')}
+            {t('save_for_later')}
           </Button>
         </div>
       }

--- a/src/pages/documents/pages/blueprints/builder/BlueprintBuilder.tsx
+++ b/src/pages/documents/pages/blueprints/builder/BlueprintBuilder.tsx
@@ -51,8 +51,9 @@ import {
   SendDialogButtonProps,
   SendDialogProps,
   SignatorySelectorProps,
-  CreateBlueprintSignatoryProps,
+  CreateBlueprintSignatoryProps
 } from '@docuninja/builder2.0';
+import { SignatorySwap } from './Elements';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQuery } from 'react-query';
@@ -443,7 +444,7 @@ function BlueprintBuilder() {
                 },
               },
               signatorySelector: SignatorySelector,
-              signatorySwap: () => null,
+              signatorySwap: SignatorySwap,
               uninvite: {
                 dialog: UninviteDialog,
                 button: UninviteButton,

--- a/src/pages/documents/pages/blueprints/builder/Elements.tsx
+++ b/src/pages/documents/pages/blueprints/builder/Elements.tsx
@@ -24,15 +24,23 @@ import { Modal } from '$app/components/Modal';
 import { get } from 'lodash';
 import { formatLabel } from './formatLabel';
 
-export function SignatorySwap(props: SignatorySwapProps) {
+export function SignatorySwap({ trigger, ...props }: SignatorySwapProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [t] = useTranslation();
 
   return (
-    <div className="flex items-center justify-center">
-      <button type="button" onClick={() => setIsOpen(true)}>
-        <IoMdSwap size={16} />
-      </button>
+    <>
+      {trigger ? (
+        <div className="cursor-pointer" onClick={() => setIsOpen(true)}>
+          {trigger}
+        </div>
+      ) : (
+        <div className="flex items-center justify-center">
+          <button type="button" onClick={() => setIsOpen(true)}>
+            <IoMdSwap size={16} />
+          </button>
+        </div>
+      )}
 
       <Modal
         visible={isOpen}
@@ -43,7 +51,7 @@ export function SignatorySwap(props: SignatorySwapProps) {
       >
         <SignatorySelector {...props} isSwapModal />
       </Modal>
-    </div>
+    </>
   );
 }
 


### PR DESCRIPTION
https://github.com/DocuNinja/builder2.0/pull/144

 - Signatory labels are now clickable. Tap a signatory name to assign a person, no more hunting for a tiny swap icon.                                                                             
- Single-signatory templates skip the editor. Pick who to send to in a popup, and it saves + sends automatically.                                                   
- Send button now saves first then sends, one click instead of two, no extra confirmation dialog.                                                                                                       
- Buttons renamed. "Send" and "Save for later" make your intent clear.                                                      
- Send button works immediately after assigning signatories, no need to refresh or save first. 
- When removing signatories (placeholders or invited), we show confirmation dialog now. 