### PR TITLE
[Bugfix] Tags Select Z Index

### DIFF
--- a/src/components/forms/CustomMultiSelect.tsx
+++ b/src/components/forms/CustomMultiSelect.tsx
@@ -164,7 +164,7 @@ function Control(props: ControlProps<SelectOption, true>) {
     <div className="relative">
       {label && (
         <span
-          className="xl:hidden absolute left-3 px-1 text-xs font-medium z-10 rounded-sm truncate"
+          className="xl:hidden absolute left-3 px-1 text-xs font-medium z-[1] rounded-sm truncate"
           style={{
             color: colors.$17,
             backgroundColor: colors.$1,


### PR DESCRIPTION
@beganovich @turbo124 The PR includes fixes for the z-index on the tags selector. Screenshot:

<img width="533" height="478" alt="Screenshot 2026-09-08 at 23 32 08" src="https://github.com/user-attachments/assets/eee376cf-61fe-4f3f-83ed-00dd34965e41" />

Let me know your thoughts.