### PR TITLE
Notifications - refactor for localStorage quota exceeded

### DIFF
--- a/src/components/Notifications.tsx
+++ b/src/components/Notifications.tsx
@@ -11,8 +11,7 @@
 import { useQueryClient } from '@tanstack/react-query';
 import classNames from 'classnames';
 import dayjs from 'dayjs';
-import { useAtom } from 'jotai';
-import { atomWithStorage } from 'jotai/utils';
+import { atom, useAtom } from 'jotai';
 import { useEffect, useState } from 'react';
 import { Bell } from 'react-feather';
 import { useTranslation } from 'react-i18next';
@@ -75,10 +74,44 @@ export interface Notification {
   readAt: string | null;
 }
 
-export const notificationsAtom = atomWithStorage<Notification[]>(
-  'notifications',
-  []
-);
+const MAX_NOTIFICATIONS = 100;
+
+export const notificationsAtom = atom<Notification[]>([]);
+
+function getNotificationIdentity(notification: Notification) {
+  const { displayLabel } = notification;
+
+  switch (displayLabel.notificationType) {
+    case 'invoiceWasPaid':
+    case 'invoiceWasViewed':
+      return `${displayLabel.notificationType}:${displayLabel.invoiceId}`;
+    case 'creditWasCreated':
+    case 'creditWasUpdated':
+      return `${displayLabel.notificationType}:${displayLabel.creditId}`;
+    case 'paymentWasUpdated':
+      return `${displayLabel.notificationType}:${displayLabel.paymentId}`;
+    case 'genericMessage':
+      return `${displayLabel.notificationType}:${notification.link ?? ''}:${displayLabel.message ?? ''}`;
+  }
+}
+
+export function appendNotification(
+  notifications: Notification[],
+  notification: Notification
+) {
+  const identity = getNotificationIdentity(notification);
+
+  if (
+    notifications.some(
+      (currentNotification) =>
+        getNotificationIdentity(currentNotification) === identity
+    )
+  ) {
+    return notifications;
+  }
+
+  return [...notifications, notification].slice(-MAX_NOTIFICATIONS);
+}
 
 export function Notifications() {
   const [t] = useTranslation();
@@ -96,6 +129,14 @@ export function Notifications() {
   const companyUser = useCurrentCompanyUser();
   const { timeFormat } = useCompanyTimeFormat();
   const { dateFormat } = useCurrentCompanyDateFormats();
+
+  useEffect(() => {
+    try {
+      localStorage.removeItem('notifications');
+    } catch {
+      // Notifications are transient, so legacy storage cleanup is best-effort.
+    }
+  }, []);
 
   const generateDisplayLabel = (currentDisplayLabel: DisplayLabel) => {
     if (currentDisplayLabel.notificationType === 'invoiceWasPaid') {
@@ -310,13 +351,6 @@ export function Notifications() {
         };
 
         if (
-          notifications.some((n) => n.label === notification.label) ||
-          notifications.some((n) => n.link === notification.link)
-        ) {
-          return;
-        }
-
-        if (
           socketId()?.toString() !==
           (data as WithSocketId<Invoice>)['x-socket-id']
         ) {
@@ -335,7 +369,9 @@ export function Notifications() {
           });
         }
 
-        setNotifications((notifications) => [...notifications, notification]);
+        setNotifications((notifications) =>
+          appendNotification(notifications, notification)
+        );
       }
 
       if (event === 'App\\Events\\Invoice\\InvoiceWasViewed') {
@@ -366,20 +402,15 @@ export function Notifications() {
         };
 
         if (
-          notifications.some((n) => n.label === notification.label) ||
-          notifications.some((n) => n.link === notification.link)
-        ) {
-          return;
-        }
-
-        if (
           socketId()?.toString() !==
           (data as WithSocketId<Invoice>)['x-socket-id']
         ) {
           $refetch(['invoices']);
         }
 
-        setNotifications((notifications) => [...notifications, notification]);
+        setNotifications((notifications) =>
+          appendNotification(notifications, notification)
+        );
       }
 
       if (event === 'App\\Events\\Credit\\CreditWasCreated') {
@@ -402,14 +433,9 @@ export function Notifications() {
           readAt: null,
         };
 
-        if (
-          notifications.some((n) => n.label === notification.label) ||
-          notifications.some((n) => n.link === notification.link)
-        ) {
-          return;
-        }
-
-        setNotifications((notifications) => [...notifications, notification]);
+        setNotifications((notifications) =>
+          appendNotification(notifications, notification)
+        );
       }
 
       if (event === 'App\\Events\\Credit\\CreditWasUpdated') {
@@ -427,14 +453,9 @@ export function Notifications() {
           readAt: null,
         };
 
-        if (
-          notifications.some((n) => n.label === notification.label) ||
-          notifications.some((n) => n.link === notification.link)
-        ) {
-          return;
-        }
-
-        setNotifications((notifications) => [...notifications, notification]);
+        setNotifications((notifications) =>
+          appendNotification(notifications, notification)
+        );
       }
 
       if (event === 'App\\Events\\Payment\\PaymentWasUpdated') {
@@ -452,14 +473,9 @@ export function Notifications() {
           readAt: null,
         };
 
-        if (
-          notifications.some((n) => n.label === notification.label) ||
-          notifications.some((n) => n.link === notification.link)
-        ) {
-          return;
-        }
-
-        setNotifications((notifications) => [...notifications, notification]);
+        setNotifications((notifications) =>
+          appendNotification(notifications, notification)
+        );
       }
     },
   });
