### PR TITLE
[Feature] Implementing Last Error Message For Health Check Modal

### DIFF
--- a/src/components/AboutModal.tsx
+++ b/src/components/AboutModal.tsx
@@ -109,6 +109,7 @@ export function AboutModal(props: Props) {
   const [systemInfo, setSystemInfo] = useState<SystemInfo | undefined>(
     currentSystemInfo
   );
+  const [lastError, setLastError] = useState<string>('');
 
   const handleHealthCheck = (allowAction?: boolean) => {
     if (!isFormBusy || allowAction) {
@@ -122,6 +123,12 @@ export function AboutModal(props: Props) {
           toast.dismiss();
         })
         .finally(() => setIsFormBusy(false));
+
+      request('GET', endpoint('/api/v1/last_error'))
+        .then((response) => {
+          setLastError(response.data?.message ?? '');
+        })
+        .catch(() => setLastError(''));
     }
   };
 
@@ -327,25 +334,40 @@ export function AboutModal(props: Props) {
             <div className="flex flex-col">
               <span className="font-medium text-base mb-1">PHP</span>
               <span>
-                {t('web')}: {systemInfo?.php_version.current_php_version}
+                {t('web')}: {systemInfo?.php_version?.current_php_version}
               </span>
               <span>
-                {t('cli')}: {systemInfo?.php_version.current_php_cli_version}
+                {t('cli')}: {systemInfo?.php_version?.current_php_cli_version}
               </span>
-              <span>Memory: {systemInfo?.php_version.memory_limit}</span>
+              <span>Memory: {systemInfo?.php_version?.memory_limit}</span>
               <span>API: {systemInfo?.api_version}</span>
             </div>
 
             <div>
               <Icon
                 element={
-                  systemInfo?.php_version.is_okay ? CheckCircle : MdWarning
+                  systemInfo?.php_version?.is_okay ? CheckCircle : MdWarning
                 }
-                color={systemInfo?.php_version.is_okay ? 'green' : 'red'}
+                color={systemInfo?.php_version?.is_okay ? 'green' : 'red'}
                 size={25}
               />
             </div>
           </div>
+
+          {Boolean(lastError) && (
+            <div className="flex justify-between items-center py-1 px-3">
+              <div className="flex flex-col">
+                <span className="font-medium text-base mb-1">
+                  {t('last_error')}
+                </span>
+                <span className="break-all">{lastError}</span>
+              </div>
+
+              <div>
+                <Icon element={MdWarning} color="red" size={25} />
+              </div>
+            </div>
+          )}
 
           {(Boolean(!systemInfo?.env_writable) ||
             Boolean(systemInfo?.file_permissions !== 'Ok')) &&

--- a/src/components/AboutModal.tsx
+++ b/src/components/AboutModal.tsx
@@ -126,7 +126,7 @@ export function AboutModal(props: Props) {
 
       request('GET', endpoint('/api/v1/last_error'))
         .then((response) => {
-          setLastError(response.data?.message ?? '');
+          setLastError(response.data?.last_error ?? '');
         })
         .catch(() => setLastError(''));
     }
@@ -358,7 +358,7 @@ export function AboutModal(props: Props) {
             <div className="flex justify-between items-center py-1 px-3">
               <div className="flex flex-col">
                 <span className="font-medium text-base mb-1">
-                  {t('last_error')}
+                  {t('recent_errors')}
                 </span>
                 <span className="break-all">{lastError}</span>
               </div>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of a "last error message" label on the health check modal. Screenshot:

<img width="321" height="541" alt="Screenshot 2026-06-17 at 18 06 58" src="https://github.com/user-attachments/assets/2b96d286-5758-46e5-a960-ea1ae1cfb90c" />

Let me know your thoughts.