### PR TITLE
[Bugfix] Fixing Footer Net Amount Calculations

### DIFF
--- a/src/common/helpers/invoices/net-amount.ts
+++ b/src/common/helpers/invoices/net-amount.ts
@@ -1,0 +1,20 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2026. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+interface NetAmountResource {
+  amount: number;
+  total_taxes: number;
+}
+
+export function calculateNetAmount(
+  resource: Partial<NetAmountResource> | undefined | null
+): number {
+  return Number(resource?.amount || 0) - Number(resource?.total_taxes || 0);
+}

--- a/src/common/hooks/useSumTableColumn.ts
+++ b/src/common/hooks/useSumTableColumn.ts
@@ -18,7 +18,8 @@ import { PurchaseOrder } from '../interfaces/purchase-order';
 import { Expense } from '../interfaces/expense';
 import { RecurringExpense } from '../interfaces/recurring-expense';
 import { Transaction } from '../interfaces/transactions';
-import { useReactSettings } from './useReactSettings';
+import { useCurrentCompany } from './useCurrentCompany';
+import { useUserNumberPrecision } from './useUserNumberPrecision';
 
 type Resource =
   | Invoice
@@ -37,14 +38,16 @@ interface Params {
 export function useSumTableColumn(params?: Params) {
   const formatMoney = useFormatMoney();
 
-  const reactSettings = useReactSettings();
+  const company = useCurrentCompany();
+
+  const numberPrecision = useUserNumberPrecision();
 
   const { currencyPath, countryPath } = params || {};
 
   return (values: number[] | undefined, resources: Resource[] | undefined) => {
     if (values && resources) {
       const result = values.reduce(
-        (total, currentValue) => (total = total + currentValue),
+        (total, currentValue) => total + Number(currentValue || 0),
         0
       );
 
@@ -55,18 +58,25 @@ export function useSumTableColumn(params?: Params) {
 
       const currencyIds = collect(resources)
         .pluck(currencyPath || 'client.settings.currency_id')
+        .map((currencyId) =>
+          typeof currencyId === 'string' && currencyId
+            ? currencyId
+            : company?.settings.currency_id
+        )
         .unique()
-        .toArray() as string[];
+        .toArray() as (string | undefined)[];
 
-      if (countryIds.length > 1 || currencyIds.length > 1) {
-        return result;
+      if (currencyIds.length > 1) {
+        return Number(result.toFixed(numberPrecision));
       }
 
       return formatMoney(
         result,
-        typeof countryIds[0] === 'string' ? countryIds[0] : undefined,
-        typeof currencyIds[0] === 'string' ? currencyIds[0] : undefined,
-        reactSettings?.number_precision || 2
+        countryIds.length === 1 && typeof countryIds[0] === 'string'
+          ? countryIds[0]
+          : undefined,
+        currencyIds[0],
+        numberPrecision
       );
     }
 

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -71,7 +71,10 @@ import { useColorScheme } from '$app/common/colors';
 import { useDebounce } from 'react-use';
 import { cloneDeep, get, isEqual } from 'lodash';
 import { FilterColumn } from './FilterColumn';
-import { buildDateRangeQueryParameter } from '$app/common/helpers/data-table';
+import {
+  buildDateRangeQueryParameter,
+  normalizeColumnName,
+} from '$app/common/helpers/data-table';
 import { Resource } from './PreviousNextNavigation';
 
 export interface DateRangeColumn {
@@ -88,6 +91,7 @@ export interface DateRangeEntry {
 }
 
 export type DataTableColumns<T = any> = {
+  column?: string;
   id: string;
   label: string;
   format?: (field: string | number, resource: T) => unknown;
@@ -95,6 +99,7 @@ export type DataTableColumns<T = any> = {
 }[];
 
 export type FooterColumns<T = any> = {
+  column: string;
   id: string;
   label: string;
   format: (
@@ -775,14 +780,22 @@ export function DataTable<T extends object>(props: Props<T>) {
     [dateRangeEntries]
   );
 
-  const getFooterColumn = (columnId: string) => {
-    return footerColumns.find((footerColumn) => footerColumn.id === columnId);
+  const getFooterColumn = (columnKey: string | undefined) => {
+    if (!columnKey) {
+      return undefined;
+    }
+
+    return footerColumns.find(
+      (footerColumn) =>
+        normalizeColumnName(footerColumn.column) ===
+        normalizeColumnName(columnKey)
+    );
   };
 
   const getColumnValues = (columnId: string) => {
     return currentData.map(
       (resource: T) => resource[columnId as keyof typeof resource]
-    );
+    ) as (string | number)[];
   };
 
   const handleCheckboxClick = useCallback(
@@ -1365,18 +1378,20 @@ export function DataTable<T extends object>(props: Props<T>) {
               <TFooter>
                 {!props.withoutActions && !hideEditableOptions && <Th></Th>}
 
-                {props.columns.map(
-                  (column, index) =>
+                {props.columns.map((column, index) => {
+                  const footerColumn = getFooterColumn(column.column);
+
+                  return (
                     Boolean(!excludeColumns.includes(column.id)) && (
                       <Td
                         key={index}
                         customizeTextColor
                         resizable={`${apiEndpoint.pathname}.${column.id}`}
                       >
-                        {getFooterColumn(column.id) ? (
+                        {footerColumn ? (
                           <div className="flex items-center space-x-3">
-                            {getFooterColumn(column.id)?.format(
-                              getColumnValues(column.id) as (string | number)[],
+                            {footerColumn.format(
+                              getColumnValues(footerColumn.id),
                               currentData || []
                             ) ?? '-/-'}
                           </div>
@@ -1385,7 +1400,8 @@ export function DataTable<T extends object>(props: Props<T>) {
                         )}
                       </Td>
                     )
-                )}
+                  );
+                })}
 
                 {props.withResourcefulActions && !hideEditableOptions && (
                   <Th></Th>

--- a/src/components/DataTableFooterColumnsPicker.tsx
+++ b/src/components/DataTableFooterColumnsPicker.tsx
@@ -109,8 +109,8 @@ export function DataTableFooterColumnsPicker(props: Props) {
               pushContentToRight
             >
               <Toggle
-                checked={isColumnChecked(column.id)}
-                onValueChange={(value) => handleChange(column.id, value)}
+                checked={isColumnChecked(column.column)}
+                onValueChange={(value) => handleChange(column.column, value)}
               />
             </Element>
           ))}

--- a/src/pages/invoices/common/hooks/useFooterColumns.tsx
+++ b/src/pages/invoices/common/hooks/useFooterColumns.tsx
@@ -14,6 +14,7 @@ import { useAllInvoiceColumns } from './useInvoiceColumns';
 import { ReactNode } from 'react';
 import { useSumTableColumn } from '$app/common/hooks/useSumTableColumn';
 import { useReactSettings } from '$app/common/hooks/useReactSettings';
+import { calculateNetAmount } from '$app/common/helpers/invoices/net-amount';
 
 export type DataTableFooterColumnsExtended<
   TResource = any,
@@ -47,6 +48,13 @@ export function useFooterColumns() {
         sumTableColumn(values as number[], invoices),
     },
     {
+      column: 'net_amount',
+      id: 'amount',
+      label: t('net_amount'),
+      format: (values, invoices) =>
+        sumTableColumn(invoices.map(calculateNetAmount), invoices),
+    },
+    {
       column: 'balance',
       id: 'balance',
       label: t('balance'),
@@ -59,7 +67,9 @@ export function useFooterColumns() {
     reactSettings?.table_footer_columns?.invoice || [];
 
   return {
-    footerColumns: columns.filter(({ id }) => currentColumns.includes(id)),
+    footerColumns: columns.filter(({ column }) =>
+      currentColumns.includes(column)
+    ),
     allFooterColumns: columns,
   };
 }

--- a/src/pages/invoices/common/hooks/useInvoiceColumns.tsx
+++ b/src/pages/invoices/common/hooks/useInvoiceColumns.tsx
@@ -49,6 +49,7 @@ import {
   PEPPOL_CLASSIFICATIONS,
 } from '$app/common/helpers/peppol-countries';
 import { TagPills } from '$app/components/tags/TagPills';
+import { calculateNetAmount } from '$app/common/helpers/invoices/net-amount';
 
 export type DataTableColumnsExtended<TResource = any, TColumn = string> = {
   column: TColumn;
@@ -316,7 +317,7 @@ export function useInvoiceColumns(): DataTableColumns<Invoice> {
       label: t('net_amount'),
       format: (value, invoice) =>
         formatMoney(
-          Number(value) - Number(invoice.total_taxes || 0),
+          calculateNetAmount(invoice),
           invoice.client?.country_id,
           invoice.client?.settings.currency_id
         ),

--- a/src/pages/quotes/common/hooks.tsx
+++ b/src/pages/quotes/common/hooks.tsx
@@ -86,6 +86,7 @@ import { Icon } from '$app/components/icons/Icon';
 import { Action } from '$app/components/ResourceActions';
 import { Tooltip } from '$app/components/Tooltip';
 import { TagPills } from '$app/components/tags/TagPills';
+import { calculateNetAmount } from '$app/common/helpers/invoices/net-amount';
 import { AddActivityComment } from '$app/pages/dashboard/hooks/useGenerateActivityElement';
 import { isDeleteActionTriggeredAtom } from '$app/pages/invoices/common/components/ProductsTable';
 import { openClientPortal } from '$app/pages/invoices/common/helpers/open-client-portal';
@@ -932,7 +933,7 @@ export function useQuoteColumns() {
       label: t('net_amount'),
       format: (value, quote) =>
         formatMoney(
-          Number(value) - Number(quote.total_taxes || 0),
+          calculateNetAmount(quote),
           quote.client?.country_id,
           quote.client?.settings.currency_id
         ),

--- a/src/pages/quotes/common/hooks/useFooterColumns.tsx
+++ b/src/pages/quotes/common/hooks/useFooterColumns.tsx
@@ -14,6 +14,7 @@ import { useReactSettings } from '$app/common/hooks/useReactSettings';
 import { useAllQuoteColumns } from '../hooks';
 import { Quote } from '$app/common/interfaces/quote';
 import { DataTableFooterColumnsExtended } from '$app/pages/invoices/common/hooks/useFooterColumns';
+import { calculateNetAmount } from '$app/common/helpers/invoices/net-amount';
 
 export function useFooterColumns() {
   const [t] = useTranslation();
@@ -32,13 +33,22 @@ export function useFooterColumns() {
       label: t('amount'),
       format: (values, quotes) => sumTableColumn(values as number[], quotes),
     },
+    {
+      column: 'net_amount',
+      id: 'amount',
+      label: t('net_amount'),
+      format: (values, quotes) =>
+        sumTableColumn(quotes.map(calculateNetAmount), quotes),
+    },
   ];
 
   const currentColumns: string[] =
     reactSettings?.table_footer_columns?.quote || [];
 
   return {
-    footerColumns: columns.filter(({ id }) => currentColumns.includes(id)),
+    footerColumns: columns.filter(({ column }) =>
+      currentColumns.includes(column)
+    ),
     allFooterColumns: columns,
   };
 }

--- a/src/pages/recurring-invoices/common/hooks.tsx
+++ b/src/pages/recurring-invoices/common/hooks.tsx
@@ -89,6 +89,7 @@ import { Dispatch, SetStateAction } from 'react';
 import { normalizeColumnName } from '$app/common/helpers/data-table';
 import { SendNowAction } from './components/SendNowAction';
 import { TagPills } from '$app/components/tags/TagPills';
+import { calculateNetAmount } from '$app/common/helpers/invoices/net-amount';
 
 interface RecurringInvoiceUtilitiesProps {
   client?: Client;
@@ -738,7 +739,7 @@ export function useRecurringInvoiceColumns() {
       label: t('net_amount'),
       format: (value, recurringInvoice) =>
         formatMoney(
-          Number(value) - Number(recurringInvoice.total_taxes || 0),
+          calculateNetAmount(recurringInvoice),
           recurringInvoice.client?.country_id,
           recurringInvoice.client?.settings.currency_id
         ),

--- a/src/pages/recurring-invoices/common/hooks/useFooterColumns.tsx
+++ b/src/pages/recurring-invoices/common/hooks/useFooterColumns.tsx
@@ -14,6 +14,7 @@ import { useReactSettings } from '$app/common/hooks/useReactSettings';
 import { DataTableFooterColumnsExtended } from '$app/pages/invoices/common/hooks/useFooterColumns';
 import { useAllRecurringInvoiceColumns } from '../hooks';
 import { RecurringInvoice } from '$app/common/interfaces/recurring-invoice';
+import { calculateNetAmount } from '$app/common/helpers/invoices/net-amount';
 
 export function useFooterColumns() {
   const [t] = useTranslation();
@@ -36,13 +37,25 @@ export function useFooterColumns() {
       format: (values, recurringInvoices) =>
         sumTableColumn(values as number[], recurringInvoices),
     },
+    {
+      column: 'net_amount',
+      id: 'amount',
+      label: t('net_amount'),
+      format: (values, recurringInvoices) =>
+        sumTableColumn(
+          recurringInvoices.map(calculateNetAmount),
+          recurringInvoices
+        ),
+    },
   ];
 
   const currentColumns: string[] =
     reactSettings?.table_footer_columns?.recurringInvoice || [];
 
   return {
-    footerColumns: columns.filter(({ id }) => currentColumns.includes(id)),
+    footerColumns: columns.filter(({ column }) =>
+      currentColumns.includes(column)
+    ),
     allFooterColumns: columns,
   };
 }

--- a/tests/unit/net-amount.test.ts
+++ b/tests/unit/net-amount.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2026. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { describe, test, expect } from 'vitest';
+import { calculateNetAmount } from '../../src/common/helpers/invoices/net-amount';
+
+describe('calculateNetAmount', () => {
+  test('backs the taxes out of the amount', () => {
+    expect(calculateNetAmount({ amount: 392.7, total_taxes: 62.7 })).toBe(330);
+  });
+
+  test('untaxed resource keeps its full amount', () => {
+    expect(calculateNetAmount({ amount: 1900, total_taxes: 0 })).toBe(1900);
+  });
+
+  test('missing total_taxes is treated as no taxes', () => {
+    expect(calculateNetAmount({ amount: 1900 })).toBe(1900);
+  });
+
+  test('missing amount is treated as zero', () => {
+    expect(calculateNetAmount({ total_taxes: 10 })).toBe(-10);
+  });
+
+  test('missing resource is zero instead of NaN', () => {
+    expect(calculateNetAmount(undefined)).toBe(0);
+    expect(calculateNetAmount(null)).toBe(0);
+    expect(calculateNetAmount({})).toBe(0);
+  });
+
+  test('the footer total equals the sum of the rows it covers', () => {
+    const invoices = [
+      { amount: 392.7, total_taxes: 62.7 },
+      { amount: 357, total_taxes: 57 },
+      { amount: 333.2, total_taxes: 53.2 },
+      { amount: 273.7, total_taxes: 43.7 },
+      { amount: 511.7, total_taxes: 81.7 },
+      { amount: 357, total_taxes: 57 },
+      { amount: 1900, total_taxes: 0 },
+    ];
+
+    const rows = invoices.map(calculateNetAmount);
+    const total = rows.reduce((sum, row) => sum + row, 0);
+
+    expect(rows).toEqual([330, 300, 280, 230, 430, 300, 1900]);
+    expect(Number(total.toFixed(2))).toBe(3770);
+  });
+});


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for the sum of the net amount column when footer columns are turned on. Screenshot:

<img width="1263" height="586" alt="Screenshot 2026-07-28 at 18 58 45" src="https://github.com/user-attachments/assets/cf48f418-14c4-4573-9ff9-c98b7a34b921" />

Closes #3279 

Let me know your thoughts.