### PR TITLE
Exclude FR + self hosted from registering on PEPPOL network

### DIFF
--- a/src/common/helpers/peppol-countries.ts
+++ b/src/common/helpers/peppol-countries.ts
@@ -8,7 +8,22 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
+import { isSelfHosted } from '$app/common/helpers';
+
 export type Classification = 'individual' | 'business' | 'government';
+
+export const FRANCE_COUNTRY_ID = '250';
+
+export function isPeppolBlockedForCompany(countryId: string): boolean {
+  return isSelfHosted() && countryId === FRANCE_COUNTRY_ID;
+}
+
+export function isPeppolCountryAllowed(countryId: string): boolean {
+  return (
+    PEPPOL_COUNTRIES.includes(countryId) &&
+    !isPeppolBlockedForCompany(countryId)
+  );
+}
 
 export const PEPPOL_COUNTRIES = [
   '20',

--- a/src/pages/settings/e-invoice/EInvoice.tsx
+++ b/src/pages/settings/e-invoice/EInvoice.tsx
@@ -44,7 +44,7 @@ import { whiteLabelPlan } from '$app/common/guards/guards/white-label';
 import { EUTaxDetails } from './common/components/EUTaxDetails';
 import { Onboarding } from './peppol/Onboarding';
 import { Preferences } from './peppol/Preferences';
-import { PEPPOL_COUNTRIES } from '$app/common/helpers/peppol-countries';
+import { isPeppolCountryAllowed } from '$app/common/helpers/peppol-countries';
 import { PEPPOLPlanBanner } from './common/components/PEPPOLPlanBanner';
 import { FranceReporting } from './common/components/FranceReporting';
 import { CloudUpload } from '$app/components/icons/CloudUpload';
@@ -94,7 +94,7 @@ export function EInvoice() {
 
     return (
       (isPlanActive || skipPlanCheck) &&
-      PEPPOL_COUNTRIES.includes(company?.settings.country_id || '')
+      isPeppolCountryAllowed(company?.settings.country_id || '')
     );
   };
 


### PR DESCRIPTION
Due to complexity managing document state changes + reporting requirements, it will not be possible to support FR users on PEPPOL 