### PR TITLE
[Cleanup] Disabling CC Email Field

### DIFF
--- a/src/common/interfaces/account.ts
+++ b/src/common/interfaces/account.ts
@@ -44,4 +44,5 @@ export interface Account {
   hosted_company_count: number;
   can_trial: boolean;
   docuninja_num_users: number;
+  is_premium: boolean;
 }

--- a/src/pages/invoices/email/components/Mailer.tsx
+++ b/src/pages/invoices/email/components/Mailer.tsx
@@ -97,7 +97,7 @@ export const Mailer = forwardRef<MailerComponent, Props>((props, ref) => {
     templateId: props.defaultEmail,
   });
 
-  const isCcEmailEnabled = isSelfHosted() || account?.is_premium === true;
+  const isCcEmailEnabled = isSelfHosted() || account?.is_premium;
 
   const handleTemplateChange = (id: string) => {
     setPayloadData(
@@ -158,21 +158,25 @@ export const Mailer = forwardRef<MailerComponent, Props>((props, ref) => {
     }
   }, [currentTemplate]);
 
-  useImperativeHandle(ref, () => {
-    return {
-      sendEmail() {
-        handleSend(
-          payloadData.body,
-          props.resourceType,
-          props.resource?.id || '',
-          payloadData.subject,
-          payloadData.templateId,
-          props.redirectUrl,
-          payloadData.ccEmail
-        );
-      },
-    };
-  }, [payloadData]);
+  useImperativeHandle(
+    ref,
+    () => {
+      return {
+        sendEmail() {
+          handleSend(
+            payloadData.body,
+            props.resourceType,
+            props.resource?.id || '',
+            payloadData.subject,
+            payloadData.templateId,
+            props.redirectUrl,
+            payloadData.ccEmail
+          );
+        },
+      };
+    },
+    [payloadData]
+  );
 
   return (
     <div className="grid grid-cols-12 lg:gap-4 my-4">

--- a/src/pages/invoices/email/components/Mailer.tsx
+++ b/src/pages/invoices/email/components/Mailer.tsx
@@ -15,6 +15,7 @@ import { freePlan } from '$app/common/guards/guards/free-plan';
 import { proPlan } from '$app/common/guards/guards/pro-plan';
 import { generateEmailPreview } from '$app/common/helpers/emails/generate-email-preview';
 import { useHandleSend } from '$app/common/hooks/emails/useHandleSend';
+import { useCurrentAccount } from '$app/common/hooks/useCurrentAccount';
 import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
 import { Invoice } from '$app/common/interfaces/invoice';
 import { PurchaseOrder } from '$app/common/interfaces/purchase-order';
@@ -72,6 +73,7 @@ export interface EmailTemplate {
 export const Mailer = forwardRef<MailerComponent, Props>((props, ref) => {
   const [t] = useTranslation();
 
+  const account = useCurrentAccount();
   const company = useCurrentCompany();
   const reactSettings = useReactSettings();
 
@@ -95,8 +97,7 @@ export const Mailer = forwardRef<MailerComponent, Props>((props, ref) => {
     templateId: props.defaultEmail,
   });
 
-  const isCcEmailAvailable =
-    isSelfHosted() || (isHosted() && (proPlan() || enterprisePlan()));
+  const isCcEmailEnabled = isSelfHosted() || account?.is_premium === true;
 
   const handleTemplateChange = (id: string) => {
     setPayloadData(
@@ -220,16 +221,15 @@ export const Mailer = forwardRef<MailerComponent, Props>((props, ref) => {
         </Card>
 
         <Card withContainer>
-          {isCcEmailAvailable && (
-            <InputField
-              label={t('cc_email')}
-              value={payloadData.ccEmail}
-              onValueChange={(value) =>
-                setPayloadData((current) => ({ ...current, ccEmail: value }))
-              }
-              errorMessage={errors?.errors.cc_email}
-            />
-          )}
+          <InputField
+            label={t('cc_email')}
+            value={payloadData.ccEmail}
+            onValueChange={(value) =>
+              setPayloadData((current) => ({ ...current, ccEmail: value }))
+            }
+            disabled={!isCcEmailEnabled}
+            errorMessage={errors?.errors.cc_email}
+          />
 
           <InputField
             label={t('subject')}

--- a/src/pages/invoices/email/components/Mailer.tsx
+++ b/src/pages/invoices/email/components/Mailer.tsx
@@ -230,20 +230,19 @@ export const Mailer = forwardRef<MailerComponent, Props>((props, ref) => {
         </Card>
 
         <Card withContainer>
-          {isCcEmailAvailable && (
-            <MultiEmailInput
-              id="cc_email"
-              label={t('cc_email')}
-              value={payloadData.ccEmail}
-              onValueChange={(value) =>
-                setPayloadData((current) => ({ ...current, ccEmail: value }))
-              }
-              maxEmails={isHosted() ? HOSTED_CC_EMAILS_LIMIT : undefined}
-              placeholder={t('enter_values_comma_separated')}
-              errorMessage={errors?.errors.cc_email}
-              cypressRef="ccEmailInput"
-            />
-          )}
+          <MultiEmailInput
+            id="cc_email"
+            label={t('cc_email')}
+            value={payloadData.ccEmail}
+            onValueChange={(value) =>
+              setPayloadData((current) => ({ ...current, ccEmail: value }))
+            }
+            disabled={!isCcEmailEnabled}
+            maxEmails={isHosted() ? HOSTED_CC_EMAILS_LIMIT : undefined}
+            placeholder={t('enter_values_comma_separated')}
+            errorMessage={errors?.errors.cc_email}
+            cypressRef="ccEmailInput"
+          />
 
           <InputField
             label={t('subject')}


### PR DESCRIPTION
@beganovich @turbo124 The PR updates the logic for disabling the CC email field. Previously, this field was always visible for self-hosted users, but only visible for Pro and Enterprise users on hosted. Now, the field is always visible for both, but for hosted users it is disabled if `is_premium` is false. Let me know your thoughts.