### PR TITLE
[Cleanup] Implementing Pagination Using API Responses

### DIFF
--- a/src/common/helpers/pagination.ts
+++ b/src/common/helpers/pagination.ts
@@ -32,7 +32,13 @@ export interface PageNavigationContext {
   requestUrl?: string;
 }
 
-const FALLBACK_BASE = 'http://localhost';
+export interface PageNavigationState {
+  canPrevious: boolean;
+  canNext: boolean;
+}
+
+const URL_BASE =
+  typeof window !== 'undefined' ? window.location.origin : 'http://localhost';
 
 export function getPaginationLinks(
   pagination?: Partial<PaginationMeta> | null
@@ -55,7 +61,7 @@ export function getPaginationLinks(
 
 export function getPageParameter(url: string): number | null {
   try {
-    const page = Number(new URL(url, FALLBACK_BASE).searchParams.get('page'));
+    const page = Number(new URL(url, URL_BASE).searchParams.get('page'));
 
     return Number.isInteger(page) && page > 0 ? page : null;
   } catch {
@@ -65,7 +71,7 @@ export function getPageParameter(url: string): number | null {
 
 export function replacePageParameter(url: string, page: number): string | null {
   try {
-    const target = new URL(url, FALLBACK_BASE);
+    const target = new URL(url, URL_BASE);
 
     target.searchParams.set('page', page.toString());
 
@@ -117,5 +123,14 @@ export function resolvePageNavigation(
   return {
     page,
     url: requestUrl ? replacePageParameter(requestUrl, page) : null,
+  };
+}
+
+export function getPageNavigationState(
+  context: PageNavigationContext
+): PageNavigationState {
+  return {
+    canPrevious: resolvePageNavigation('previous', context) !== null,
+    canNext: resolvePageNavigation('next', context) !== null,
   };
 }

--- a/src/common/helpers/pagination.ts
+++ b/src/common/helpers/pagination.ts
@@ -20,16 +20,10 @@ export type PageNavigationAction =
   | 'last'
   | number;
 
-export interface PageNavigationTarget {
-  page: number;
-  url: string | null;
-}
-
 export interface PageNavigationContext {
   currentPage: number;
   totalPages: number;
   pagination?: Partial<PaginationMeta> | null;
-  requestUrl?: string;
 }
 
 export interface PageNavigationState {
@@ -69,23 +63,11 @@ export function getPageParameter(url: string): number | null {
   }
 }
 
-export function replacePageParameter(url: string, page: number): string | null {
-  try {
-    const target = new URL(url, URL_BASE);
-
-    target.searchParams.set('page', page.toString());
-
-    return target.href;
-  } catch {
-    return null;
-  }
-}
-
 export function resolvePageNavigation(
   action: PageNavigationAction,
   context: PageNavigationContext
-): PageNavigationTarget | null {
-  const { currentPage, requestUrl } = context;
+): number | null {
+  const { currentPage } = context;
   const totalPages = Math.max(context.totalPages, 1);
 
   if (action === 'previous' || action === 'next') {
@@ -96,7 +78,7 @@ export function resolvePageNavigation(
       const page = getPageParameter(link);
 
       if (page !== null) {
-        return { page, url: link };
+        return page;
       }
     } else if (links) {
       return null;
@@ -104,26 +86,12 @@ export function resolvePageNavigation(
 
     const page = action === 'next' ? currentPage + 1 : currentPage - 1;
 
-    if (page < 1 || page > totalPages) {
-      return null;
-    }
-
-    return {
-      page,
-      url: requestUrl ? replacePageParameter(requestUrl, page) : null,
-    };
+    return page < 1 || page > totalPages ? null : page;
   }
 
   const page = action === 'first' ? 1 : action === 'last' ? totalPages : action;
 
-  if (!Number.isInteger(page) || page < 1 || page > totalPages) {
-    return null;
-  }
-
-  return {
-    page,
-    url: requestUrl ? replacePageParameter(requestUrl, page) : null,
-  };
+  return !Number.isInteger(page) || page < 1 || page > totalPages ? null : page;
 }
 
 export function getPageNavigationState(

--- a/src/common/helpers/pagination.ts
+++ b/src/common/helpers/pagination.ts
@@ -1,0 +1,121 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import {
+  PaginationLinks,
+  PaginationMeta,
+} from '$app/common/interfaces/generic-many-response';
+
+export type PageNavigationAction =
+  | 'first'
+  | 'previous'
+  | 'next'
+  | 'last'
+  | number;
+
+export interface PageNavigationTarget {
+  page: number;
+  url: string | null;
+}
+
+export interface PageNavigationContext {
+  currentPage: number;
+  totalPages: number;
+  pagination?: Partial<PaginationMeta> | null;
+  requestUrl?: string;
+}
+
+const FALLBACK_BASE = 'http://localhost';
+
+export function getPaginationLinks(
+  pagination?: Partial<PaginationMeta> | null
+): PaginationLinks | undefined {
+  const links = pagination?.links;
+
+  if (!links || Array.isArray(links) || typeof links !== 'object') {
+    return undefined;
+  }
+
+  const previous = links.previous?.length ? links.previous : undefined;
+  const next = links.next?.length ? links.next : undefined;
+
+  if (!previous && !next) {
+    return undefined;
+  }
+
+  return { previous, next };
+}
+
+export function getPageParameter(url: string): number | null {
+  try {
+    const page = Number(new URL(url, FALLBACK_BASE).searchParams.get('page'));
+
+    return Number.isInteger(page) && page > 0 ? page : null;
+  } catch {
+    return null;
+  }
+}
+
+export function replacePageParameter(url: string, page: number): string | null {
+  try {
+    const target = new URL(url, FALLBACK_BASE);
+
+    target.searchParams.set('page', page.toString());
+
+    return target.href;
+  } catch {
+    return null;
+  }
+}
+
+export function resolvePageNavigation(
+  action: PageNavigationAction,
+  context: PageNavigationContext
+): PageNavigationTarget | null {
+  const { currentPage, requestUrl } = context;
+  const totalPages = Math.max(context.totalPages, 1);
+
+  if (action === 'previous' || action === 'next') {
+    const links = getPaginationLinks(context.pagination);
+    const link = links?.[action];
+
+    if (link) {
+      const page = getPageParameter(link);
+
+      if (page !== null) {
+        return { page, url: link };
+      }
+    } else if (links) {
+      return null;
+    }
+
+    const page = action === 'next' ? currentPage + 1 : currentPage - 1;
+
+    if (page < 1 || page > totalPages) {
+      return null;
+    }
+
+    return {
+      page,
+      url: requestUrl ? replacePageParameter(requestUrl, page) : null,
+    };
+  }
+
+  const page = action === 'first' ? 1 : action === 'last' ? totalPages : action;
+
+  if (!Number.isInteger(page) || page < 1 || page > totalPages) {
+    return null;
+  }
+
+  return {
+    page,
+    url: requestUrl ? replacePageParameter(requestUrl, page) : null,
+  };
+}

--- a/src/common/interfaces/generic-many-response.ts
+++ b/src/common/interfaces/generic-many-response.ts
@@ -8,16 +8,24 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
+export interface PaginationLinks {
+  previous?: string | null;
+  next?: string | null;
+}
+
+export interface PaginationMeta {
+  total: number;
+  count: number;
+  per_page: number;
+  current_page: number;
+  total_pages: number;
+  // Backends without link support serialize `links` as an empty array.
+  links?: PaginationLinks | string[];
+}
+
 export interface GenericManyResponse<T> {
   data: T[];
   meta: {
-    pagination: {
-      total: number;
-      count: number;
-      per_page: number;
-      current_page: number;
-      total_pages: number;
-      links: string[];
-    };
+    pagination: PaginationMeta;
   };
 }

--- a/src/common/interfaces/generic-many-response.ts
+++ b/src/common/interfaces/generic-many-response.ts
@@ -19,7 +19,6 @@ export interface PaginationMeta {
   per_page: number;
   current_page: number;
   total_pages: number;
-  // Backends without link support serialize `links` as an empty array.
   links?: PaginationLinks | string[];
 }
 

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -1410,7 +1410,6 @@ export function DataTable<T extends object>(props: Props<T>) {
               : data.data.meta.pagination.total
           }
           pagination={data.data.meta?.pagination}
-          requestUrl={apiEndpoint.href}
         />
       )}
     </div>

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -1409,6 +1409,8 @@ export function DataTable<T extends object>(props: Props<T>) {
               ? get(data, totalRecordsPropPath)
               : data.data.meta.pagination.total
           }
+          pagination={data.data.meta?.pagination}
+          requestUrl={apiEndpoint.href}
         />
       )}
     </div>

--- a/src/components/tables/Pagination.tsx
+++ b/src/components/tables/Pagination.tsx
@@ -26,15 +26,18 @@ import {
 } from '$app/common/helpers/pagination';
 import { PaginationMeta } from '$app/common/interfaces/generic-many-response';
 
-const PaginationButton = styled.div<{ $disabled?: boolean }>`
+const PaginationButton = styled.button`
   background-color: ${(props) => props.theme.backgroundColor};
   border-color: ${(props) => props.theme.borderColor};
-  opacity: ${(props) => (props.$disabled ? 0.5 : 1)};
-  cursor: ${(props) => (props.$disabled ? 'not-allowed' : 'pointer')};
+  cursor: pointer;
 
-  &:hover {
-    background-color: ${(props) =>
-      props.$disabled ? props.theme.backgroundColor : props.theme.hoverColor};
+  &:hover:not(:disabled) {
+    background-color: ${(props) => props.theme.hoverColor};
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
   }
 `;
 
@@ -145,31 +148,31 @@ export function Pagination(props: Props) {
       >
         <div className="flex items-center">
           <PaginationButton
+            type="button"
             className="p-2 sm:p-[0.725rem] border rounded-l-md shadow-sm"
             theme={{
               hoverColor: colors.$4,
               backgroundColor: colors.$1,
               borderColor: colors.$24,
             }}
-            $disabled={!canPrevious}
-            aria-disabled={!canPrevious}
+            disabled={!canPrevious}
             data-cy="paginationFirstPage"
-            onClick={() => canPrevious && navigate('first')}
+            onClick={() => navigate('first')}
           >
             <DoubleChevronLeft size="0.9rem" color={colors.$3} />
           </PaginationButton>
 
           <PaginationButton
+            type="button"
             className="p-2 sm:p-[0.725rem] border-b border-t border-r rounded-r-md shadow-sm"
             theme={{
               hoverColor: colors.$4,
               backgroundColor: colors.$1,
               borderColor: colors.$24,
             }}
-            $disabled={!canPrevious}
-            aria-disabled={!canPrevious}
+            disabled={!canPrevious}
             data-cy="paginationPreviousPage"
-            onClick={() => canPrevious && navigate('previous')}
+            onClick={() => navigate('previous')}
           >
             <ChevronLeft size="0.9rem" color={colors.$3} />
           </PaginationButton>
@@ -196,31 +199,31 @@ export function Pagination(props: Props) {
 
         <div className="flex">
           <PaginationButton
+            type="button"
             className="p-2 sm:p-[0.725rem] border-t border-b border-l rounded-l-md shadow-sm"
             theme={{
               hoverColor: colors.$4,
               backgroundColor: colors.$1,
               borderColor: colors.$24,
             }}
-            $disabled={!canNext}
-            aria-disabled={!canNext}
+            disabled={!canNext}
             data-cy="paginationNextPage"
-            onClick={() => canNext && navigate('next')}
+            onClick={() => navigate('next')}
           >
             <ChevronRight size="0.9rem" color={colors.$3} />
           </PaginationButton>
 
           <PaginationButton
+            type="button"
             className="p-2 sm:p-[0.725rem] border rounded-r-md shadow-sm"
             theme={{
               hoverColor: colors.$4,
               backgroundColor: colors.$1,
               borderColor: colors.$24,
             }}
-            $disabled={!canNext}
-            aria-disabled={!canNext}
+            disabled={!canNext}
             data-cy="paginationLastPage"
-            onClick={() => canNext && navigate('last')}
+            onClick={() => navigate('last')}
           >
             <DoubleChevronRight size="0.9rem" color={colors.$3} />
           </PaginationButton>

--- a/src/components/tables/Pagination.tsx
+++ b/src/components/tables/Pagination.tsx
@@ -58,7 +58,6 @@ interface Props extends CommonProps {
   onRowsChange: (rows: PerPage) => any;
   totalRecords?: number;
   pagination?: PaginationMeta;
-  requestUrl?: string;
 }
 
 const defaultProps: Props = {
@@ -85,25 +84,23 @@ export function Pagination(props: Props) {
   }, [props.currentPage]);
 
   const navigate = (action: PageNavigationAction) => {
-    const target = resolvePageNavigation(action, {
+    const page = resolvePageNavigation(action, {
       currentPage: props.currentPage,
       totalPages: props.totalPages,
       pagination: props.pagination,
-      requestUrl: props.requestUrl,
     });
 
-    if (target) {
-      props.onPageChange(target.page);
+    if (page !== null) {
+      props.onPageChange(page);
     }
 
-    return target;
+    return page;
   };
 
   const { canPrevious, canNext } = getPageNavigationState({
     currentPage: props.currentPage,
     totalPages: props.totalPages,
     pagination: props.pagination,
-    requestUrl: props.requestUrl,
   });
 
   const handlePageInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -121,9 +118,9 @@ export function Pagination(props: Props) {
   const handlePageInputBlur = () => {
     const pageNumber = parseInt(pageInputValue, 10);
 
-    const target = !isNaN(pageNumber) ? navigate(pageNumber) : null;
+    const page = !isNaN(pageNumber) ? navigate(pageNumber) : null;
 
-    if (!target) {
+    if (page === null) {
       setPageInputValue(String(props.currentPage));
     }
   };
@@ -155,6 +152,8 @@ export function Pagination(props: Props) {
               borderColor: colors.$24,
             }}
             $disabled={!canPrevious}
+            aria-disabled={!canPrevious}
+            data-cy="paginationFirstPage"
             onClick={() => canPrevious && navigate('first')}
           >
             <DoubleChevronLeft size="0.9rem" color={colors.$3} />
@@ -168,6 +167,8 @@ export function Pagination(props: Props) {
               borderColor: colors.$24,
             }}
             $disabled={!canPrevious}
+            aria-disabled={!canPrevious}
+            data-cy="paginationPreviousPage"
             onClick={() => canPrevious && navigate('previous')}
           >
             <ChevronLeft size="0.9rem" color={colors.$3} />
@@ -202,6 +203,8 @@ export function Pagination(props: Props) {
               borderColor: colors.$24,
             }}
             $disabled={!canNext}
+            aria-disabled={!canNext}
+            data-cy="paginationNextPage"
             onClick={() => canNext && navigate('next')}
           >
             <ChevronRight size="0.9rem" color={colors.$3} />
@@ -215,6 +218,8 @@ export function Pagination(props: Props) {
               borderColor: colors.$24,
             }}
             $disabled={!canNext}
+            aria-disabled={!canNext}
+            data-cy="paginationLastPage"
             onClick={() => canNext && navigate('last')}
           >
             <DoubleChevronRight size="0.9rem" color={colors.$3} />

--- a/src/components/tables/Pagination.tsx
+++ b/src/components/tables/Pagination.tsx
@@ -20,17 +20,21 @@ import { ChevronRight } from '../icons/ChevronRight';
 import { DoubleChevronRight } from '../icons/DoubleChevronRight';
 import styled from 'styled-components';
 import {
+  getPageNavigationState,
   PageNavigationAction,
   resolvePageNavigation,
 } from '$app/common/helpers/pagination';
 import { PaginationMeta } from '$app/common/interfaces/generic-many-response';
 
-const PaginationButton = styled.div`
+const PaginationButton = styled.div<{ $disabled?: boolean }>`
   background-color: ${(props) => props.theme.backgroundColor};
   border-color: ${(props) => props.theme.borderColor};
+  opacity: ${(props) => (props.$disabled ? 0.5 : 1)};
+  cursor: ${(props) => (props.$disabled ? 'not-allowed' : 'pointer')};
 
   &:hover {
-    background-color: ${(props) => props.theme.hoverColor};
+    background-color: ${(props) =>
+      props.$disabled ? props.theme.backgroundColor : props.theme.hoverColor};
   }
 `;
 
@@ -95,6 +99,13 @@ export function Pagination(props: Props) {
     return target;
   };
 
+  const { canPrevious, canNext } = getPageNavigationState({
+    currentPage: props.currentPage,
+    totalPages: props.totalPages,
+    pagination: props.pagination,
+    requestUrl: props.requestUrl,
+  });
+
   const handlePageInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
 
@@ -137,25 +148,27 @@ export function Pagination(props: Props) {
       >
         <div className="flex items-center">
           <PaginationButton
-            className="p-2 sm:p-[0.725rem] border rounded-l-md shadow-sm cursor-pointer"
+            className="p-2 sm:p-[0.725rem] border rounded-l-md shadow-sm"
             theme={{
               hoverColor: colors.$4,
               backgroundColor: colors.$1,
               borderColor: colors.$24,
             }}
-            onClick={() => navigate('first')}
+            $disabled={!canPrevious}
+            onClick={() => canPrevious && navigate('first')}
           >
             <DoubleChevronLeft size="0.9rem" color={colors.$3} />
           </PaginationButton>
 
           <PaginationButton
-            className="p-2 sm:p-[0.725rem] border-b border-t border-r rounded-r-md shadow-sm cursor-pointer"
+            className="p-2 sm:p-[0.725rem] border-b border-t border-r rounded-r-md shadow-sm"
             theme={{
               hoverColor: colors.$4,
               backgroundColor: colors.$1,
               borderColor: colors.$24,
             }}
-            onClick={() => navigate('previous')}
+            $disabled={!canPrevious}
+            onClick={() => canPrevious && navigate('previous')}
           >
             <ChevronLeft size="0.9rem" color={colors.$3} />
           </PaginationButton>
@@ -182,25 +195,27 @@ export function Pagination(props: Props) {
 
         <div className="flex">
           <PaginationButton
-            className="p-2 sm:p-[0.725rem] border-t border-b border-l rounded-l-md shadow-sm cursor-pointer"
+            className="p-2 sm:p-[0.725rem] border-t border-b border-l rounded-l-md shadow-sm"
             theme={{
               hoverColor: colors.$4,
               backgroundColor: colors.$1,
               borderColor: colors.$24,
             }}
-            onClick={() => navigate('next')}
+            $disabled={!canNext}
+            onClick={() => canNext && navigate('next')}
           >
             <ChevronRight size="0.9rem" color={colors.$3} />
           </PaginationButton>
 
           <PaginationButton
-            className="p-2 sm:p-[0.725rem] border rounded-r-md shadow-sm cursor-pointer"
+            className="p-2 sm:p-[0.725rem] border rounded-r-md shadow-sm"
             theme={{
               hoverColor: colors.$4,
               backgroundColor: colors.$1,
               borderColor: colors.$24,
             }}
-            onClick={() => navigate('last')}
+            $disabled={!canNext}
+            onClick={() => canNext && navigate('last')}
           >
             <DoubleChevronRight size="0.9rem" color={colors.$3} />
           </PaginationButton>

--- a/src/components/tables/Pagination.tsx
+++ b/src/components/tables/Pagination.tsx
@@ -19,6 +19,11 @@ import { DoubleChevronLeft } from '../icons/DoubleChevronLeft';
 import { ChevronRight } from '../icons/ChevronRight';
 import { DoubleChevronRight } from '../icons/DoubleChevronRight';
 import styled from 'styled-components';
+import {
+  PageNavigationAction,
+  resolvePageNavigation,
+} from '$app/common/helpers/pagination';
+import { PaginationMeta } from '$app/common/interfaces/generic-many-response';
 
 const PaginationButton = styled.div`
   background-color: ${(props) => props.theme.backgroundColor};
@@ -48,6 +53,8 @@ interface Props extends CommonProps {
   currentPerPage?: PerPage;
   onRowsChange: (rows: PerPage) => any;
   totalRecords?: number;
+  pagination?: PaginationMeta;
+  requestUrl?: string;
 }
 
 const defaultProps: Props = {
@@ -73,10 +80,19 @@ export function Pagination(props: Props) {
     setPageInputValue(String(props.currentPage));
   }, [props.currentPage]);
 
-  const goToPage = (pageNumber: number) => {
-    if (pageNumber >= 1 && pageNumber <= props.totalPages) {
-      props.onPageChange(pageNumber);
+  const navigate = (action: PageNavigationAction) => {
+    const target = resolvePageNavigation(action, {
+      currentPage: props.currentPage,
+      totalPages: props.totalPages,
+      pagination: props.pagination,
+      requestUrl: props.requestUrl,
+    });
+
+    if (target) {
+      props.onPageChange(target.page);
     }
+
+    return target;
   };
 
   const handlePageInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -94,13 +110,9 @@ export function Pagination(props: Props) {
   const handlePageInputBlur = () => {
     const pageNumber = parseInt(pageInputValue, 10);
 
-    if (
-      !isNaN(pageNumber) &&
-      pageNumber >= 1 &&
-      pageNumber <= props.totalPages
-    ) {
-      goToPage(pageNumber);
-    } else {
+    const target = !isNaN(pageNumber) ? navigate(pageNumber) : null;
+
+    if (!target) {
       setPageInputValue(String(props.currentPage));
     }
   };
@@ -131,7 +143,7 @@ export function Pagination(props: Props) {
               backgroundColor: colors.$1,
               borderColor: colors.$24,
             }}
-            onClick={() => goToPage(1)}
+            onClick={() => navigate('first')}
           >
             <DoubleChevronLeft size="0.9rem" color={colors.$3} />
           </PaginationButton>
@@ -143,7 +155,7 @@ export function Pagination(props: Props) {
               backgroundColor: colors.$1,
               borderColor: colors.$24,
             }}
-            onClick={() => goToPage(props.currentPage - 1)}
+            onClick={() => navigate('previous')}
           >
             <ChevronLeft size="0.9rem" color={colors.$3} />
           </PaginationButton>
@@ -176,7 +188,7 @@ export function Pagination(props: Props) {
               backgroundColor: colors.$1,
               borderColor: colors.$24,
             }}
-            onClick={() => goToPage(props.currentPage + 1)}
+            onClick={() => navigate('next')}
           >
             <ChevronRight size="0.9rem" color={colors.$3} />
           </PaginationButton>
@@ -188,7 +200,7 @@ export function Pagination(props: Props) {
               backgroundColor: colors.$1,
               borderColor: colors.$24,
             }}
-            onClick={() => goToPage(props.totalPages)}
+            onClick={() => navigate('last')}
           >
             <DoubleChevronRight size="0.9rem" color={colors.$3} />
           </PaginationButton>

--- a/src/pages/settings/company/documents/components/Table.tsx
+++ b/src/pages/settings/company/documents/components/Table.tsx
@@ -322,6 +322,7 @@ export function Table() {
           onRowsChange={setPerPage}
           totalPages={data.data.meta.pagination.total_pages}
           totalRecords={data.data.meta.pagination.total}
+          pagination={data.data.meta.pagination}
         />
       )}
 

--- a/tests/e2e/invoice-list-pagination.spec.ts
+++ b/tests/e2e/invoice-list-pagination.spec.ts
@@ -177,10 +177,13 @@ async function expectControlDisabled(
   dataCy: string,
   disabled: boolean
 ) {
-  await expect(paginationControl(page, dataCy)).toHaveAttribute(
-    'aria-disabled',
-    disabled ? 'true' : 'false'
-  );
+  const control = paginationControl(page, dataCy);
+
+  if (disabled) {
+    await expect(control).toBeDisabled();
+  } else {
+    await expect(control).toBeEnabled();
+  }
 }
 
 async function expectStoredInvoicePage(page: Page, pageNumber: number) {

--- a/tests/e2e/invoice-list-pagination.spec.ts
+++ b/tests/e2e/invoice-list-pagination.spec.ts
@@ -74,6 +74,80 @@ test('preserves invoice list page after navigating back from an invoice', async 
   await expect(getPageInput(page)).toHaveValue('2');
 });
 
+test('navigates the invoice list with the pagination controls', async ({
+  page,
+  api,
+}) => {
+  test.setTimeout(60_000);
+
+  const client = await api.createEntity('clients', {
+    name: uniqueName('pagination-controls-client'),
+    contacts: [
+      {
+        first_name: 'Pagination',
+        last_name: 'Controls',
+        email: uniqueName('pagination-controls-client') + '@example.test',
+      },
+    ],
+  });
+
+  for (let index = 1; index <= INVOICE_COUNT; index++) {
+    await api.createEntity('invoices', {
+      client_id: client.id,
+      number: uniqueName(`pagination-controls-invoice-${index}`),
+      status_id: '1',
+      date: '2026-06-14',
+      line_items: [lineItem(index)],
+    });
+  }
+
+  await login(page);
+  await page
+    .locator('[data-cy="navigationBar"]')
+    .getByRole('link', { name: 'Invoices', exact: true })
+    .click();
+
+  await page.waitForURL('**/invoices');
+  await waitForTableData(page);
+
+  const pageInput = getPageInput(page);
+
+  // 15 invoices at the default 10 per page produce two pages.
+  await expect(pageInput).toHaveValue('1');
+  await expect(
+    page.locator('[data-cy="dataTable"]').getByText('/ 2')
+  ).toBeVisible();
+
+  // First page: the backward controls are disabled, the forward ones enabled.
+  await expectControlDisabled(page, 'paginationFirstPage', true);
+  await expectControlDisabled(page, 'paginationPreviousPage', true);
+  await expectControlDisabled(page, 'paginationNextPage', false);
+  await expectControlDisabled(page, 'paginationLastPage', false);
+
+  // Next advances one page and issues a real request for the second page.
+  const nextResponse = waitForInvoicesPage(page, 2);
+  await paginationControl(page, 'paginationNextPage').click();
+  await nextResponse;
+  await expect(pageInput).toHaveValue('2');
+
+  // Last page: the forward controls are disabled, the backward ones enabled.
+  await expectControlDisabled(page, 'paginationNextPage', true);
+  await expectControlDisabled(page, 'paginationLastPage', true);
+  await expectControlDisabled(page, 'paginationPreviousPage', false);
+  await expectControlDisabled(page, 'paginationFirstPage', false);
+
+  // Previous steps back to the first page.
+  await paginationControl(page, 'paginationPreviousPage').click();
+  await expect(pageInput).toHaveValue('1');
+
+  // Last jumps to the final page; first jumps back to the start.
+  await paginationControl(page, 'paginationLastPage').click();
+  await expect(pageInput).toHaveValue('2');
+
+  await paginationControl(page, 'paginationFirstPage').click();
+  await expect(pageInput).toHaveValue('1');
+});
+
 function getPageInput(page: Page) {
   return page
     .locator('[data-cy="dataTable"]')
@@ -82,18 +156,37 @@ function getPageInput(page: Page) {
     );
 }
 
-async function goToPage(page: Page, pageNumber: number) {
-  const response = page.waitForResponse(
+function waitForInvoicesPage(page: Page, pageNumber: number) {
+  return page.waitForResponse(
     (currentResponse) =>
       currentResponse.request().method() === 'GET' &&
       currentResponse.url().includes('/api/v1/invoices?') &&
       currentResponse.url().includes(`page=${pageNumber}`) &&
       currentResponse.ok()
   );
+}
+
+async function goToPage(page: Page, pageNumber: number) {
+  const response = waitForInvoicesPage(page, pageNumber);
 
   await getPageInput(page).fill(pageNumber.toString());
   await getPageInput(page).press('Enter');
   await response;
+}
+
+function paginationControl(page: Page, dataCy: string) {
+  return page.locator(`[data-cy="dataTable"] [data-cy="${dataCy}"]`);
+}
+
+async function expectControlDisabled(
+  page: Page,
+  dataCy: string,
+  disabled: boolean
+) {
+  await expect(paginationControl(page, dataCy)).toHaveAttribute(
+    'aria-disabled',
+    disabled ? 'true' : 'false'
+  );
 }
 
 async function expectStoredInvoicePage(page: Page, pageNumber: number) {

--- a/tests/e2e/invoice-list-pagination.spec.ts
+++ b/tests/e2e/invoice-list-pagination.spec.ts
@@ -112,35 +112,29 @@ test('navigates the invoice list with the pagination controls', async ({
 
   const pageInput = getPageInput(page);
 
-  // 15 invoices at the default 10 per page produce two pages.
   await expect(pageInput).toHaveValue('1');
   await expect(
     page.locator('[data-cy="dataTable"]').getByText('/ 2')
   ).toBeVisible();
 
-  // First page: the backward controls are disabled, the forward ones enabled.
   await expectControlDisabled(page, 'paginationFirstPage', true);
   await expectControlDisabled(page, 'paginationPreviousPage', true);
   await expectControlDisabled(page, 'paginationNextPage', false);
   await expectControlDisabled(page, 'paginationLastPage', false);
 
-  // Next advances one page and issues a real request for the second page.
   const nextResponse = waitForInvoicesPage(page, 2);
   await paginationControl(page, 'paginationNextPage').click();
   await nextResponse;
   await expect(pageInput).toHaveValue('2');
 
-  // Last page: the forward controls are disabled, the backward ones enabled.
   await expectControlDisabled(page, 'paginationNextPage', true);
   await expectControlDisabled(page, 'paginationLastPage', true);
   await expectControlDisabled(page, 'paginationPreviousPage', false);
   await expectControlDisabled(page, 'paginationFirstPage', false);
 
-  // Previous steps back to the first page.
   await paginationControl(page, 'paginationPreviousPage').click();
   await expect(pageInput).toHaveValue('1');
 
-  // Last jumps to the final page; first jumps back to the start.
   await paginationControl(page, 'paginationLastPage').click();
   await expect(pageInput).toHaveValue('2');
 

--- a/tests/unit/pagination.test.ts
+++ b/tests/unit/pagination.test.ts
@@ -10,6 +10,7 @@
 
 import { describe, test, expect } from 'vitest';
 import {
+  getPageNavigationState,
   getPaginationLinks,
   getPageParameter,
   replacePageParameter,
@@ -224,5 +225,65 @@ describe('resolvePageNavigation', () => {
         pagination: undefined,
       })
     ).toEqual({ page: 1, url: null });
+  });
+});
+
+describe('getPageNavigationState', () => {
+  test('both directions available in the middle of the range', () => {
+    expect(
+      getPageNavigationState({
+        currentPage: 2,
+        totalPages: 26,
+        pagination,
+      })
+    ).toEqual({ canPrevious: true, canNext: true });
+  });
+
+  test('on the first page the api omits the previous link', () => {
+    expect(
+      getPageNavigationState({
+        currentPage: 1,
+        totalPages: 26,
+        pagination: { ...pagination, links: { next: nextLink } },
+      })
+    ).toEqual({ canPrevious: false, canNext: true });
+  });
+
+  test('on the last page the api omits the next link', () => {
+    expect(
+      getPageNavigationState({
+        currentPage: 26,
+        totalPages: 26,
+        pagination: { ...pagination, links: { previous: previousLink } },
+      })
+    ).toEqual({ canPrevious: true, canNext: false });
+  });
+
+  test('falls back to page bounds for backends without link support', () => {
+    expect(
+      getPageNavigationState({
+        currentPage: 1,
+        totalPages: 26,
+        pagination: legacyPagination,
+      })
+    ).toEqual({ canPrevious: false, canNext: true });
+
+    expect(
+      getPageNavigationState({
+        currentPage: 26,
+        totalPages: 26,
+        pagination: legacyPagination,
+      })
+    ).toEqual({ canPrevious: true, canNext: false });
+  });
+
+  test('a single page disables both directions', () => {
+    expect(
+      getPageNavigationState({
+        currentPage: 1,
+        totalPages: 1,
+        pagination: undefined,
+      })
+    ).toEqual({ canPrevious: false, canNext: false });
   });
 });

--- a/tests/unit/pagination.test.ts
+++ b/tests/unit/pagination.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { describe, test, expect } from 'vitest';
+import {
+  getPaginationLinks,
+  getPageParameter,
+  replacePageParameter,
+  resolvePageNavigation,
+} from '$app/common/helpers/pagination';
+import { PaginationMeta } from '$app/common/interfaces/generic-many-response';
+
+const previousLink =
+  'https://grok.romulus.com.au/api/v1/invoices?q=%2Fapi%2Fv1%2Finvoices&per_page=2&balance=gt%3A10&page=1';
+const nextLink =
+  'https://grok.romulus.com.au/api/v1/invoices?q=%2Fapi%2Fv1%2Finvoices&per_page=2&balance=gt%3A10&page=3';
+
+const pagination: PaginationMeta = {
+  total: 51,
+  count: 2,
+  per_page: 2,
+  current_page: 2,
+  total_pages: 26,
+  links: {
+    previous: previousLink,
+    next: nextLink,
+  },
+};
+
+const legacyPagination: PaginationMeta = {
+  total: 51,
+  count: 2,
+  per_page: 2,
+  current_page: 2,
+  total_pages: 26,
+  links: [],
+};
+
+describe('getPaginationLinks', () => {
+  test('returns the links of the response', () => {
+    expect(getPaginationLinks(pagination)).toEqual({
+      previous: previousLink,
+      next: nextLink,
+    });
+  });
+
+  test('drops empty and null directions', () => {
+    expect(
+      getPaginationLinks({ links: { previous: null, next: nextLink } })
+    ).toEqual({ previous: undefined, next: nextLink });
+
+    expect(
+      getPaginationLinks({ links: { previous: '', next: nextLink } })
+    ).toEqual({ previous: undefined, next: nextLink });
+  });
+
+  test('returns undefined for backends without link support', () => {
+    expect(getPaginationLinks(legacyPagination)).toBeUndefined();
+    expect(getPaginationLinks({ links: undefined })).toBeUndefined();
+    expect(getPaginationLinks({ links: {} })).toBeUndefined();
+    expect(getPaginationLinks(undefined)).toBeUndefined();
+    expect(getPaginationLinks(null)).toBeUndefined();
+  });
+});
+
+describe('getPageParameter', () => {
+  test('reads the page of a link', () => {
+    expect(getPageParameter(nextLink)).toEqual(3);
+    expect(getPageParameter(previousLink)).toEqual(1);
+  });
+
+  test('supports relative urls', () => {
+    expect(getPageParameter('/api/v1/invoices?page=4')).toEqual(4);
+  });
+
+  test('returns null when the page is missing or invalid', () => {
+    expect(getPageParameter('https://invoicing.co/api/v1/invoices')).toBeNull();
+    expect(getPageParameter('/api/v1/invoices?page=0')).toBeNull();
+    expect(getPageParameter('/api/v1/invoices?page=-1')).toBeNull();
+    expect(getPageParameter('/api/v1/invoices?page=abc')).toBeNull();
+    expect(getPageParameter('/api/v1/invoices?page=1.5')).toBeNull();
+    expect(getPageParameter('http://')).toBeNull();
+  });
+});
+
+describe('replacePageParameter', () => {
+  test('replaces the page keeping every other query parameter', () => {
+    const url = replacePageParameter(nextLink, 26);
+
+    expect(url).toContain('page=26');
+    expect(url).toContain('per_page=2');
+    expect(url).toContain('balance=gt%3A10');
+    expect(getPageParameter(url as string)).toEqual(26);
+  });
+
+  test('adds the page when it is missing', () => {
+    expect(
+      replacePageParameter('https://invoicing.co/api/v1/invoices', 5)
+    ).toEqual('https://invoicing.co/api/v1/invoices?page=5');
+  });
+
+  test('returns null for invalid urls', () => {
+    expect(replacePageParameter('http://', 5)).toBeNull();
+  });
+});
+
+describe('resolvePageNavigation', () => {
+  const context = {
+    currentPage: 2,
+    totalPages: 26,
+    pagination,
+    requestUrl: nextLink.replace('page=3', 'page=2'),
+  };
+
+  test('next and previous are driven by the api links', () => {
+    expect(resolvePageNavigation('next', context)).toEqual({
+      page: 3,
+      url: nextLink,
+    });
+
+    expect(resolvePageNavigation('previous', context)).toEqual({
+      page: 1,
+      url: previousLink,
+    });
+  });
+
+  test('a missing link direction means the page does not exist', () => {
+    expect(
+      resolvePageNavigation('next', {
+        ...context,
+        pagination: { ...pagination, links: { previous: previousLink } },
+      })
+    ).toBeNull();
+
+    expect(
+      resolvePageNavigation('previous', {
+        ...context,
+        pagination: { ...pagination, links: { next: nextLink } },
+      })
+    ).toBeNull();
+  });
+
+  test('falls back to arithmetic for backends without link support', () => {
+    const legacyContext = { ...context, pagination: legacyPagination };
+
+    expect(resolvePageNavigation('next', legacyContext)).toEqual({
+      page: 3,
+      url: expect.stringContaining('page=3'),
+    });
+
+    expect(resolvePageNavigation('previous', legacyContext)).toEqual({
+      page: 1,
+      url: expect.stringContaining('page=1'),
+    });
+
+    expect(
+      resolvePageNavigation('next', {
+        ...legacyContext,
+        currentPage: 26,
+      })
+    ).toBeNull();
+
+    expect(
+      resolvePageNavigation('previous', {
+        ...legacyContext,
+        currentPage: 1,
+      })
+    ).toBeNull();
+  });
+
+  test('falls back to arithmetic when the link has no valid page', () => {
+    expect(
+      resolvePageNavigation('next', {
+        ...context,
+        pagination: {
+          ...pagination,
+          links: { next: 'https://invoicing.co/api/v1/invoices' },
+        },
+      })
+    ).toEqual({ page: 3, url: expect.stringContaining('page=3') });
+  });
+
+  test('first and last replace the page of the current request url', () => {
+    expect(resolvePageNavigation('first', context)).toEqual({
+      page: 1,
+      url: expect.stringContaining('page=1'),
+    });
+
+    const last = resolvePageNavigation('last', context);
+
+    expect(last).toEqual({ page: 26, url: expect.stringContaining('page=26') });
+    expect(last?.url).toContain('balance=gt%3A10');
+  });
+
+  test('explicit pages are clamped to the available range', () => {
+    expect(resolvePageNavigation(13, context)).toEqual({
+      page: 13,
+      url: expect.stringContaining('page=13'),
+    });
+
+    expect(resolvePageNavigation(0, context)).toBeNull();
+    expect(resolvePageNavigation(27, context)).toBeNull();
+    expect(resolvePageNavigation(1.5, context)).toBeNull();
+  });
+
+  test('resolves the page even without a request url', () => {
+    expect(
+      resolvePageNavigation('last', { ...context, requestUrl: undefined })
+    ).toEqual({ page: 26, url: null });
+  });
+
+  test('treats an empty result set as a single page', () => {
+    expect(
+      resolvePageNavigation('last', {
+        currentPage: 1,
+        totalPages: 0,
+        pagination: undefined,
+      })
+    ).toEqual({ page: 1, url: null });
+  });
+});

--- a/tests/unit/pagination.test.ts
+++ b/tests/unit/pagination.test.ts
@@ -13,7 +13,6 @@ import {
   getPageNavigationState,
   getPaginationLinks,
   getPageParameter,
-  replacePageParameter,
   resolvePageNavigation,
 } from '$app/common/helpers/pagination';
 import { PaginationMeta } from '$app/common/interfaces/generic-many-response';
@@ -91,45 +90,16 @@ describe('getPageParameter', () => {
   });
 });
 
-describe('replacePageParameter', () => {
-  test('replaces the page keeping every other query parameter', () => {
-    const url = replacePageParameter(nextLink, 26);
-
-    expect(url).toContain('page=26');
-    expect(url).toContain('per_page=2');
-    expect(url).toContain('balance=gt%3A10');
-    expect(getPageParameter(url as string)).toEqual(26);
-  });
-
-  test('adds the page when it is missing', () => {
-    expect(
-      replacePageParameter('https://invoicing.co/api/v1/invoices', 5)
-    ).toEqual('https://invoicing.co/api/v1/invoices?page=5');
-  });
-
-  test('returns null for invalid urls', () => {
-    expect(replacePageParameter('http://', 5)).toBeNull();
-  });
-});
-
 describe('resolvePageNavigation', () => {
   const context = {
     currentPage: 2,
     totalPages: 26,
     pagination,
-    requestUrl: nextLink.replace('page=3', 'page=2'),
   };
 
   test('next and previous are driven by the api links', () => {
-    expect(resolvePageNavigation('next', context)).toEqual({
-      page: 3,
-      url: nextLink,
-    });
-
-    expect(resolvePageNavigation('previous', context)).toEqual({
-      page: 1,
-      url: previousLink,
-    });
+    expect(resolvePageNavigation('next', context)).toEqual(3);
+    expect(resolvePageNavigation('previous', context)).toEqual(1);
   });
 
   test('a missing link direction means the page does not exist', () => {
@@ -151,28 +121,15 @@ describe('resolvePageNavigation', () => {
   test('falls back to arithmetic for backends without link support', () => {
     const legacyContext = { ...context, pagination: legacyPagination };
 
-    expect(resolvePageNavigation('next', legacyContext)).toEqual({
-      page: 3,
-      url: expect.stringContaining('page=3'),
-    });
-
-    expect(resolvePageNavigation('previous', legacyContext)).toEqual({
-      page: 1,
-      url: expect.stringContaining('page=1'),
-    });
+    expect(resolvePageNavigation('next', legacyContext)).toEqual(3);
+    expect(resolvePageNavigation('previous', legacyContext)).toEqual(1);
 
     expect(
-      resolvePageNavigation('next', {
-        ...legacyContext,
-        currentPage: 26,
-      })
+      resolvePageNavigation('next', { ...legacyContext, currentPage: 26 })
     ).toBeNull();
 
     expect(
-      resolvePageNavigation('previous', {
-        ...legacyContext,
-        currentPage: 1,
-      })
+      resolvePageNavigation('previous', { ...legacyContext, currentPage: 1 })
     ).toBeNull();
   });
 
@@ -185,36 +142,19 @@ describe('resolvePageNavigation', () => {
           links: { next: 'https://invoicing.co/api/v1/invoices' },
         },
       })
-    ).toEqual({ page: 3, url: expect.stringContaining('page=3') });
+    ).toEqual(3);
   });
 
-  test('first and last replace the page of the current request url', () => {
-    expect(resolvePageNavigation('first', context)).toEqual({
-      page: 1,
-      url: expect.stringContaining('page=1'),
-    });
-
-    const last = resolvePageNavigation('last', context);
-
-    expect(last).toEqual({ page: 26, url: expect.stringContaining('page=26') });
-    expect(last?.url).toContain('balance=gt%3A10');
+  test('first and last resolve to the range bounds', () => {
+    expect(resolvePageNavigation('first', context)).toEqual(1);
+    expect(resolvePageNavigation('last', context)).toEqual(26);
   });
 
   test('explicit pages are clamped to the available range', () => {
-    expect(resolvePageNavigation(13, context)).toEqual({
-      page: 13,
-      url: expect.stringContaining('page=13'),
-    });
-
+    expect(resolvePageNavigation(13, context)).toEqual(13);
     expect(resolvePageNavigation(0, context)).toBeNull();
     expect(resolvePageNavigation(27, context)).toBeNull();
     expect(resolvePageNavigation(1.5, context)).toBeNull();
-  });
-
-  test('resolves the page even without a request url', () => {
-    expect(
-      resolvePageNavigation('last', { ...context, requestUrl: undefined })
-    ).toEqual({ page: 26, url: null });
   });
 
   test('treats an empty result set as a single page', () => {
@@ -224,7 +164,7 @@ describe('resolvePageNavigation', () => {
         totalPages: 0,
         pagination: undefined,
       })
-    ).toEqual({ page: 1, url: null });
+    ).toEqual(1);
   });
 });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
+  plugins: [tsconfigPaths()],
   test: {
     include: ['tests/unit/**/*.test.ts'],
   },


### PR DESCRIPTION
@beganovich @turbo124 The PR includes implementation of new logic for changing pages on tables. So, instead of handling it in React, we will take the next or previous property values from the pagination response object. Also, the PR prepares logic for more changes like this one. Let me know your thoughts.