### PR TITLE
Support status 400 for join onboard

### DIFF
--- a/src/common/components/DocuNinjaProvider.tsx
+++ b/src/common/components/DocuNinjaProvider.tsx
@@ -92,7 +92,8 @@ export function DocuNinjaProvider({ children }: DocuNinjaProviderProps) {
   });
 
   const isNoAccount =
-    (error as { response?: { status?: number } })?.response?.status === 401;
+    (error as { response?: { status?: number } })?.response?.status === 401 ||
+    (error as { response?: { status?: number } })?.response?.status === 400;
 
   useEffect(() => {
     if (isNoAccount) {


### PR DESCRIPTION
This redirects users to join when we hit 400 or 401 on login request.