### PR TITLE
[Bugfix] Hiding Status Card | E-Invoice Tab

### DIFF
--- a/src/pages/invoices/edit/components/EInvoice.tsx
+++ b/src/pages/invoices/edit/components/EInvoice.tsx
@@ -288,7 +288,7 @@ export default function EInvoice() {
         </Card>
       ) : null}
 
-      {isInvoiceEditable(invoice) && (
+      {displayEInvoiceAndStatusCard && isInvoiceEditable(invoice) && (
         <Card title={t('status')}>
           <div className="px-6 text-sm">
             <div


### PR DESCRIPTION
@beganovich @turbo124 The PR includes a correction that hides the status card when Peppol is not enabled, as it does not make sense for it to be visible.

Closes #3214 

Let me know your thoughts.