### PR TITLE
Fixes individual removal of location fields from custom report columns.

### DIFF
--- a/src/common/constants/exports/client-map.ts
+++ b/src/common/constants/exports/client-map.ts
@@ -12,6 +12,7 @@ export interface Record {
   trans: string;
   value: string;
   map: string;
+  origin?: string;
 }
 
 export const clientMap: Record[] = [

--- a/src/pages/reports/common/components/SortableColumns.tsx
+++ b/src/pages/reports/common/components/SortableColumns.tsx
@@ -10,33 +10,34 @@
 
 import {
   DragDropContext,
-  DropResult,
-  Droppable,
   Draggable,
+  Droppable,
+  DropResult,
 } from '@hello-pangea/dnd';
-import { Record, clientMap } from '$app/common/constants/exports/client-map';
-import { paymentMap } from '$app/common/constants/exports/payment-map';
-import { quoteMap } from '$app/common/constants/exports/quote-map';
-import { creditMap } from '$app/common/constants/exports/credit-map';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useColorScheme } from '$app/common/colors';
+import { clientMap, Record } from '$app/common/constants/exports/client-map';
+import { contactMap } from '$app/common/constants/exports/contact-map';
+import { creditMap } from '$app/common/constants/exports/credit-map';
+import { expenseMap } from '$app/common/constants/exports/expense-map';
+import { invoiceMap } from '$app/common/constants/exports/invoice-map';
 import { itemMap } from '$app/common/constants/exports/item-map';
 import { locationMap } from '$app/common/constants/exports/location-map';
-import { vendorMap } from '$app/common/constants/exports/vendor-map';
+import { paymentMap } from '$app/common/constants/exports/payment-map';
 import { purchaseorderMap } from '$app/common/constants/exports/purchase-order-map';
-import { taskMap } from '$app/common/constants/exports/task-map';
-import { expenseMap } from '$app/common/constants/exports/expense-map';
+import { quoteMap } from '$app/common/constants/exports/quote-map';
 import { recurringinvoiceMap } from '$app/common/constants/exports/recurring-invoice-map';
-import { usePreferences } from '$app/common/hooks/usePreferences';
-import { Identifier } from '../useReports';
-import { contactMap } from '$app/common/constants/exports/contact-map';
-import { useColorScheme } from '$app/common/colors';
-import { Entity } from '$app/common/hooks/useEntityCustomFields';
-import { invoiceMap } from '$app/common/constants/exports/invoice-map';
+import { taskMap } from '$app/common/constants/exports/task-map';
+import { vendorMap } from '$app/common/constants/exports/vendor-map';
 import { useCurrentCompany } from '$app/common/hooks/useCurrentCompany';
+import { Entity } from '$app/common/hooks/useEntityCustomFields';
+import { usePreferences } from '$app/common/hooks/usePreferences';
 import { customField } from '$app/components/CustomField';
 import { DoubleChevronRight } from '$app/components/icons/DoubleChevronRight';
 import { XMark } from '$app/components/icons/XMark';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Identifier } from '../useReports';
+import { getColumnPosition } from '../utils/sortableColumns';
 
 export const reportColumn = 11;
 
@@ -254,20 +255,6 @@ interface Props {
   onColumnsChange?: (columns: Record[][]) => void;
 }
 
-const positions = [
-  'client',
-  'invoice',
-  'credit',
-  'quote',
-  'payment',
-  'vendor',
-  'purchase_order',
-  'task',
-  'expense',
-  'recurring_invoice',
-  'contact',
-] as const;
-
 export function useColumns({ report, columns }: Props) {
   const { preferences } = usePreferences();
 
@@ -302,9 +289,7 @@ export function useColumns({ report, columns }: Props) {
                 itemMap.map((i) => ({ ...i, origin: 'purchase_order' }))
               )
             : purchaseorderMap
-          ).concat(
-            locationMap.map((l) => ({ ...l, origin: 'purchase_order' }))
-          )
+          ).concat(locationMap.map((l) => ({ ...l, origin: 'purchase_order' })))
         : [],
       columns.includes('task') ? taskMap : [],
       columns.includes('expense') ? expenseMap : [],
