### PR TITLE
[Cleanup] Adding Invoice Selector On Payment Page

### DIFF
--- a/src/components/invoices/InvoiceSelector.tsx
+++ b/src/components/invoices/InvoiceSelector.tsx
@@ -19,6 +19,7 @@ interface Props extends GenericSelectorProps<Invoice> {
   onClearButtonClick?: () => void;
   errorMessage?: string | string[];
   clientId?: string;
+  endpoint?: string;
 }
 
 export function InvoiceSelector(props: Props) {
@@ -37,11 +38,14 @@ export function InvoiceSelector(props: Props) {
       inputOptions={{
         value: props.value ?? null,
       }}
-      endpoint={endpoint(
-        `/api/v1/invoices?include=client&filter_deleted_clients=true&status=active${
-          props.clientId ? `&client_id=${props.clientId}` : ''
-        }`
-      )}
+      endpoint={
+        props.endpoint ??
+        endpoint(
+          `/api/v1/invoices?include=client&filter_deleted_clients=true&status=active${
+            props.clientId ? `&client_id=${props.clientId}` : ''
+          }`
+        )
+      }
       onChange={(invoice: Entry<Invoice>) =>
         invoice.resource && props.onChange?.(invoice.resource)
       }

--- a/src/pages/payments/create/Create.tsx
+++ b/src/pages/payments/create/Create.tsx
@@ -72,6 +72,7 @@ export default function Create() {
   const [searchParams] = useSearchParams();
 
   const hasCapturedPreSelection = useRef<boolean>(false);
+  const hasInvoiceTableSelection = useRef<boolean>(false);
 
   const pages = [
     { name: t('payments'), href: '/payments' },
@@ -316,6 +317,7 @@ export default function Create() {
                   credits: '',
                 });
 
+                hasInvoiceTableSelection.current = false;
                 setPreSelectedInvoiceIds([]);
 
                 setTimeout(() => {
@@ -370,6 +372,7 @@ export default function Create() {
                   credits: '',
                 });
 
+                hasInvoiceTableSelection.current = false;
                 setPreSelectedInvoiceIds([invoice.id]);
 
                 setTimeout(() => {
@@ -443,11 +446,19 @@ export default function Create() {
                       });
                     });
 
+                    hasInvoiceTableSelection.current = true;
+
                     setPayment(
                       (current) =>
                         current && { ...current, invoices: newInvoices }
                     );
                   } else {
+                    if (hasInvoiceTableSelection.current) {
+                      setPreSelectedInvoiceIds([]);
+                    }
+
+                    hasInvoiceTableSelection.current = false;
+
                     setPayment(
                       (current) => current && { ...current, invoices: [] }
                     );

--- a/src/pages/payments/create/Create.tsx
+++ b/src/pages/payments/create/Create.tsx
@@ -27,7 +27,7 @@ import { CustomField } from '$app/components/CustomField';
 
 import Toggle from '$app/components/forms/Toggle';
 import { Default } from '$app/components/layouts/Default';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
 import { useSave } from './hooks/useSave';
@@ -243,15 +243,22 @@ export default function Create() {
 
   const onSubmit = useSave({ setErrors, setIsFormBusy, isFormBusy });
 
-  const action = searchParams.get('action');
+  const isPrefilledFlow = useMemo(() => {
+    const action = searchParams.get('action');
 
-  const isPrefilledFlow =
-    searchParams.has('invoice') || action === 'enter' || action === 'apply';
+    return (
+      searchParams.has('invoice') || action === 'enter' || action === 'apply'
+    );
+  }, [searchParams]);
 
-  const invoiceSelectorEndpoint = endpoint(
-    `/api/v1/invoices?include=client&filter_deleted_clients=true&payable=${
-      payment?.client_id ?? ''
-    }&sort=date|desc`
+  const invoiceSelectorEndpoint = useMemo(
+    () =>
+      endpoint(
+        `/api/v1/invoices?include=client&filter_deleted_clients=true&payable=${
+          payment?.client_id ?? ''
+        }&sort=date|desc`
+      ),
+    [payment?.client_id]
   );
 
   return (

--- a/src/pages/payments/create/Create.tsx
+++ b/src/pages/payments/create/Create.tsx
@@ -27,7 +27,7 @@ import { CustomField } from '$app/components/CustomField';
 
 import Toggle from '$app/components/forms/Toggle';
 import { Default } from '$app/components/layouts/Default';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
 import { useSave } from './hooks/useSave';
@@ -71,6 +71,8 @@ export default function Create() {
   const [t] = useTranslation();
   const [searchParams] = useSearchParams();
 
+  const hasCapturedPreSelection = useRef<boolean>(false);
+
   const pages = [
     { name: t('payments'), href: '/payments' },
     { name: t('new_payment'), href: '/payments/create' },
@@ -100,17 +102,7 @@ export default function Create() {
   });
 
   const [preSelectedInvoiceIds, setPreSelectedInvoiceIds] = useState<string[]>(
-    () => {
-      if (searchParams.has('invoice')) {
-        return [searchParams.get('invoice') as string];
-      }
-
-      if (searchParams.get('action') === 'enter') {
-        return payment?.invoices.map(({ invoice_id }) => invoice_id) ?? [];
-      }
-
-      return [];
-    }
+    []
   );
 
   const { data: blankPayment } = useBlankPaymentQuery();
@@ -206,6 +198,28 @@ export default function Create() {
       );
     }
   }, [blankPayment]);
+
+  useEffect(() => {
+    if (hasCapturedPreSelection.current) {
+      return;
+    }
+
+    if (searchParams.has('invoice')) {
+      hasCapturedPreSelection.current = true;
+
+      setPreSelectedInvoiceIds([searchParams.get('invoice') as string]);
+
+      return;
+    }
+
+    if (searchParams.get('action') === 'enter' && payment?.invoices.length) {
+      hasCapturedPreSelection.current = true;
+
+      setPreSelectedInvoiceIds(
+        payment.invoices.map((invoice) => invoice.invoice_id)
+      );
+    }
+  }, [payment?.invoices, searchParams]);
 
   useEffect(() => {
     if (
@@ -329,65 +343,59 @@ export default function Create() {
             />
           </Element>
 
-          {!isPrefilledFlow && (
-            <>
-              <div className="flex items-center px-5 sm:px-6 py-1">
-                <div
-                  className="flex-1 border-b"
-                  style={{ borderColor: colors.$21 }}
-                />
-                <span
-                  className="px-4 text-xs font-medium uppercase"
-                  style={{ color: colors.$22, opacity: 0.8 }}
-                >
-                  {t('or')}
-                </span>
-                <div
-                  className="flex-1 border-b"
-                  style={{ borderColor: colors.$21 }}
-                />
-              </div>
+          <div className="flex items-center px-5 sm:px-6 py-1">
+            <div
+              className="flex-1 border-b"
+              style={{ borderColor: colors.$21 }}
+            />
+            <span
+              className="px-4 text-xs font-medium uppercase"
+              style={{ color: colors.$22, opacity: 0.8 }}
+            >
+              {t('or')}
+            </span>
+            <div
+              className="flex-1 border-b"
+              style={{ borderColor: colors.$21 }}
+            />
+          </div>
 
-              <Element leftSide={t('invoice')}>
-                <InvoiceSelector
-                  value={preSelectedInvoiceIds[0] ?? ''}
-                  endpoint={invoiceSelectorEndpoint}
-                  onChange={(invoice) => {
-                    setInitialEndpoints({
-                      invoices: '',
-                      credits: '',
-                    });
+          <Element leftSide={t('invoice')}>
+            <InvoiceSelector
+              value={preSelectedInvoiceIds[0] ?? ''}
+              endpoint={invoiceSelectorEndpoint}
+              onChange={(invoice) => {
+                setInitialEndpoints({
+                  invoices: '',
+                  credits: '',
+                });
 
-                    setPreSelectedInvoiceIds([invoice.id]);
+                setPreSelectedInvoiceIds([invoice.id]);
 
-                    setTimeout(() => {
-                      handleChange('client_id', invoice.client_id);
-                      handleChange(
-                        'currency_id',
-                        invoice.client?.settings.currency_id || '1'
-                      );
-                      handleChange('credits', []);
-                      handleChange('invoices', [
-                        {
-                          _id: v4(),
-                          invoice_id: invoice.id,
-                          amount:
-                            invoice.balance > 0
-                              ? invoice.balance
-                              : invoice.amount,
-                        },
-                      ]);
-                    }, 25);
-                  }}
-                  onClearButtonClick={() => {
-                    setPreSelectedInvoiceIds([]);
-                    handleChange('invoices', []);
-                  }}
-                  clearButton={Boolean(preSelectedInvoiceIds.length)}
-                />
-              </Element>
-            </>
-          )}
+                setTimeout(() => {
+                  handleChange('client_id', invoice.client_id);
+                  handleChange(
+                    'currency_id',
+                    invoice.client?.settings.currency_id || '1'
+                  );
+                  handleChange('credits', []);
+                  handleChange('invoices', [
+                    {
+                      _id: v4(),
+                      invoice_id: invoice.id,
+                      amount:
+                        invoice.balance > 0 ? invoice.balance : invoice.amount,
+                    },
+                  ]);
+                }, 25);
+              }}
+              onClearButtonClick={() => {
+                setPreSelectedInvoiceIds([]);
+                handleChange('invoices', []);
+              }}
+              clearButton={Boolean(preSelectedInvoiceIds.length)}
+            />
+          </Element>
 
           <Element
             leftSide={t('amount_received')}

--- a/src/pages/payments/create/Create.tsx
+++ b/src/pages/payments/create/Create.tsx
@@ -254,9 +254,11 @@ export default function Create() {
   const invoiceSelectorEndpoint = useMemo(
     () =>
       endpoint(
-        `/api/v1/invoices?include=client&filter_deleted_clients=true&payable=${
-          payment?.client_id ?? ''
-        }&sort=date|desc`
+        `/api/v1/invoices?include=client&filter_deleted_clients=true&sort=date|desc${
+          payment?.client_id
+            ? `&payable=${payment.client_id}`
+            : '&client_status=unpaid,partial'
+        }`
       ),
     [payment?.client_id]
   );

--- a/src/pages/payments/create/Create.tsx
+++ b/src/pages/payments/create/Create.tsx
@@ -27,7 +27,7 @@ import { CustomField } from '$app/components/CustomField';
 
 import Toggle from '$app/components/forms/Toggle';
 import { Default } from '$app/components/layouts/Default';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
 import { useSave } from './hooks/useSave';
@@ -71,8 +71,6 @@ export default function Create() {
   const [t] = useTranslation();
   const [searchParams] = useSearchParams();
 
-  const hasCapturedPreSelection = useRef<boolean>(false);
-
   const pages = [
     { name: t('payments'), href: '/payments' },
     { name: t('new_payment'), href: '/payments/create' },
@@ -101,10 +99,18 @@ export default function Create() {
     credits: '',
   });
 
-  const [selectedInvoiceId, setSelectedInvoiceId] = useState<string>('');
-
   const [preSelectedInvoiceIds, setPreSelectedInvoiceIds] = useState<string[]>(
-    []
+    () => {
+      if (searchParams.has('invoice')) {
+        return [searchParams.get('invoice') as string];
+      }
+
+      if (searchParams.get('action') === 'enter') {
+        return payment?.invoices.map(({ invoice_id }) => invoice_id) ?? [];
+      }
+
+      return [];
+    }
   );
 
   const { data: blankPayment } = useBlankPaymentQuery();
@@ -202,40 +208,18 @@ export default function Create() {
   }, [blankPayment]);
 
   useEffect(() => {
-    if (hasCapturedPreSelection.current) {
-      return;
-    }
-
-    if (searchParams.has('invoice')) {
-      hasCapturedPreSelection.current = true;
-
-      setPreSelectedInvoiceIds([searchParams.get('invoice') as string]);
-
-      return;
-    }
-
-    if (payment?.invoices.length) {
-      hasCapturedPreSelection.current = true;
-
-      setPreSelectedInvoiceIds(
-        payment.invoices.map((invoice) => invoice.invoice_id)
-      );
-    }
-  }, [payment?.invoices, searchParams]);
-
-  useEffect(() => {
     if (
       payment?.client_id &&
       (searchParams.get('client') === payment?.client_id ||
         !searchParams.get('client'))
     ) {
-      const withInvoice = searchParams.get('invoice') || selectedInvoiceId;
+      const withInvoices = preSelectedInvoiceIds.join(',');
 
       setInitialEndpoints({
         invoices: `/api/v1/invoices?include=client&payable=${
           payment?.client_id
         }&per_page=100&sort=date|desc&per_page=1000${
-          withInvoice ? `&with=${withInvoice}` : ''
+          withInvoices ? `&with=${withInvoices}` : ''
         }`,
         credits: `/api/v1/credits?include=client&client_id=${
           payment?.client_id
@@ -246,12 +230,7 @@ export default function Create() {
         }`,
       });
     }
-  }, [
-    payment?.client_id,
-    searchParams,
-    preSelectedInvoiceIds,
-    selectedInvoiceId,
-  ]);
+  }, [payment?.client_id, searchParams, preSelectedInvoiceIds]);
 
   useEffect(() => {
     return () => {
@@ -323,7 +302,7 @@ export default function Create() {
                   credits: '',
                 });
 
-                setSelectedInvoiceId('');
+                setPreSelectedInvoiceIds([]);
 
                 setTimeout(() => {
                   handleChange('client_id', client?.id as string);
@@ -336,7 +315,7 @@ export default function Create() {
                 }, 25);
               }}
               onClearButtonClick={() => {
-                setSelectedInvoiceId('');
+                setPreSelectedInvoiceIds([]);
                 handleChange('client_id', '');
                 handleChange('currency_id', '');
                 handleChange('invoices', []);
@@ -371,7 +350,7 @@ export default function Create() {
 
               <Element leftSide={t('invoice')}>
                 <InvoiceSelector
-                  value={selectedInvoiceId}
+                  value={preSelectedInvoiceIds[0] ?? ''}
                   endpoint={invoiceSelectorEndpoint}
                   onChange={(invoice) => {
                     setInitialEndpoints({
@@ -379,7 +358,7 @@ export default function Create() {
                       credits: '',
                     });
 
-                    setSelectedInvoiceId(invoice.id);
+                    setPreSelectedInvoiceIds([invoice.id]);
 
                     setTimeout(() => {
                       handleChange('client_id', invoice.client_id);
@@ -401,10 +380,10 @@ export default function Create() {
                     }, 25);
                   }}
                   onClearButtonClick={() => {
-                    setSelectedInvoiceId('');
+                    setPreSelectedInvoiceIds([]);
                     handleChange('invoices', []);
                   }}
-                  clearButton={Boolean(selectedInvoiceId)}
+                  clearButton={Boolean(preSelectedInvoiceIds.length)}
                 />
               </Element>
             </>
@@ -469,13 +448,7 @@ export default function Create() {
                 withoutPagination
                 withoutStatusFilter
                 withoutAllBulkActions
-                preSelected={
-                  searchParams.get('invoice')
-                    ? [searchParams.get('invoice') as string]
-                    : selectedInvoiceId
-                    ? [selectedInvoiceId]
-                    : []
-                }
+                preSelected={preSelectedInvoiceIds}
                 emptyState={
                   <div className="flex items-center justify-center pt-2">
                     <span className="text-sm" style={{ color: colors.$17 }}>

--- a/src/pages/payments/create/Create.tsx
+++ b/src/pages/payments/create/Create.tsx
@@ -32,12 +32,14 @@ import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
 import { useSave } from './hooks/useSave';
 import { ClientSelector } from '$app/components/clients/ClientSelector';
+import { InvoiceSelector } from '$app/components/invoices/InvoiceSelector';
 import { useAtom } from 'jotai';
 import { paymentAtom } from '../common/atoms';
 import { usePaymentTypes } from '$app/common/hooks/usePaymentTypes';
 import { NumberInputField } from '$app/components/forms/NumberInputField';
 import { Banner } from '$app/components/Banner';
 import { useColorScheme } from '$app/common/colors';
+import { endpoint } from '$app/common/helpers';
 import { ErrorMessage } from '$app/components/ErrorMessage';
 import { DataTable } from '$app/components/DataTable';
 import { useApplyInvoiceTableColumns } from '../common/hooks/useApplyInvoiceTableColumns';
@@ -96,6 +98,8 @@ export default function Create() {
     invoices: '',
     credits: '',
   });
+
+  const [selectedInvoiceId, setSelectedInvoiceId] = useState<string>('');
 
   const { data: blankPayment } = useBlankPaymentQuery();
 
@@ -197,13 +201,13 @@ export default function Create() {
       (searchParams.get('client') === payment?.client_id ||
         !searchParams.get('client'))
     ) {
+      const withInvoice = searchParams.get('invoice') || selectedInvoiceId;
+
       setInitialEndpoints({
         invoices: `/api/v1/invoices?include=client&payable=${
           payment?.client_id
         }&per_page=100&sort=date|desc&per_page=1000${
-          searchParams.get('invoice')
-            ? `&with=${searchParams.get('invoice')}`
-            : ''
+          withInvoice ? `&with=${withInvoice}` : ''
         }`,
         credits: `/api/v1/credits?include=client&client_id=${
           payment?.client_id
@@ -214,7 +218,7 @@ export default function Create() {
         }`,
       });
     }
-  }, [payment?.client_id, searchParams]);
+  }, [payment?.client_id, searchParams, selectedInvoiceId]);
 
   useEffect(() => {
     return () => {
@@ -238,6 +242,17 @@ export default function Create() {
   };
 
   const onSubmit = useSave({ setErrors, setIsFormBusy, isFormBusy });
+
+  const action = searchParams.get('action');
+
+  const isPrefilledFlow =
+    searchParams.has('invoice') || action === 'enter' || action === 'apply';
+
+  const invoiceSelectorEndpoint = endpoint(
+    `/api/v1/invoices?include=client&filter_deleted_clients=true&payable=${
+      payment?.client_id ?? ''
+    }&sort=date|desc`
+  );
 
   return (
     <Default
@@ -268,6 +283,8 @@ export default function Create() {
                   credits: '',
                 });
 
+                setSelectedInvoiceId('');
+
                 setTimeout(() => {
                   handleChange('client_id', client?.id as string);
                   handleChange(
@@ -279,6 +296,7 @@ export default function Create() {
                 }, 25);
               }}
               onClearButtonClick={() => {
+                setSelectedInvoiceId('');
                 handleChange('client_id', '');
                 handleChange('currency_id', '');
                 handleChange('invoices', []);
@@ -287,14 +305,70 @@ export default function Create() {
               errorMessage={errors?.errors.client_id}
               defaultValue={payment?.client_id}
               value={payment?.client_id}
-              readonly={
-                searchParams.has('invoice') ||
-                searchParams.get('action') === 'enter' ||
-                searchParams.get('action') === 'apply'
-              }
+              readonly={isPrefilledFlow}
               initiallyVisible={!payment?.client_id}
             />
           </Element>
+
+          {!isPrefilledFlow && (
+            <>
+              <div className="flex items-center px-5 sm:px-6 py-1">
+                <div
+                  className="flex-1 border-b"
+                  style={{ borderColor: colors.$21 }}
+                />
+                <span
+                  className="px-4 text-xs font-medium uppercase"
+                  style={{ color: colors.$22, opacity: 0.8 }}
+                >
+                  {t('or')}
+                </span>
+                <div
+                  className="flex-1 border-b"
+                  style={{ borderColor: colors.$21 }}
+                />
+              </div>
+
+              <Element leftSide={t('invoice')}>
+                <InvoiceSelector
+                  value={selectedInvoiceId}
+                  endpoint={invoiceSelectorEndpoint}
+                  onChange={(invoice) => {
+                    setInitialEndpoints({
+                      invoices: '',
+                      credits: '',
+                    });
+
+                    setSelectedInvoiceId(invoice.id);
+
+                    setTimeout(() => {
+                      handleChange('client_id', invoice.client_id);
+                      handleChange(
+                        'currency_id',
+                        invoice.client?.settings.currency_id || '1'
+                      );
+                      handleChange('credits', []);
+                      handleChange('invoices', [
+                        {
+                          _id: v4(),
+                          invoice_id: invoice.id,
+                          amount:
+                            invoice.balance > 0
+                              ? invoice.balance
+                              : invoice.amount,
+                        },
+                      ]);
+                    }, 25);
+                  }}
+                  onClearButtonClick={() => {
+                    setSelectedInvoiceId('');
+                    handleChange('invoices', []);
+                  }}
+                  clearButton={Boolean(selectedInvoiceId)}
+                />
+              </Element>
+            </>
+          )}
 
           <Element
             leftSide={t('amount_received')}
@@ -358,6 +432,8 @@ export default function Create() {
                 preSelected={
                   searchParams.get('invoice')
                     ? [searchParams.get('invoice') as string]
+                    : selectedInvoiceId
+                    ? [selectedInvoiceId]
                     : []
                 }
                 emptyState={

--- a/src/pages/payments/create/Create.tsx
+++ b/src/pages/payments/create/Create.tsx
@@ -255,9 +255,7 @@ export default function Create() {
     () =>
       endpoint(
         `/api/v1/invoices?include=client&filter_deleted_clients=true&sort=date|desc${
-          payment?.client_id
-            ? `&payable=${payment.client_id}`
-            : '&client_status=unpaid,partial'
+          payment?.client_id ? `&payable=${payment.client_id}` : '&payable=true'
         }`
       ),
     [payment?.client_id]


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of an invoice selector on the payment creation page to enable the ability to create a payment by selecting an invoice. Screenshot:

<img width="1030" height="768" alt="Screenshot 2026-06-17 at 13 46 27" src="https://github.com/user-attachments/assets/1c879312-f2cc-4199-942c-5cc50ceb6a1f" />

Let me know your thoughts.