### PR TITLE
[Cleanup] Adding Product Cost Column

### DIFF
--- a/src/pages/products/common/hooks.tsx
+++ b/src/pages/products/common/hooks.tsx
@@ -75,6 +75,7 @@ export function useAllProductColumns() {
     'quantity',
     'archived_at',
     // 'assigned_to', @Todo: Relationship not included.
+    'cost',
     'created_at',
     // 'created_by', @Todo: Relationship not included.
     firstCustom,
@@ -184,6 +185,17 @@ export function useProductColumns() {
       id: 'archived_at',
       label: t('archived_at'),
       format: (value) => date(value, dateFormat),
+    },
+    {
+      column: 'cost',
+      id: 'cost',
+      label: t('cost'),
+      format: (value, product) =>
+        formatMoney(
+          value,
+          product.company?.settings.country_id,
+          product.company?.settings.currency_id
+        ),
     },
     {
       column: 'created_at',


### PR DESCRIPTION
@beganovich @turbo124 The PR includes adding a product cost column that is selectable from the list. Screenshot:

<img width="1670" height="633" alt="Screenshot 2026-08-28 at 19 57 49" src="https://github.com/user-attachments/assets/bf1b36d1-bc13-40f3-b7c1-767b3f438068" />

Let me know your thoughts.