### PR TITLE
[Cleanup] Adjusting Passing Filters From Main Tables & Dashboard Tables Query Params

### DIFF
--- a/src/common/hooks/useDataTablePreferences.ts
+++ b/src/common/hooks/useDataTablePreferences.ts
@@ -40,7 +40,7 @@ interface Params {
   withoutStoringPerPage: boolean;
   enableSavingFilterPreference?: boolean;
   withoutStoringPage?: boolean;
-  withoutStoringFilters?: boolean;
+  withoutStoringSearchFilter?: boolean;
 }
 
 export function useDataTablePreferences(params: Params) {
@@ -66,7 +66,7 @@ export function useDataTablePreferences(params: Params) {
     withoutStoringPerPage,
     enableSavingFilterPreference,
     withoutStoringPage,
-    withoutStoringFilters,
+    withoutStoringSearchFilter,
   } = params;
 
   const getPreference = useDataTablePreference({ tableKey });
@@ -80,7 +80,7 @@ export function useDataTablePreferences(params: Params) {
     status: string[],
     perPage: PerPage
   ) => {
-    if (tableKey) {
+    if (tableKey && !withoutStoringSearchFilter) {
       storeSessionTableFilters(filter, currentPage, withoutStoringPage);
     }
 
@@ -140,9 +140,11 @@ export function useDataTablePreferences(params: Params) {
     if (!isHydrated || appliedRef.current) return;
 
     if (!isInitialConfiguration && !customFilter) {
-      setFilter((getPreference('filter') as string) || '');
+      if (!withoutStoringSearchFilter) {
+        setFilter((getPreference('filter') as string) || '');
+      }
 
-      if (customFilters && !withoutStoringFilters) {
+      if (customFilters) {
         if ((getPreference('customFilter') as string[]).length) {
           setCustomFilter(getPreference('customFilter') as string[]);
         } else {
@@ -163,10 +165,7 @@ export function useDataTablePreferences(params: Params) {
           'id|asc'
       );
       setSortedBy((getPreference('sortedBy') as string) || undefined);
-      if (
-        !withoutStoringFilters &&
-        (getPreference('status') as string[]).length
-      ) {
+      if ((getPreference('status') as string[]).length) {
         setStatus(getPreference('status') as string[]);
       } else {
         setStatus(['active']);

--- a/src/common/hooks/useDataTablePreferences.ts
+++ b/src/common/hooks/useDataTablePreferences.ts
@@ -41,6 +41,7 @@ interface Params {
   enableSavingFilterPreference?: boolean;
   withoutStoringPage?: boolean;
   withoutStoringSearchFilter?: boolean;
+  withoutStoringPreferences?: boolean;
 }
 
 export function useDataTablePreferences(params: Params) {
@@ -67,6 +68,7 @@ export function useDataTablePreferences(params: Params) {
     enableSavingFilterPreference,
     withoutStoringPage,
     withoutStoringSearchFilter,
+    withoutStoringPreferences,
   } = params;
 
   const getPreference = useDataTablePreference({ tableKey });
@@ -80,6 +82,10 @@ export function useDataTablePreferences(params: Params) {
     status: string[],
     perPage: PerPage
   ) => {
+    if (withoutStoringPreferences) {
+      return;
+    }
+
     if (tableKey && !withoutStoringSearchFilter) {
       storeSessionTableFilters(filter, currentPage, withoutStoringPage);
     }
@@ -138,6 +144,12 @@ export function useDataTablePreferences(params: Params) {
   useEffect(() => {
     // Guards logout/unmount races where the atom has been reset to null.
     if (!isHydrated || appliedRef.current) return;
+
+    if (withoutStoringPreferences) {
+      setArePreferencesApplied(true);
+      appliedRef.current = true;
+      return;
+    }
 
     if (!isInitialConfiguration && !customFilter) {
       if (!withoutStoringSearchFilter) {

--- a/src/common/hooks/useDataTableUtilities.ts
+++ b/src/common/hooks/useDataTableUtilities.ts
@@ -19,7 +19,6 @@ interface Params {
   tableKey: string | undefined;
   customFilters?: SelectOption[];
   customFilter?: string[] | undefined;
-  withoutStoringFilters?: boolean;
 }
 export function useDataTableUtilities(params: Params) {
   const options = useDataTableOptions();
@@ -30,16 +29,13 @@ export function useDataTableUtilities(params: Params) {
     customFilters,
     apiEndpoint,
     customFilter,
-    withoutStoringFilters,
   } = params;
 
   const getPreference = useDataTablePreference({ tableKey });
 
   const getDefaultOptions = () => {
     if (!isInitialConfiguration) {
-      const preferenceStatuses = withoutStoringFilters
-        ? []
-        : (getPreference('status') as string[]);
+      const preferenceStatuses = getPreference('status') as string[];
 
       const currentStatuses = preferenceStatuses?.length
         ? preferenceStatuses
@@ -57,9 +53,7 @@ export function useDataTableUtilities(params: Params) {
 
   const getDefaultCustomFilterOptions = () => {
     if (!isInitialConfiguration && customFilters) {
-      const preferenceCustomFilters = withoutStoringFilters
-        ? []
-        : (getPreference('customFilter') as string[]);
+      const preferenceCustomFilters = getPreference('customFilter') as string[];
 
       const currentStatuses = preferenceCustomFilters?.length
         ? preferenceCustomFilters

--- a/src/common/hooks/useDataTableUtilities.ts
+++ b/src/common/hooks/useDataTableUtilities.ts
@@ -19,6 +19,7 @@ interface Params {
   tableKey: string | undefined;
   customFilters?: SelectOption[];
   customFilter?: string[] | undefined;
+  withoutStoringPreferences?: boolean;
 }
 export function useDataTableUtilities(params: Params) {
   const options = useDataTableOptions();
@@ -29,13 +30,16 @@ export function useDataTableUtilities(params: Params) {
     customFilters,
     apiEndpoint,
     customFilter,
+    withoutStoringPreferences,
   } = params;
 
   const getPreference = useDataTablePreference({ tableKey });
 
   const getDefaultOptions = () => {
     if (!isInitialConfiguration) {
-      const preferenceStatuses = getPreference('status') as string[];
+      const preferenceStatuses = withoutStoringPreferences
+        ? []
+        : (getPreference('status') as string[]);
 
       const currentStatuses = preferenceStatuses?.length
         ? preferenceStatuses
@@ -53,7 +57,9 @@ export function useDataTableUtilities(params: Params) {
 
   const getDefaultCustomFilterOptions = () => {
     if (!isInitialConfiguration && customFilters) {
-      const preferenceCustomFilters = getPreference('customFilter') as string[];
+      const preferenceCustomFilters = withoutStoringPreferences
+        ? []
+        : (getPreference('customFilter') as string[]);
 
       const currentStatuses = preferenceCustomFilters?.length
         ? preferenceCustomFilters

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -190,6 +190,7 @@ interface Props<T> extends CommonProps {
   withoutPerPageAsPreference?: boolean;
   withoutPageAsPreference?: boolean;
   withoutStoringSearchFilter?: boolean;
+  withoutStoringPreferences?: boolean;
   withoutSortQueryParameter?: boolean;
   showRestoreBulk?: (selectedResources: T[]) => boolean;
   enableSavingFilterPreference?: boolean;
@@ -300,6 +301,7 @@ export function DataTable<T extends object>(props: Props<T>) {
     onDeleteBulkAction,
     withoutPageAsPreference = false,
     withoutStoringSearchFilter = false,
+    withoutStoringPreferences = false,
     filterColumns,
     onSelectedResourcesChange,
     preSelected = [],
@@ -323,7 +325,9 @@ export function DataTable<T extends object>(props: Props<T>) {
   const [customFilter, setCustomFilter] = useState<string[] | undefined>(
     undefined
   );
-  const [currentPage, setCurrentPage] = useState<number>(1);
+  const [currentPage, setCurrentPage] = useState<number>(
+    Number(apiEndpoint.searchParams.get('page')) || 1
+  );
   const [perPage, setPerPage] = useState<PerPage>(
     (apiEndpoint.searchParams.get('per_page') as PerPage) || '10'
   );
@@ -331,7 +335,9 @@ export function DataTable<T extends object>(props: Props<T>) {
     apiEndpoint.searchParams.get('sort') || 'id|asc'
   );
   const [sortedBy, setSortedBy] = useState<string | undefined>(undefined);
-  const [status, setStatus] = useState<string[]>(['active']);
+  const [status, setStatus] = useState<string[]>(
+    apiEndpoint.searchParams.get('status')?.split(',') || ['active']
+  );
   const [dateRangeEntries, setDateRangeEntries] = useAtom(dateRangeAtom);
   const [dateRangeQueryParameter, setDateRangeQueryParameter] =
     useState<string>('');
@@ -366,6 +372,7 @@ export function DataTable<T extends object>(props: Props<T>) {
     withoutStoringPerPage: withoutPerPageAsPreference,
     withoutStoringPage: withoutPageAsPreference,
     withoutStoringSearchFilter,
+    withoutStoringPreferences,
     enableSavingFilterPreference,
   });
 
@@ -379,6 +386,7 @@ export function DataTable<T extends object>(props: Props<T>) {
     tableKey: `${props.resource}s`,
     customFilter,
     customFilters,
+    withoutStoringPreferences,
   });
 
   const normalizeNumericCommas = (value: string): string => {

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -189,7 +189,7 @@ interface Props<T> extends CommonProps {
   footerColumns?: FooterColumns;
   withoutPerPageAsPreference?: boolean;
   withoutPageAsPreference?: boolean;
-  withoutStoringFilters?: boolean;
+  withoutStoringSearchFilter?: boolean;
   withoutSortQueryParameter?: boolean;
   showRestoreBulk?: (selectedResources: T[]) => boolean;
   enableSavingFilterPreference?: boolean;
@@ -299,7 +299,7 @@ export function DataTable<T extends object>(props: Props<T>) {
     totalRecordsPropPath,
     onDeleteBulkAction,
     withoutPageAsPreference = false,
-    withoutStoringFilters = false,
+    withoutStoringSearchFilter = false,
     filterColumns,
     onSelectedResourcesChange,
     preSelected = [],
@@ -365,7 +365,7 @@ export function DataTable<T extends object>(props: Props<T>) {
     customFilters,
     withoutStoringPerPage: withoutPerPageAsPreference,
     withoutStoringPage: withoutPageAsPreference,
-    withoutStoringFilters,
+    withoutStoringSearchFilter,
     enableSavingFilterPreference,
   });
 
@@ -379,7 +379,6 @@ export function DataTable<T extends object>(props: Props<T>) {
     tableKey: `${props.resource}s`,
     customFilter,
     customFilters,
-    withoutStoringFilters,
   });
 
   const normalizeNumericCommas = (value: string): string => {

--- a/src/pages/clients/show/pages/Credits.tsx
+++ b/src/pages/clients/show/pages/Credits.tsx
@@ -50,7 +50,7 @@ export default function Credits() {
       linkToCreateGuards={[permission('create_credit')]}
       hideEditableOptions={!hasPermission('edit_credit')}
       withoutPageAsPreference
-      withoutStoringFilters
+      withoutStoringSearchFilter
     />
   );
 }

--- a/src/pages/clients/show/pages/Expenses.tsx
+++ b/src/pages/clients/show/pages/Expenses.tsx
@@ -51,7 +51,7 @@ export default function Expenses() {
       linkToCreateGuards={[permission('create_expense')]}
       hideEditableOptions={!hasPermission('edit_expense')}
       withoutPageAsPreference
-      withoutStoringFilters
+      withoutStoringSearchFilter
     />
   );
 }

--- a/src/pages/clients/show/pages/Invoices.tsx
+++ b/src/pages/clients/show/pages/Invoices.tsx
@@ -76,7 +76,7 @@ export default function Invoices() {
           Boolean(!verifactuEnabled) ||
           (verifactuEnabled && invoice.status_id === InvoiceStatus.Draft)
         }
-        withoutStoringFilters
+        withoutStoringSearchFilter
       />
 
       <DeleteInvoicesConfirmationModal

--- a/src/pages/clients/show/pages/Payments.tsx
+++ b/src/pages/clients/show/pages/Payments.tsx
@@ -56,7 +56,7 @@ export default function Payments() {
         )
       }
       withoutPageAsPreference
-      withoutStoringFilters
+      withoutStoringSearchFilter
     />
   );
 }

--- a/src/pages/clients/show/pages/Projects.tsx
+++ b/src/pages/clients/show/pages/Projects.tsx
@@ -66,7 +66,7 @@ export default function Projects() {
       linkToCreateGuards={[permission('create_project')]}
       hideEditableOptions={!hasPermission('edit_project')}
       withoutPageAsPreference
-      withoutStoringFilters
+      withoutStoringSearchFilter
     />
   );
 }

--- a/src/pages/clients/show/pages/Quotes.tsx
+++ b/src/pages/clients/show/pages/Quotes.tsx
@@ -53,7 +53,7 @@ export default function Quotes() {
       linkToCreateGuards={[permission('create_quote')]}
       hideEditableOptions={!hasPermission('edit_quote')}
       withoutPageAsPreference
-      withoutStoringFilters
+      withoutStoringSearchFilter
     />
   );
 }

--- a/src/pages/clients/show/pages/RecurringExpenses.tsx
+++ b/src/pages/clients/show/pages/RecurringExpenses.tsx
@@ -44,7 +44,7 @@ export default function RecurringExpenses() {
       linkToCreateGuards={[permission('create_recurring_expense')]}
       hideEditableOptions={!hasPermission('edit_recurring_expense')}
       withoutPageAsPreference
-      withoutStoringFilters
+      withoutStoringSearchFilter
     />
   );
 }

--- a/src/pages/clients/show/pages/RecurringInvoices.tsx
+++ b/src/pages/clients/show/pages/RecurringInvoices.tsx
@@ -54,7 +54,7 @@ export default function RecurringInvoices() {
       linkToCreateGuards={[permission('create_recurring_invoice')]}
       hideEditableOptions={!hasPermission('edit_recurring_invoice')}
       withoutPageAsPreference
-      withoutStoringFilters
+      withoutStoringSearchFilter
     />
   );
 }

--- a/src/pages/clients/show/pages/Tasks.tsx
+++ b/src/pages/clients/show/pages/Tasks.tsx
@@ -66,7 +66,7 @@ export default function Tasks() {
       linkToCreateGuards={[permission('create_task')]}
       hideEditableOptions={!hasPermission('edit_task')}
       withoutPageAsPreference
-      withoutStoringFilters
+      withoutStoringSearchFilter
     />
   );
 }

--- a/src/pages/dashboard/components/ExpiredQuotes.tsx
+++ b/src/pages/dashboard/components/ExpiredQuotes.tsx
@@ -102,6 +102,7 @@ export function ExpiredQuotes() {
           withoutPagination
           withoutPadding
           withoutPerPageAsPreference
+          withoutStoringPreferences
           styleOptions={{
             withoutBottomBorder: true,
             withoutTopBorder: true,

--- a/src/pages/dashboard/components/PastDueInvoices.tsx
+++ b/src/pages/dashboard/components/PastDueInvoices.tsx
@@ -113,6 +113,7 @@ export function PastDueInvoices() {
           withoutPagination
           withoutPadding
           withoutPerPageAsPreference
+          withoutStoringPreferences
           styleOptions={{
             withoutBottomBorder: true,
             withoutTopBorder: true,

--- a/src/pages/dashboard/components/RecentPayments.tsx
+++ b/src/pages/dashboard/components/RecentPayments.tsx
@@ -124,6 +124,7 @@ export function RecentPayments() {
           withoutPagination
           withoutPadding
           withoutPerPageAsPreference
+          withoutStoringPreferences
           styleOptions={{
             withoutBottomBorder: true,
             withoutTopBorder: true,

--- a/src/pages/dashboard/components/UpcomingInvoices.tsx
+++ b/src/pages/dashboard/components/UpcomingInvoices.tsx
@@ -113,6 +113,7 @@ export function UpcomingInvoices() {
           withoutPagination
           withoutPadding
           withoutPerPageAsPreference
+          withoutStoringPreferences
           styleOptions={{
             withoutBottomBorder: true,
             withoutTopBorder: true,

--- a/src/pages/dashboard/components/UpcomingQuotes.tsx
+++ b/src/pages/dashboard/components/UpcomingQuotes.tsx
@@ -102,6 +102,7 @@ export function UpcomingQuotes() {
           withoutPagination
           withoutPadding
           withoutPerPageAsPreference
+          withoutStoringPreferences
           styleOptions={{
             withoutBottomBorder: true,
             withoutTopBorder: true,

--- a/src/pages/dashboard/components/UpcomingRecurringInvoices.tsx
+++ b/src/pages/dashboard/components/UpcomingRecurringInvoices.tsx
@@ -121,6 +121,7 @@ export function UpcomingRecurringInvoices() {
           withoutPagination
           withoutPadding
           withoutPerPageAsPreference
+          withoutStoringPreferences
           styleOptions={{
             withoutBottomBorder: true,
             withoutTopBorder: true,

--- a/src/pages/vendors/show/pages/Expenses.tsx
+++ b/src/pages/vendors/show/pages/Expenses.tsx
@@ -51,7 +51,7 @@ export default function Expenses() {
       linkToCreateGuards={[permission('create_expense')]}
       hideEditableOptions={!hasPermission('edit_expense')}
       withoutPageAsPreference
-      withoutStoringFilters
+      withoutStoringSearchFilter
     />
   );
 }

--- a/src/pages/vendors/show/pages/PurchaseOrders.tsx
+++ b/src/pages/vendors/show/pages/PurchaseOrders.tsx
@@ -55,7 +55,7 @@ export default function PurchaseOrders() {
       linkToCreateGuards={[permission('create_purchase_order')]}
       hideEditableOptions={!hasPermission('edit_purchase_order')}
       withoutPageAsPreference
-      withoutStoringFilters
+      withoutStoringSearchFilter
     />
   );
 }

--- a/src/pages/vendors/show/pages/RecurringExpenses.tsx
+++ b/src/pages/vendors/show/pages/RecurringExpenses.tsx
@@ -44,7 +44,7 @@ export default function RecurringExpenses() {
       linkToCreateGuards={[permission('create_recurring_expense')]}
       hideEditableOptions={!hasPermission('edit_recurring_expense')}
       withoutPageAsPreference
-      withoutStoringFilters
+      withoutStoringSearchFilter
     />
   );
 }


### PR DESCRIPTION
@beganovich @turbo124 The PR includes logic adjustments so that search filters are not passed to sub-tables, only status filters are passed. It also includes fixes for dashboard tables so they do not take any preferences from the main tables, but instead just use the passed endpoint. Let me know your thoughts.