### PR TITLE
Support for mapping multiple signatories

### DIFF
--- a/src/pages/documents/builder/Builder.tsx
+++ b/src/pages/documents/builder/Builder.tsx
@@ -55,6 +55,8 @@ import {
   DeleteDialog,
   ImportFromGoogleDrive,
   Loading,
+  MapSignatoriesFlowButton,
+  MapSignatoriesFlowDialog,
   RectangleSettingsButton,
   RectangleSettingsCheckbox,
   RectangleSettingsDialog,
@@ -65,8 +67,6 @@ import {
   RectangleSettingsRemoveButton,
   RectangleSettingsSaveButton,
   RectangleSettingsSelect,
-  SingleSignatoryFlowButton,
-  SingleSignatoryFlowDialog,
   ToolboxContext,
   UninviteButton,
   UninviteDialog,
@@ -413,7 +413,7 @@ function Builder() {
     );
 
     window.addEventListener(
-      'builder:single-signatory-sent',
+      'builder:map-signatories-sent',
       handleSingleSignatorySent
     );
 
@@ -444,7 +444,7 @@ function Builder() {
       );
 
       window.removeEventListener(
-        'builder:single-signatory-sent',
+        'builder:map-signatories-sent',
         handleSingleSignatorySent
       );
 
@@ -571,9 +571,9 @@ function Builder() {
               },
               signatorySelector: SignatorySelector,
               signatorySwap: SignatorySwap,
-              singleSignatoryFlow: {
-                dialog: SingleSignatoryFlowDialog,
-                button: SingleSignatoryFlowButton,
+              mapSignatoriesFlow: {
+                dialog: MapSignatoriesFlowDialog,
+                button: MapSignatoriesFlowButton,
               },
               uninvite: {
                 dialog: UninviteDialog,

--- a/src/pages/documents/builder/components.tsx
+++ b/src/pages/documents/builder/components.tsx
@@ -17,6 +17,8 @@ import {
   DeleteDialogButtonProps,
   DeleteDialogProps,
   ImportFromButtonProps,
+  MapSignatoriesFlowButtonProps,
+  MapSignatoriesFlowDialogProps,
   RectangleSettingsCheckboxProps,
   RectangleSettingsDialogButtonProps,
   RectangleSettingsDialogProps,
@@ -26,8 +28,6 @@ import {
   RectangleSettingsOptionsListProps,
   RectangleSettingsRemoveButtonProps,
   RectangleSettingsSelectProps,
-  SingleSignatoryFlowButtonProps,
-  SingleSignatoryFlowDialogProps,
   ToolboxContextProps,
   UninviteDialogButtonProps,
   UninviteDialogProps,
@@ -81,13 +81,13 @@ export function DeleteButton({ isSubmitting }: DeleteDialogButtonProps) {
   );
 }
 
-export function SingleSignatoryFlowDialog({
+export function MapSignatoriesFlowDialog({
   open,
   onOpenChange,
   title,
   content,
   action,
-}: SingleSignatoryFlowDialogProps) {
+}: MapSignatoriesFlowDialogProps) {
   return (
     <Modal title={title} visible={open} onClose={onOpenChange} overflowVisible>
       {content}
@@ -97,10 +97,10 @@ export function SingleSignatoryFlowDialog({
   );
 }
 
-export function SingleSignatoryFlowButton({
+export function MapSignatoriesFlowButton({
   disabled,
   onClick,
-}: SingleSignatoryFlowButtonProps) {
+}: MapSignatoriesFlowButtonProps) {
   const [t] = useTranslation();
 
   return (

--- a/src/pages/documents/pages/blueprints/builder/BlueprintBuilder.tsx
+++ b/src/pages/documents/pages/blueprints/builder/BlueprintBuilder.tsx
@@ -42,6 +42,8 @@ import {
   DeleteDialog,
   ImportFromGoogleDrive,
   Loading,
+  MapSignatoriesFlowButton,
+  MapSignatoriesFlowDialog,
   RectangleSettingsButton,
   RectangleSettingsCheckbox,
   RectangleSettingsDialog,
@@ -52,8 +54,6 @@ import {
   RectangleSettingsRemoveButton,
   RectangleSettingsSaveButton,
   RectangleSettingsSelect,
-  SingleSignatoryFlowButton,
-  SingleSignatoryFlowDialog,
   ToolboxContext,
   UninviteButton,
   UninviteDialog,
@@ -443,9 +443,9 @@ function BlueprintBuilder() {
               },
               signatorySelector: SignatorySelector,
               signatorySwap: SignatorySwap,
-              singleSignatoryFlow: {
-                dialog: SingleSignatoryFlowDialog,
-                button: SingleSignatoryFlowButton,
+              mapSignatoriesFlow: {
+                dialog: MapSignatoriesFlowDialog,
+                button: MapSignatoriesFlowButton,
               },
               uninvite: {
                 dialog: UninviteDialog,

--- a/src/pages/documents/pages/blueprints/common/hooks/useActions.tsx
+++ b/src/pages/documents/pages/blueprints/common/hooks/useActions.tsx
@@ -46,83 +46,25 @@ export function useActions(params: UseActionsParams) {
 
   const { onSettingsClick } = params;
 
-  const extractSignatoryInfo = (blueprint: Blueprint) => {
-    if (!blueprint.document?.files) {
-      return { signatoryIds: [], signatoryInfo: {} };
-    }
-
-    const signatoryIds = new Set<string>();
-    const signatoryInfo: Record<string, { id: string; color: string }> = {};
-
-    // Track signatories and their colors in order
-    const signatoryOrder: string[] = [];
-
-    blueprint.document.files.forEach((file) => {
-      if (
-        file.metadata?.rectangles &&
-        Array.isArray(file.metadata.rectangles)
-      ) {
-        file.metadata.rectangles.forEach((rectangle: any) => {
-          if (
-            rectangle.signatory_id &&
-            rectangle.signatory_id.startsWith('blueprint|')
-          ) {
-            const signatoryId = rectangle.signatory_id;
-
-            // Only add to signatoryOrder if we haven't seen this ID before
-            if (!signatoryIds.has(signatoryId)) {
-              signatoryIds.add(signatoryId);
-              signatoryOrder.push(signatoryId);
-            }
-
-            // Store or update the color for this signatory
-            signatoryInfo[signatoryId] = {
-              id: signatoryId,
-              color: rectangle.color || '#FF5733',
-            };
-          }
-        });
-      }
-    });
-
-    // Return signatories in the order they were encountered
-    return {
-      signatoryIds: signatoryOrder,
-      signatoryInfo,
-    };
-  };
-
   const handleUseTemplate = (blueprint: Blueprint) => {
     toast.processing();
-    const { signatoryIds, signatoryInfo } = extractSignatoryInfo(blueprint);
 
-    if (signatoryIds.length > 0) {
-      // Navigate to signatory mapping page
+    request(
+      'POST',
+      docuNinjaEndpoint(`/api/blueprints/${blueprint.id}/action`),
+      { action: 'make_document' },
+      {
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem('X-DOCU-NINJA-TOKEN')}`,
+        },
+      }
+    ).then((response: AxiosResponse<GenericSingleResponse<Document>>) =>
       navigate(
-        route('/docuninja/templates/:id/map-signatories', { id: blueprint.id }),
-        {
-          state: { blueprint, signatoryIds, signatoryInfo },
-        }
-      );
-    } else {
-      // No signatories to map, proceed directly
-      request(
-        'POST',
-        docuNinjaEndpoint(`/api/blueprints/${blueprint.id}/action`),
-        { action: 'make_document' },
-        {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem('X-DOCU-NINJA-TOKEN')}`,
-          },
-        }
-      ).then((response: AxiosResponse<GenericSingleResponse<Document>>) =>
-        navigate(
-          route('/docuninja/:id/builder?from_template=true', {
-            id: response.data.data.id,
-          })
-        )
-      );
-    }
+        route('/docuninja/:id/builder?from_template=true', {
+          id: response.data.data.id,
+        })
+      )
+    );
   };
 
   const handleUseTemplateNoMapping = (blueprint: Blueprint) => {


### PR DESCRIPTION
This supports mapping multiple signatories on the use template action, skipping "map signatories" dedicated page.

<img width="2044" height="1313" alt="Screenshot 2026-09-03 at 18-32-56 Invoice Ninja" src="https://github.com/user-attachments/assets/d2813dc6-c491-45db-9424-e052d26293e3" />