@@ -490,7 +506,9 @@ export function Notifications() {
             readAt: null,
           };
 
-          setNotifications((notifications) => [...notifications, notification]);
+          setNotifications((notifications) =>
+            appendNotification(notifications, notification)
+          );
         }
       );
 

--- a/tests/unit/notifications.test.ts
+++ b/tests/unit/notifications.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import {
+  appendNotification,
+  Notification,
+} from '../../src/components/Notifications';
+
+function paymentNotification(id: string): Notification {
+  return {
+    label: `Payment ${id} updated`,
+    displayLabel: {
+      notificationType: 'paymentWasUpdated',
+      paymentId: id,
+      paymentNumber: id,
+    },
+    date: Number(id),
+    link: `/payments/${id}`,
+    readAt: null,
+  };
+}
+
+describe('appendNotification', () => {
+  it('keeps the newest 100 notifications', () => {
+    const notifications = Array.from({ length: 101 }, (_, index) =>
+      paymentNotification(index.toString())
+    ).reduce(appendNotification, [] as Notification[]);
+
+    expect(notifications).toHaveLength(100);
+    expect(notifications[0].displayLabel.paymentId).toBe('1');
+    expect(notifications[99].displayLabel.paymentId).toBe('100');
+  });
+
+  it('ignores repeated events for the same entity and event type', () => {
+    const notification = paymentNotification('1');
+    const notifications = appendNotification([notification], {
+      ...notification,
+      date: 2,
+    });
+
+    expect(notifications).toEqual([notification]);
+  });
+
+  it('keeps different event types for the same entity', () => {
+    const paid: Notification = {
+      label: 'Invoice paid',
+      displayLabel: {
+        notificationType: 'invoiceWasPaid',
+        invoiceId: '1',
+      },
+      date: 1,
+      link: '/invoices/1',
+      readAt: null,
+    };
+    const viewed: Notification = {
+      ...paid,
+      label: 'Invoice viewed',
+      displayLabel: {
+        notificationType: 'invoiceWasViewed',
+        invoiceId: '1',
+      },
+    };
+
+    expect(appendNotification([paid], viewed)).toEqual([paid, viewed]);
+  });
+
+  it('de-duplicates identical generic messages', () => {
+    const message: Notification = {
+      label: 'Maintenance notice',
+      displayLabel: {
+        notificationType: 'genericMessage',
+        message: 'Maintenance notice',
+      },
+      date: 1,
+      link: '/status',
+      readAt: null,
+    };
+
+    expect(appendNotification([message], { ...message, date: 2 })).toEqual([
+      message,
+    ]);
+  });
+});


### PR DESCRIPTION
If a significant number of websocket events land in a short time period, the localstorage can quickly exceeds it quota.

The changes in this PR address this by introducing:

1. Jotai only storage with no persistence layer
2. Dedupe functionality to prevent duplicate messages appearing
3. Capping notififcations to 100
4. Ensuring we dump all notifications on logout / company switching