@@ -411,7 +396,7 @@ export function SortableColumns({
 
   const onRemove = useCallback(
     (record: Record) => {
-      const index = positions.indexOf(record.map as (typeof positions)[number]);
+      const index = getColumnPosition(record);
 
       if (index === -1) {
         return;

--- a/src/pages/reports/common/components/SortableColumns.tsx
+++ b/src/pages/reports/common/components/SortableColumns.tsx
@@ -132,6 +132,7 @@ export function Column({
             <span style={{ color: colors.$3 }}>{label}</span>
 
             <div
+              data-cy={`report-column-reset-${droppableId}`}
               className="flex items-center space-x-1 cursor-pointer"
               onClick={onReset}
             >
@@ -149,7 +150,11 @@ export function Column({
             <span style={{ color: colors.$3 }}>{label}</span>
 
             {onAddAll && (
-              <button type="button" onClick={onAddAll}>
+              <button
+                type="button"
+                onClick={onAddAll}
+                data-cy={`report-column-add-all-${droppableId}`}
+              >
                 <DoubleChevronRight size="0.85rem" color={colors.$3} />
               </button>
             )}
@@ -170,6 +175,8 @@ export function Column({
               {...provided.dragHandleProps}
             >
               <div
+                data-cy="report-column-item"
+                data-report-column-value={record.value}
                 className="p-2 flex border justify-between items-center cursor-grab text-sm shadow-sm"
                 style={{
                   color: colors.$3,
@@ -188,6 +195,7 @@ export function Column({
             className="w-80 flex-column"
             ref={provided.innerRef}
             {...provided.droppableProps}
+            data-cy={`report-column-${droppableId}`}
           >
             <div
               className="overflow-y-scroll h-96 mt-2 border rounded-md"
@@ -204,6 +212,8 @@ export function Column({
                   >
                     {(provided) => (
                       <div
+                        data-cy="report-column-item"
+                        data-report-column-value={record.value}
                         ref={provided.innerRef}
                         {...provided.draggableProps}
                         {...provided.dragHandleProps}
@@ -220,6 +230,7 @@ export function Column({
 
                           {droppableId === reportColumn.toString() && (
                             <button
+                              data-cy="report-column-remove"
                               style={{
                                 color: colors.$3,
                                 colorScheme: colors.$0,
@@ -435,6 +446,7 @@ export function SortableColumns({
 
   return (
     <div
+      data-cy="sortable-columns"
       className="overflow-x-auto border rounded-md w-full my-6 shadow-sm"
       style={{ borderColor: colors.$24 }}
     >

--- a/src/pages/reports/common/utils/sortableColumns.ts
+++ b/src/pages/reports/common/utils/sortableColumns.ts
@@ -1,0 +1,21 @@
+import { Record } from '$app/common/constants/exports/client-map';
+
+export const columnPositions = [
+  'client',
+  'invoice',
+  'credit',
+  'quote',
+  'payment',
+  'vendor',
+  'purchase_order',
+  'task',
+  'expense',
+  'recurring_invoice',
+  'contact',
+] as const;
+
+export function getColumnPosition(record: Record): number {
+  const source = record.origin ?? record.map;
+
+  return columnPositions.indexOf(source as (typeof columnPositions)[number]);
+}

--- a/src/pages/reports/index/Reports.tsx
+++ b/src/pages/reports/index/Reports.tsx
@@ -848,6 +848,7 @@ export default function Reports() {
                 onValueChange={(value) => {
                   setShowCustomColumns(Boolean(value));
                 }}
+                cypressRef="customizeReportColumns"
               />
             </Element>
           )}

--- a/tests/e2e/report-location-columns.spec.ts
+++ b/tests/e2e/report-location-columns.spec.ts
@@ -1,0 +1,72 @@
+import { type Locator, type Page } from '@playwright/test';
+import { expect, resetAccountBeforeAll, test } from '$tests/e2e/fixtures';
+import { login } from '$tests/e2e/helpers';
+
+resetAccountBeforeAll();
+
+const reportColumn = 11;
+const locationField = 'location.city';
+
+const reportCases = [
+  { label: 'Invoice', sourceColumn: 1 },
+  { label: 'Quote', sourceColumn: 3 },
+] as const;
+
+test.beforeEach(async ({ page }) => {
+  await login(page);
+  await page.goto('/reports');
+  await page.waitForURL('**/reports');
+});
+
+for (const reportCase of reportCases) {
+  test(`removing a location field returns it to the ${reportCase.label} column`, async ({
+    page,
+  }) => {
+    await selectReport(page, reportCase.label);
+    await page.locator('[data-cy="customizeReportColumns"]').click();
+    await page
+      .locator(`[data-cy="report-column-reset-${reportColumn}"]`)
+      .click();
+
+    const source = column(page, reportCase.sourceColumn);
+    const selected = column(page, reportColumn);
+    const sourceLocation = item(source, locationField);
+    const selectedLocation = item(selected, locationField);
+
+    await expect(sourceLocation).toBeVisible();
+    await expect(selectedLocation).toHaveCount(0);
+
+    await page
+      .locator(`[data-cy="report-column-add-all-${reportCase.sourceColumn}"]`)
+      .click();
+
+    await expect(sourceLocation).toHaveCount(0);
+    await expect(selectedLocation).toBeVisible();
+
+    await selectedLocation.locator('[data-cy="report-column-remove"]').click();
+
+    await expect(selectedLocation).toHaveCount(0);
+    await expect(sourceLocation).toBeVisible();
+  });
+}
+
+async function selectReport(page: Page, label: string) {
+  const reportSelect = page
+    .locator('dt')
+    .filter({ hasText: /^Report$/ })
+    .locator('..')
+    .locator('dd');
+
+  await reportSelect.locator('svg').last().click();
+  await page.getByRole('option', { name: label, exact: true }).click();
+}
+
+function column(page: Page, index: number) {
+  return page.locator(`[data-cy="report-column-${index}"]`);
+}
+
+function item(column: Locator, value: string) {
+  return column.locator(
+    `[data-cy="report-column-item"][data-report-column-value="${value}"]`
+  );
+}

--- a/tests/unit/report-column-position.test.ts
+++ b/tests/unit/report-column-position.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { describe, test, expect } from 'vitest';
+import { getColumnPosition } from '$app/pages/reports/common/utils/sortableColumns';
+
+describe('getColumnPosition', () => {
+  test('returns the origin group for location fields', () => {
+    expect(
+      getColumnPosition({
+        trans: 'city',
+        value: 'location.city',
+        map: 'location',
+        origin: 'invoice',
+      })
+    ).toBe(1);
+  });
+
+  test('returns the origin group for item fields', () => {
+    expect(
+      getColumnPosition({
+        trans: 'quantity',
+        value: 'item.quantity',
+        map: '',
+        origin: 'purchase_order',
+      })
+    ).toBe(6);
+  });
+
+  test('falls back to map when origin is absent', () => {
+    expect(
+      getColumnPosition({ trans: 'name', value: 'client.name', map: 'client' })
+    ).toBe(0);
+  });
+
+  test('returns -1 for unknown groups', () => {
+    expect(
+      getColumnPosition({ trans: 'city', value: 'location.city', map: 'location' })
+    ).toBe(-1);
+  });
+});


### PR DESCRIPTION
Fixes individual removal of location fields from custom report columns.

Location fields use map: 'location' but belong to an originating report group such as Invoice or Quote. The removal handler previously used record.map to determine the destination group. Because there is no standalone Location group, the handler returned early and clicking the remove button did nothing.

Changes
Added optional origin metadata to report column records.
Updated column removal to prefer record.origin, falling back to record.map.
Location fields now return to their original Invoice, Quote, Credit, Purchase Order, or Recurring Invoice group.
Added stable selectors for report-column E2E coverage.
Added unit and Playwright regression tests.