### PR TITLE
[Cleanup] Implementing Validation For Tag Names

### DIFF
--- a/src/common/hooks/useValidateTagName.ts
+++ b/src/common/hooks/useValidateTagName.ts
@@ -1,0 +1,26 @@
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2022. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+import { useTranslation } from 'react-i18next';
+import { ValidationBag } from '$app/common/interfaces/validation-bag';
+
+export const useValidateTagName = () => {
+  const [t] = useTranslation();
+
+  return (name: string | undefined): ValidationBag | undefined => {
+    if (!name?.includes(',')) {
+      return undefined;
+    }
+
+    const message = t('commas_not_allowed');
+
+    return { message, errors: { name: [message] } };
+  };
+};

--- a/src/components/tags/TagPillSelector.tsx
+++ b/src/components/tags/TagPillSelector.tsx
@@ -20,6 +20,7 @@ import { randomTagColor } from '$app/common/helpers/tags';
 import { toast } from '$app/common/helpers/toast/toast';
 import { useAdmin } from '$app/common/hooks/permissions/useHasPermission';
 import { $refetch } from '$app/common/hooks/useRefetch';
+import { useValidateTagName } from '$app/common/hooks/useValidateTagName';
 import { GenericSingleResourceResponse } from '$app/common/interfaces/generic-api-response';
 import { Tag, TagEntityType } from '$app/common/interfaces/tag';
 import { ValidationBag } from '$app/common/interfaces/validation-bag';
