### PR TITLE
[Cleanup] Linking Transaction On Expense

### DIFF
--- a/src/pages/expenses/common/hooks.tsx
+++ b/src/pages/expenses/common/hooks.tsx
@@ -270,6 +270,7 @@ export function useAllExpenseColumns() {
     'tax_rate1',
     'tax_rate2',
     'tax_rate3',
+    'transaction',
     'transaction_reference',
     'updated_at',
   ] as const;
@@ -579,6 +580,20 @@ export function useExpenseColumns() {
       id: 'tax_rate3',
       label: t('tax_rate3'),
       format: (value) => formatNumber(value),
+    },
+    {
+      column: 'transaction',
+      id: 'transaction_id',
+      label: t('transaction'),
+      format: (value, expense) =>
+        expense.transaction_id && (
+          <DynamicLink
+            to={route('/transactions/:id/edit', { id: value.toString() })}
+            renderSpan={disableNavigation('bank_transaction', null)}
+          >
+            {t('view')}
+          </DynamicLink>
+        ),
     },
     {
       column: 'transaction_reference',

--- a/src/pages/expenses/create/components/Details.tsx
+++ b/src/pages/expenses/create/components/Details.tsx
@@ -145,6 +145,18 @@ export function Details(props: Props) {
           </>
         )}
 
+        {expense && pageType === 'edit' && expense.transaction_id && (
+          <Element leftSide={t('transaction')}>
+            <LinkBase
+              to={route('/transactions/:id/edit', {
+                id: expense.transaction_id,
+              })}
+            >
+              {t('view')}
+            </LinkBase>
+          </Element>
+        )}
+
         {expense && (
           <Element
             leftSide={


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of a new column, 'transaction', on the expense table, which links the expense to a transaction if one exists. It also implements the link on the expense edit page. Screenshots:

<img width="1262" height="650" alt="Screenshot 2026-06-24 at 11 59 01" src="https://github.com/user-attachments/assets/1a863c72-a08b-4c68-a7c2-bbe337f62751" />

<img width="914" height="769" alt="Screenshot 2026-06-24 at 11 59 18" src="https://github.com/user-attachments/assets/328220d0-cf54-411d-abf5-cb55e44e5b39" />

Let me know your thoughts.