### PR TITLE
Hide sidebar for Invoice Ninja generated documents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "28.06.2025.1",
       "dependencies": {
         "@azure/msal-browser": "^3.28.1",
-        "@docuninja/builder2.0": "^0.0.102",
+        "@docuninja/builder2.0": "^0.0.103",
         "@emotion/styled": "^11.14.0",
         "@excalidraw/excalidraw": "^0.18.0",
         "@fontsource/alex-brush": "^5.2.6",
@@ -565,9 +565,9 @@
       }
     },
     "node_modules/@docuninja/builder2.0": {
-      "version": "0.0.102",
-      "resolved": "https://registry.npmjs.org/@docuninja/builder2.0/-/builder2.0-0.0.102.tgz",
-      "integrity": "sha512-GDiEvhU7GcBo/+YMl4jfr3xjhXWUP1UTLF/Q35hxtYJEGILz3s1il0dIAXnQOhu/7JOfpeQJwwMYNmneRXKwWQ==",
+      "version": "0.0.103",
+      "resolved": "https://registry.npmjs.org/@docuninja/builder2.0/-/builder2.0-0.0.103.tgz",
+      "integrity": "sha512-kVSr1LMjHFeBKZGj484T2oQntD7Tfp4qlKdJdaUtaL7rcfq5FTHvgy3loXizOKmUK4fiwVN8BjnzcLWUYZxd7g==",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@azure/msal-browser": "^3.28.1",
-    "@docuninja/builder2.0": "^0.0.102",
+    "@docuninja/builder2.0": "^0.0.103",
     "@emotion/styled": "^11.14.0",
     "@excalidraw/excalidraw": "^0.18.0",
     "@fontsource/alex-brush": "^5.2.6",
@@ -131,7 +131,7 @@
     "build": "concurrently --kill-others-on-fail \"tsc --noEmit --incremental\" \"vite build\"",
     "format": "biome format --write src/",
     "lint": "biome lint src/",
-"check": "biome check --write --unsafe src/",
+    "check": "biome check --write --unsafe src/",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test --workers=1",

--- a/src/pages/documents/builder/Builder.tsx
+++ b/src/pages/documents/builder/Builder.tsx
@@ -140,6 +140,8 @@ function Builder() {
 
   const [entity, setEntity] = useState<Document | null>(null);
 
+  const isNinjaDocument = entity?.metadata?.is_ninja === true;
+
   useBuilderStore((state) => state.rectangles);
   const [isDocumentSaving, setIsDocumentSaving] = useState<boolean>(false);
   const [isDocumentSending, setIsDocumentSending] = useState<boolean>(false);
@@ -640,6 +642,9 @@ function Builder() {
             options: {
               header: {
                 sticky: false,
+              },
+              leftSidebar: {
+                visible: !isNinjaDocument,
               },
               widgets: {
                 showLabel: getDocuNinjaCompany()?.settings?.widget_show_label,


### PR DESCRIPTION
This hides left part of sidebar for Invoice Ninja documents, since it's redundant. 

<img width="2256" height="1348" alt="image" src="https://github.com/user-attachments/assets/f6820669-1cd7-40a6-9f45-841ecf6a527e" />
