### PR TITLE
[Cleanup] Implementing Convert To Purchase Order Action

### DIFF
--- a/src/common/hooks/useCommonActions.ts
+++ b/src/common/hooks/useCommonActions.ts
@@ -34,6 +34,7 @@ export function useAllCommonActions() {
       { value: 'client_portal', label: t('client_portal') },
       { value: 'cancel_invoice', label: t('cancel_invoice') },
       { value: 'reverse', label: t('reverse') },
+      { value: 'convert_to', label: t('convert_to') },
       { value: 'clone_to', label: t('clone_to') },
       { value: 'archive', label: t('archive') },
       { value: 'restore', label: t('restore') },

--- a/src/common/interfaces/purchase-order.ts
+++ b/src/common/interfaces/purchase-order.ts
@@ -75,6 +75,7 @@ export interface PurchaseOrder {
   paid_to_date: number;
   subscription_id: string;
   expense_id: string;
+  invoice_id: string;
   invitations: Invitation[];
   documents: any[];
   vendor?: Vendor;

--- a/src/pages/invoices/common/components/ConvertOptionsModal.tsx
+++ b/src/pages/invoices/common/components/ConvertOptionsModal.tsx
@@ -1,0 +1,79 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { MdSwitchRight } from 'react-icons/md';
+import { useColorScheme } from '$app/common/colors';
+import { useHasPermission } from '$app/common/hooks/permissions/useHasPermission';
+import { Invoice } from '$app/common/interfaces/invoice';
+import { CloneOption } from '$app/components/CloneOption';
+import { EntityActionElement } from '$app/components/EntityActionElement';
+import { FileClock } from '$app/components/icons/FileClock';
+import { Modal } from '$app/components/Modal';
+import { useConvertToPurchaseOrder } from '../hooks/useConvertToPurchaseOrder';
+
+interface Props {
+  invoice: Invoice;
+  dropdown: boolean;
+}
+
+export function ConvertOptionsModal({ invoice, dropdown }: Props) {
+  const [t] = useTranslation();
+
+  const colors = useColorScheme();
+  const hasPermission = useHasPermission();
+
+  const convertToPurchaseOrder = useConvertToPurchaseOrder({
+    entity: 'invoice',
+  });
+
+  const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
+
+  return (
+    <>
+      {hasPermission('create_purchase_order') && (
+        <EntityActionElement
+          entity="invoice"
+          actionKey="convert_to"
+          isCommonActionSection={!dropdown}
+          tooltipText={t('convert_to')}
+          onClick={() => setIsModalVisible(true)}
+          icon={MdSwitchRight}
+          disablePreventNavigation
+        >
+          {t('convert_to')}
+        </EntityActionElement>
+      )}
+
+      <Modal
+        title={t('convert_to')}
+        visible={isModalVisible}
+        onClose={() => setIsModalVisible(false)}
+      >
+        <div className="flex justify-center">
+          <div className="flex flex-1 flex-col items-center space-y-3">
+            {hasPermission('create_purchase_order') ? (
+              <CloneOption
+                label={t('purchase_order')}
+                iconElement={<FileClock size="1.1rem" color={colors.$3} />}
+                onClick={() => {
+                  convertToPurchaseOrder([invoice.id]);
+
+                  setIsModalVisible(false);
+                }}
+              />
+            ) : null}
+          </div>
+        </div>
+      </Modal>
+    </>
+  );
+}

--- a/src/pages/invoices/common/hooks/useConvertToPurchaseOrder.ts
+++ b/src/pages/invoices/common/hooks/useConvertToPurchaseOrder.ts
@@ -8,14 +8,13 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
-import { AxiosResponse } from 'axios';
 import { useSetAtom } from 'jotai';
 import { useNavigate } from 'react-router-dom';
 import { v4 } from 'uuid';
 import { endpoint } from '$app/common/helpers';
 import { request } from '$app/common/helpers/request';
 import { toast } from '$app/common/helpers/toast/toast';
-import { GenericManyResponse } from '$app/common/interfaces/generic-many-response';
+import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-api-response';
 import { PurchaseOrder } from '$app/common/interfaces/purchase-order';
 import { purchaseOrderAtom } from '$app/pages/purchase-orders/common/atoms';
 
@@ -34,8 +33,8 @@ export function useConvertToPurchaseOrder({ entity }: Props) {
     request('POST', endpoint(`/api/v1/${entity}s/bulk`), {
       action: 'convert_to_purchase_order',
       ids,
-    }).then((response: AxiosResponse<GenericManyResponse<PurchaseOrder>>) => {
-      const purchaseOrder = response.data.data[0];
+    }).then((response: GenericSingleResourceResponse<PurchaseOrder>) => {
+      const purchaseOrder = response.data.data;
 
       purchaseOrder.line_items.forEach((lineItem) => (lineItem._id = v4()));
 

--- a/src/pages/invoices/common/hooks/useConvertToPurchaseOrder.ts
+++ b/src/pages/invoices/common/hooks/useConvertToPurchaseOrder.ts
@@ -1,0 +1,44 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { useSetAtom } from 'jotai';
+import { useNavigate } from 'react-router-dom';
+import { v4 } from 'uuid';
+import { endpoint } from '$app/common/helpers';
+import { request } from '$app/common/helpers/request';
+import { toast } from '$app/common/helpers/toast/toast';
+import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-api-response';
+import { PurchaseOrder } from '$app/common/interfaces/purchase-order';
+import { purchaseOrderAtom } from '$app/pages/purchase-orders/common/atoms';
+
+export function useConvertToPurchaseOrder() {
+  const navigate = useNavigate();
+
+  const setPurchaseOrder = useSetAtom(purchaseOrderAtom);
+
+  return (ids: string[]) => {
+    toast.processing();
+
+    request('POST', endpoint('/api/v1/invoices/bulk'), {
+      action: 'convert_to_purchase_order',
+      ids,
+    }).then((response: GenericSingleResourceResponse<PurchaseOrder>) => {
+      const purchaseOrder = response.data.data;
+
+      purchaseOrder.line_items.forEach((lineItem) => (lineItem._id = v4()));
+
+      setPurchaseOrder(purchaseOrder);
+
+      toast.dismiss();
+
+      navigate('/purchase_orders/create?action=convert_to_purchase_order');
+    });
+  };
+}

--- a/src/pages/invoices/common/hooks/useConvertToPurchaseOrder.ts
+++ b/src/pages/invoices/common/hooks/useConvertToPurchaseOrder.ts
@@ -19,7 +19,11 @@ import { GenericManyResponse } from '$app/common/interfaces/generic-many-respons
 import { PurchaseOrder } from '$app/common/interfaces/purchase-order';
 import { purchaseOrderAtom } from '$app/pages/purchase-orders/common/atoms';
 
-export function useConvertToPurchaseOrder() {
+interface Props {
+  entity: 'invoice' | 'quote';
+}
+
+export function useConvertToPurchaseOrder({ entity }: Props) {
   const navigate = useNavigate();
 
   const setPurchaseOrder = useSetAtom(purchaseOrderAtom);
@@ -27,7 +31,7 @@ export function useConvertToPurchaseOrder() {
   return (ids: string[]) => {
     toast.processing();
 
-    request('POST', endpoint('/api/v1/invoices/bulk'), {
+    request('POST', endpoint(`/api/v1/${entity}s/bulk`), {
       action: 'convert_to_purchase_order',
       ids,
     }).then((response: AxiosResponse<GenericManyResponse<PurchaseOrder>>) => {

--- a/src/pages/invoices/common/hooks/useConvertToPurchaseOrder.ts
+++ b/src/pages/invoices/common/hooks/useConvertToPurchaseOrder.ts
@@ -8,13 +8,14 @@
  * @license https://www.elastic.co/licensing/elastic-license
  */
 
+import { AxiosResponse } from 'axios';
 import { useSetAtom } from 'jotai';
 import { useNavigate } from 'react-router-dom';
 import { v4 } from 'uuid';
 import { endpoint } from '$app/common/helpers';
 import { request } from '$app/common/helpers/request';
 import { toast } from '$app/common/helpers/toast/toast';
-import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-api-response';
+import { GenericManyResponse } from '$app/common/interfaces/generic-many-response';
 import { PurchaseOrder } from '$app/common/interfaces/purchase-order';
 import { purchaseOrderAtom } from '$app/pages/purchase-orders/common/atoms';
 
@@ -29,8 +30,8 @@ export function useConvertToPurchaseOrder() {
     request('POST', endpoint('/api/v1/invoices/bulk'), {
       action: 'convert_to_purchase_order',
       ids,
-    }).then((response: GenericSingleResourceResponse<PurchaseOrder>) => {
-      const purchaseOrder = response.data.data;
+    }).then((response: AxiosResponse<GenericManyResponse<PurchaseOrder>>) => {
+      const purchaseOrder = response.data.data[0];
 
       purchaseOrder.line_items.forEach((lineItem) => (lineItem._id = v4()));
 

--- a/src/pages/invoices/common/hooks/useCustomBulkActions.tsx
+++ b/src/pages/invoices/common/hooks/useCustomBulkActions.tsx
@@ -21,6 +21,7 @@ import {
   MdPaid,
   MdPrint,
   MdRestore,
+  MdSwitchRight,
 } from 'react-icons/md';
 import { EntityState } from '$app/common/enums/entity-state';
 import { InvoiceStatus } from '$app/common/enums/invoice-status';
@@ -40,6 +41,7 @@ import { useChangeTemplate } from '$app/pages/settings/invoice-design/pages/cust
 import { isInvoiceAutoBillable } from '../../edit/components/Actions';
 import { CancelInvoiceBulkAction } from '../components/CancelInvoiceBulkAction';
 import { SendEmailBulkAction } from '../components/SendEmailBulkAction';
+import { useConvertToPurchaseOrder } from './useConvertToPurchaseOrder';
 import { useDownloadPdfs } from './useDownloadPdfs';
 import { useEnterPayment } from './useEnterPayment';
 import { usePrintPdf } from './usePrintPdf';
@@ -63,6 +65,8 @@ export const useCustomBulkActions = () => {
   const bulk = useBulk();
 
   const reverseInvoice = useReverseInvoice();
+
+  const convertToPurchaseOrder = useConvertToPurchaseOrder();
 
   const getDocumentsIds = (invoices: Invoice[]) => {
     return invoices.flatMap(({ documents }) => documents.map(({ id }) => id));
@@ -274,6 +278,18 @@ export const useCustomBulkActions = () => {
           icon={<Icon element={MdDownload} />}
         >
           {t('documents')}
+        </DropdownElement>
+      ),
+    ({ selectedIds, setSelected }) =>
+      hasPermission('create_purchase_order') && (
+        <DropdownElement
+          onClick={() => {
+            convertToPurchaseOrder(selectedIds);
+            setSelected([]);
+          }}
+          icon={<Icon element={MdSwitchRight} />}
+        >
+          {t('convert_to_purchase_order')}
         </DropdownElement>
       ),
     // ({ selectedResources, setSelected }) =>

--- a/src/pages/invoices/common/hooks/useCustomBulkActions.tsx
+++ b/src/pages/invoices/common/hooks/useCustomBulkActions.tsx
@@ -21,7 +21,6 @@ import {
   MdPaid,
   MdPrint,
   MdRestore,
-  MdSwitchRight,
 } from 'react-icons/md';
 import { EntityState } from '$app/common/enums/entity-state';
 import { InvoiceStatus } from '$app/common/enums/invoice-status';
@@ -41,7 +40,6 @@ import { useChangeTemplate } from '$app/pages/settings/invoice-design/pages/cust
 import { isInvoiceAutoBillable } from '../../edit/components/Actions';
 import { CancelInvoiceBulkAction } from '../components/CancelInvoiceBulkAction';
 import { SendEmailBulkAction } from '../components/SendEmailBulkAction';
-import { useConvertToPurchaseOrder } from './useConvertToPurchaseOrder';
 import { useDownloadPdfs } from './useDownloadPdfs';
 import { useEnterPayment } from './useEnterPayment';
 import { usePrintPdf } from './usePrintPdf';
@@ -65,8 +63,6 @@ export const useCustomBulkActions = () => {
   const bulk = useBulk();
 
   const reverseInvoice = useReverseInvoice();
-
-  const convertToPurchaseOrder = useConvertToPurchaseOrder();
 
   const getDocumentsIds = (invoices: Invoice[]) => {
     return invoices.flatMap(({ documents }) => documents.map(({ id }) => id));
@@ -278,18 +274,6 @@ export const useCustomBulkActions = () => {
           icon={<Icon element={MdDownload} />}
         >
           {t('documents')}
-        </DropdownElement>
-      ),
-    ({ selectedIds, setSelected }) =>
-      hasPermission('create_purchase_order') && (
-        <DropdownElement
-          onClick={() => {
-            convertToPurchaseOrder(selectedIds);
-            setSelected([]);
-          }}
-          icon={<Icon element={MdSwitchRight} />}
-        >
-          {t('convert_to_purchase_order')}
         </DropdownElement>
       ),
     // ({ selectedResources, setSelected }) =>

--- a/src/pages/invoices/edit/components/Actions.tsx
+++ b/src/pages/invoices/edit/components/Actions.tsx
@@ -58,6 +58,7 @@ import { usePrintPdf } from '$app/pages/invoices/common/hooks/usePrintPdf';
 import { useScheduleEmailRecord } from '$app/pages/invoices/common/hooks/useScheduleEmailRecord';
 import { useChangeTemplate } from '$app/pages/settings/invoice-design/pages/custom-designs/components/ChangeTemplate';
 import { CloneOptionsModal } from '../../common/components/CloneOptionsModal';
+import { ConvertOptionsModal } from '../../common/components/ConvertOptionsModal';
 // import { useReverseInvoice } from '../../common/hooks/useReverseInvoice';
 import { EmailInvoiceAction } from '../../common/components/EmailInvoiceAction';
 import { useCancelInvoiceModal } from '../hooks/useCancelInvoiceModal';
@@ -436,6 +437,15 @@ export function useActions(params?: Params) {
           {t('schedule')}
         </EntityActionElement>
       ),
+    (invoice: Invoice) => (
+      <ConvertOptionsModal
+        {...(!dropdown && {
+          key: 'convert_to',
+        })}
+        dropdown={dropdown}
+        invoice={invoice}
+      />
+    ),
     (invoice: Invoice) =>
       shouldBeRunTemplateActionVisible && (
         <EntityActionElement

--- a/src/pages/purchase-orders/create/Create.tsx
+++ b/src/pages/purchase-orders/create/Create.tsx
@@ -128,7 +128,8 @@ export default function Create() {
       if (
         typeof data !== 'undefined' &&
         typeof value === 'undefined' &&
-        searchParams.get('action') !== 'clone'
+        searchParams.get('action') !== 'clone' &&
+        searchParams.get('action') !== 'convert_to_purchase_order'
       ) {
         const po = cloneDeep(data);
 
@@ -157,7 +158,10 @@ export default function Create() {
     });
 
     return () => {
-      if (searchParams.get('action') !== 'clone') {
+      if (
+        searchParams.get('action') !== 'clone' &&
+        searchParams.get('action') !== 'convert_to_purchase_order'
+      ) {
         setPurchaseOrder(undefined);
       }
     };

--- a/src/pages/purchase-orders/create/Create.tsx
+++ b/src/pages/purchase-orders/create/Create.tsx
@@ -119,7 +119,8 @@ export default function Create() {
 
       if (
         searchParams.get('action') !== 'clone' &&
-        searchParams.get('action') !== 'purchase_order_product'
+        searchParams.get('action') !== 'purchase_order_product' &&
+        searchParams.get('action') !== 'convert_to_purchase_order'
       ) {
         value = undefined;
       }

--- a/src/pages/quotes/common/components/ConvertOptionsModal.tsx
+++ b/src/pages/quotes/common/components/ConvertOptionsModal.tsx
@@ -18,9 +18,11 @@ import { Quote } from '$app/common/interfaces/quote';
 import { CloneOption } from '$app/components/CloneOption';
 import { EntityActionElement } from '$app/components/EntityActionElement';
 import { Button } from '$app/components/forms';
+import { FileClock } from '$app/components/icons/FileClock';
 import { Invoice as InvoiceIcon } from '$app/components/icons/Invoice';
 import { SuitCase } from '$app/components/icons/SuitCase';
 import { Modal } from '$app/components/Modal';
+import { useConvertToPurchaseOrder } from '$app/pages/invoices/common/hooks/useConvertToPurchaseOrder';
 import { useBulkAction } from '../hooks/useBulkAction';
 
 interface Props {
@@ -34,6 +36,8 @@ export function ConvertOptionsModal({ quote, dropdown }: Props) {
   const bulk = useBulkAction();
   const hasPermission = useHasPermission();
 
+  const convertToPurchaseOrder = useConvertToPurchaseOrder({ entity: 'quote' });
+
   const colors = useColorScheme();
 
   const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
@@ -44,6 +48,7 @@ export function ConvertOptionsModal({ quote, dropdown }: Props) {
     <>
       {((hasPermission('create_invoice') &&
         quote.status_id !== QuoteStatus.Converted) ||
+        hasPermission('create_purchase_order') ||
         (hasPermission('create_project') && !quote.project_id)) && (
         <EntityActionElement
           entity="quote"
@@ -72,6 +77,18 @@ export function ConvertOptionsModal({ quote, dropdown }: Props) {
                 iconElement={<InvoiceIcon size="1.1rem" color={colors.$3} />}
                 onClick={() => {
                   bulk([quote.id], 'convert_to_invoice');
+
+                  setIsModalVisible(false);
+                }}
+              />
+            ) : null}
+
+            {hasPermission('create_purchase_order') ? (
+              <CloneOption
+                label={t('purchase_order')}
+                iconElement={<FileClock size="1.1rem" color={colors.$3} />}
+                onClick={() => {
+                  convertToPurchaseOrder([quote.id]);
 
                   setIsModalVisible(false);
                 }}


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the implementation of the "Convert to Purchase Order" action for invoices and quotes. I picked a modal for invoices as well because I guess we will have more of those actions in the future, but for quotes, it is just one more action in the modal. Screenshots:

<img width="1512" height="777" alt="Screenshot 2026-09-09 at 21 13 00" src="https://github.com/user-attachments/assets/028501f5-e4a3-4303-9703-58bf95c46b05" />

<img width="1512" height="774" alt="Screenshot 2026-09-09 at 21 13 19" src="https://github.com/user-attachments/assets/587efe7a-a11a-40e0-94ad-9f00a3df9a6c" />

Let me know your thoughts.