### PR TITLE
Ensure expense_id set when cloning to PO

### DIFF
--- a/src/pages/invoices/common/components/CloneOptionsModal.tsx
+++ b/src/pages/invoices/common/components/CloneOptionsModal.tsx
@@ -161,6 +161,7 @@ export function CloneOptionsModal(props: Props) {
       paid_to_date: 0,
       due_date: '',
       partial_due_date: '',
+      expense_id: '',
       design_id: company.settings.purchase_order_design_id,
       vendor: undefined,
     });


### PR DESCRIPTION
When converting invoice => PO, expense_id was not set causing a white screen.