### PR TITLE
[Bugfix] Breaking Words For Error Message

### DIFF
--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -57,7 +57,7 @@ export function Alert(props: Props) {
             style={{ backgroundColor: colors.$1, borderColor: colors.$4 }}
           >
             <div
-              className="w-full break-all"
+              className="w-full break-words"
               style={{ backgroundColor: colors.$1, borderColor: colors.$4 }}
             >
               {props.children}

--- a/src/pages/payments/refund/Refund.tsx
+++ b/src/pages/payments/refund/Refund.tsx
@@ -288,7 +288,7 @@ export default function Refund() {
                   {(errors?.errors[`invoices.${[index]}.invoice_id`] ||
                     errors?.errors[`invoices.${[index]}.amount`]) && (
                     <div className="px-6">
-                      <ErrorMessage className="mt-2 break-all">
+                      <ErrorMessage className="mt-2">
                         {errors?.errors[`invoices.${[index]}.invoice_id`] ||
                           errors?.errors[`invoices.${[index]}.amount`]}
                       </ErrorMessage>


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for breaking words in error messages. Screenshot:

<img width="516" height="456" alt="Screenshot 2026-08-10 at 17 25 53" src="https://github.com/user-attachments/assets/1f86d546-f13e-4894-a55b-af4347240a8f" />

Let me know your thoughts.