@@ -48,10 +49,12 @@ export function TagPillSelector(props: Props) {
   const [t] = useTranslation();
   const colors = useColorScheme();
   const { isAdmin } = useAdmin();
+  const validateTagName = useValidateTagName();
 
   const [query, setQuery] = useState('');
   const [isOpen, setIsOpen] = useState(false);
   const [isCreating, setIsCreating] = useState(false);
+  const [errors, setErrors] = useState<ValidationBag>();
   const containerRef = useRef<HTMLDivElement>(null);
 
   const { data, isLoading, refetch } = useTagsQuery({
@@ -91,6 +94,7 @@ export function TagPillSelector(props: Props) {
   useClickAway(containerRef, () => setIsOpen(false));
 
   const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setErrors(undefined);
     setQuery(event.target.value);
     setIsOpen(true);
   };
@@ -110,7 +114,18 @@ export function TagPillSelector(props: Props) {
       return;
     }
 
+    const validationErrors = validateTagName(tagName);
+
+    if (validationErrors) {
+      setErrors(validationErrors);
+      setIsOpen(false);
+
+      return;
+    }
+
     toast.processing();
+
+    setErrors(undefined);
     setIsCreating(true);
 
     request('POST', endpoint('/api/v1/tags'), {
@@ -130,6 +145,8 @@ export function TagPillSelector(props: Props) {
       })
       .catch((error: AxiosError<ValidationBag>) => {
         if (error.response?.status === 422) {
+          setErrors(error.response.data);
+          setIsOpen(false);
           toast.dismiss();
         }
       })
@@ -244,7 +261,9 @@ export function TagPillSelector(props: Props) {
         )}
       </div>
 
-      <ErrorMessage className="mt-2">{props.errorMessage}</ErrorMessage>
+      <ErrorMessage className="mt-2">
+        {errors?.errors.name ?? props.errorMessage}
+      </ErrorMessage>
     </div>
   );
 }

--- a/src/pages/settings/tags/Create.tsx
+++ b/src/pages/settings/tags/Create.tsx
@@ -22,6 +22,7 @@ import { toast } from '$app/common/helpers/toast/toast';
 import { useAccentColor } from '$app/common/hooks/useAccentColor';
 import { $refetch } from '$app/common/hooks/useRefetch';
 import { useTitle } from '$app/common/hooks/useTitle';
+import { useValidateTagName } from '$app/common/hooks/useValidateTagName';
 import {
   TAG_ENTITY_TYPE_OPTIONS,
   TAG_ENTITY_TYPES,
@@ -48,6 +49,7 @@ function Create(props: Props) {
   const navigate = useNavigate();
   const colors = useColorScheme();
   const accentColor = useAccentColor();
+  const validateTagName = useValidateTagName();
   const initialEntityType = props.initialEntityType ?? TAG_ENTITY_TYPES.global;
 
   const pages = [
@@ -84,6 +86,14 @@ function Create(props: Props) {
     event.preventDefault();
 
     if (!isFormBusy) {
+      const validationErrors = validateTagName(tag?.name);
+
+      if (validationErrors) {
+        setErrors(validationErrors);
+
+        return;
+      }
+
       toast.processing();
 
       setErrors(undefined);

--- a/src/pages/settings/tags/Edit.tsx
+++ b/src/pages/settings/tags/Edit.tsx
@@ -19,6 +19,7 @@ import { route } from '$app/common/helpers/route';
 import { toast } from '$app/common/helpers/toast/toast';
 import { $refetch } from '$app/common/hooks/useRefetch';
 import { useTitle } from '$app/common/hooks/useTitle';
+import { useValidateTagName } from '$app/common/hooks/useValidateTagName';
 import {
   resolveTagEntityType,
   TAG_ENTITY_TYPE_OPTIONS,
@@ -46,6 +47,7 @@ function Edit(props: Props) {
 
   const actions = useActions();
   const colors = useColorScheme();
+  const validateTagName = useValidateTagName();
 
   const pages = [
     { name: t('settings'), href: '/settings' },
@@ -70,6 +72,14 @@ function Edit(props: Props) {
     event.preventDefault();
 
     if (!isFormBusy) {
+      const validationErrors = validateTagName(tag?.name);
+
+      if (validationErrors) {
+        setErrors(validationErrors);
+
+        return;
+      }
+
       toast.processing();
 
       setErrors(undefined);

--- a/tests/e2e/entity-tags.spec.ts
+++ b/tests/e2e/entity-tags.spec.ts
@@ -301,6 +301,55 @@ for (const entityCase of ENTITY_CASES) {
   });
 }
 
+const countTagWrites = (page: Page) => {
+  const state = { count: 0 };
+
+  page.on('request', (request) => {
+    const isTagWrite =
+      request.url().includes('/api/v1/tags') &&
+      ['POST', 'PUT'].includes(request.method());
+
+    if (isTagWrite) {
+      state.count += 1;
+    }
+  });
+
+  return state;
+};
+
+test('blocks a comma tag name in the tag selector', async ({ page, api }) => {
+  await login(page);
+
+  const client = await createEntity(api, 'clients', {
+    name: uniqueName('comma-tag-client'),
+  });
+
+  const editUrl = `/clients/${client.id}/edit`;
+
+  await page.goto(editUrl);
+  await page.waitForURL(`**${editUrl}`);
+
+  const input = page.locator('[data-cy="tagSelectorInput"]').first();
+  await input.waitFor({ state: 'visible', timeout: 15000 });
+
+  const tagWrites = countTagWrites(page);
+  const name = `${uniqueName('comma-tag')},13`;
+
+  await input.click();
+  await input.fill(name);
+
+  await page.locator('[data-cy="createTagOption"]').first().click();
+
+  await expect(page.locator('.error-message-box')).toBeVisible({
+    timeout: 10000,
+  });
+
+  expect(tagWrites.count).toBe(0);
+
+  await expect(page.locator('[data-cy="createTagOption"]')).toHaveCount(0);
+  await expect(input).toHaveValue(name);
+});
+
 test('can create and persist a tag on a bank transaction', async ({
   page,
   api,

--- a/tests/e2e/tags.spec.ts
+++ b/tests/e2e/tags.spec.ts
@@ -209,6 +209,22 @@ const runBulkAction = async (page: Page, action: 'Archive' | 'Delete') => {
     .click();
 };
 
+const countTagWrites = (page: Page) => {
+  const state = { count: 0 };
+
+  page.on('request', (request) => {
+    const isTagWrite =
+      request.url().includes('/api/v1/tags') &&
+      ['POST', 'PUT'].includes(request.method());
+
+    if (isTagWrite) {
+      state.count += 1;
+    }
+  });
+
+  return state;
+};
+
 // ---------------------------------------------------------------------------
 // CRUD
 // ---------------------------------------------------------------------------
@@ -377,6 +393,68 @@ test('can edit a task tag', async ({ page, api }) => {
 
   await expect(nameInput).toHaveValue(updatedName);
 
+});
+
+test('cannot create a tag whose name contains a comma', async ({ page }) => {
+  await login(page);
+
+  await navigateToTags(page);
+
+  await page
+    .getByRole('main')
+    .getByRole('link', { name: 'New Tag', exact: true })
+    .click();
+
+  await page.waitForURL('**/settings/tags/create');
+
+  const tagWrites = countTagWrites(page);
+  const name = `${uniqueName('comma-tag')},13`;
+
+  const nameInput = page.locator('#name');
+  await nameInput.waitFor({ state: 'visible', timeout: 5000 });
+  await nameInput.click();
+  await nameInput.fill(name);
+
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
+
+  await expect(page.locator('.error-message-box')).toBeVisible({
+    timeout: 10000,
+  });
+
+  expect(tagWrites.count).toBe(0);
+
+  await expect(page.getByText('Successfully created tag')).toHaveCount(0);
+  await expect(nameInput).toHaveValue(name);
+});
+
+test('cannot rename a tag to a name containing a comma', async ({
+  page,
+  api,
+}) => {
+  await login(page);
+
+  const name = uniqueName('comma-edit-tag');
+
+  await createTag({ page, name });
+
+  const tagId = extractIdFromUrl(page.url(), 'tags');
+  if (tagId) createdTagIds.push(tagId);
+
+  const tagWrites = countTagWrites(page);
+
+  const nameInput = page.locator('#name');
+  await nameInput.click();
+  await nameInput.fill(`${name},13`);
+
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
+
+  await expect(page.locator('.error-message-box')).toBeVisible({
+    timeout: 10000,
+  });
+
+  expect(tagWrites.count).toBe(0);
+
+  await expect(page.getByText('Successfully updated tag')).toHaveCount(0);
 });
 
 test('can delete a task tag from the edit page', async ({ page, api }) => {


### PR DESCRIPTION
@beganovich @turbo124 The PR includes implementation of validation for tag names, not allowing commas in the name either on creation or editing. Screenshots:

<img width="1080" height="396" alt="Screenshot 2026-09-08 at 21 55 36" src="https://github.com/user-attachments/assets/aac37365-10c0-42b7-8f97-d454ee51cdaf" />

<img width="492" height="398" alt="Screenshot 2026-09-08 at 21 55 57" src="https://github.com/user-attachments/assets/67407d1b-69ab-4f36-9ad7-4d700b3977a6" />

`Note`: As we do not have any translation keyword for this purpose, I assumed "commas_not_allowed". So, if you agree with it, please just add it to the translation files.

Let me know your thoughts.