### PR TITLE
[Cleanup] Adding Tax Exempt Client Column For Mapping

### DIFF
--- a/src/common/constants/exports/client-map.ts
+++ b/src/common/constants/exports/client-map.ts
@@ -63,6 +63,7 @@ export const clientMap: Record[] = [
   { trans: 'id_number', value: 'client.id_number', map: 'client' },
   { trans: 'public_notes', value: 'client.public_notes', map: 'client' },
   { trans: 'phone', value: 'client.phone', map: 'client' },
+  { trans: 'is_tax_exempt', value: 'client.is_tax_exempt', map: 'client' },
   { trans: 'classification', value: 'client.classification', map: 'client' },
   { trans: 'credit_balance', value: 'client.credit_balance', map: 'client' },
   { trans: 'payment_balance', value: 'client.payment_balance', map: 'client' },


### PR DESCRIPTION
@beganovich @turbo124 The actual task is adding mapping columns for import https://invoiceninja.atlassian.net/browse/RU-2397, but when we are importing any entity, we rely 100% on the backend for where the mapping columns come from. In the screenshot, you can see my attempt where those two columns are on the left side because they are included in the CSV, but there are no such columns in the dropdown on the right side to select them (it comes from backend). However, the tax exempt property was not included in the report mapping, so I added it. Screenshot:

<img width="869" height="178" alt="Screenshot 2026-07-23 at 13 14 38" src="https://github.com/user-attachments/assets/16d65725-f5d3-47b8-adbb-535cab8113c2" />

Let me know your thoughts.