### PR TITLE
[Feature] Adding All Time Date Ranges On Additional Cases

### DIFF
--- a/src/common/helpers/dateRange.ts
+++ b/src/common/helpers/dateRange.ts
@@ -3,6 +3,8 @@ import type { Dayjs } from 'dayjs';
 export type DayjsRange = [Dayjs | null, Dayjs | null] | null;
 export type SerializedDateRange = [string, string];
 
+export const ALL_TIME_START_DATE = '2000-01-01';
+
 export function serializeDateRange(value: DayjsRange): SerializedDateRange {
   return [
     value?.[0]?.format('YYYY-MM-DD') ?? '',

--- a/src/components/DropdownDateRangePicker.tsx
+++ b/src/components/DropdownDateRangePicker.tsx
@@ -220,6 +220,7 @@ export function DropdownDateRangePicker(props: Props) {
         <option value="this_year">{t('this_year')}</option>
         <option value="last_year">{t('last_year')}</option>
         <option value="last365_days">{t('last365_days')}</option>
+        <option value="all_time">{t('all_time')}</option>
         <option value="custom">{t('custom')}</option>
       </SelectField>
 

--- a/src/pages/clients/statement/Statement.tsx
+++ b/src/pages/clients/statement/Statement.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from 'react-i18next';
 import { MdDownload, MdSchedule, MdSend } from 'react-icons/md';
 import { useParams } from 'react-router-dom';
 import { endpoint } from '$app/common/helpers';
+import { ALL_TIME_START_DATE } from '$app/common/helpers/dateRange';
 import { request } from '$app/common/helpers/request';
 import { route } from '$app/common/helpers/route';
 import { toast } from '$app/common/helpers/toast/toast';
@@ -124,6 +125,11 @@ export default function Statement() {
       id: 'last_year',
       start: dayjs().subtract(1, 'year').startOf('year').format('YYYY-MM-DD'),
       end: dayjs().subtract(1, 'year').endOf('year').format('YYYY-MM-DD'),
+    },
+    {
+      id: 'all_time',
+      start: ALL_TIME_START_DATE,
+      end: dayjs().format('YYYY-MM-DD'),
     },
     {
       id: 'custom',

--- a/src/pages/dashboard/components/Totals.tsx
+++ b/src/pages/dashboard/components/Totals.tsx
@@ -19,6 +19,7 @@ import styled from 'styled-components';
 import { useColorScheme } from '$app/common/colors';
 import { endpoint } from '$app/common/helpers';
 import {
+  ALL_TIME_START_DATE,
   type DayjsRange,
   serializeOrderedDateRange,
 } from '$app/common/helpers/dateRange';
@@ -121,6 +122,10 @@ const GLOBAL_DATE_RANGES: Record<string, { start: string; end: string }> = {
   last_year: {
     start: dayjs().subtract(1, 'year').startOf('year').format('YYYY-MM-DD'),
     end: dayjs().subtract(1, 'year').endOf('year').format('YYYY-MM-DD'),
+  },
+  all_time: {
+    start: ALL_TIME_START_DATE,
+    end: dayjs().format('YYYY-MM-DD'),
   },
 };
 
@@ -447,6 +452,7 @@ export function Totals() {
                 <option value="this_year">{t('this_year')}</option>
                 <option value="last_year">{t('last_year')}</option>
                 <option value={'last365_days'}>{`${t('last365_days')}`}</option>
+                <option value="all_time">{t('all_time')}</option>
                 <option value="custom">{t('custom_range')}</option>
               </SelectField>
 

--- a/src/pages/settings/import-export/common/components/Export.tsx
+++ b/src/pages/settings/import-export/common/components/Export.tsx
@@ -112,6 +112,10 @@ const DATE_RANGES: Range[] = [
     identifier: 'last_year',
     label: 'last_year',
   },
+  {
+    identifier: 'all_time',
+    label: 'all_time',
+  },
   { identifier: 'custom', label: 'custom' },
 ];
 

--- a/tests/e2e/all-time-date-range.spec.ts
+++ b/tests/e2e/all-time-date-range.spec.ts
@@ -1,0 +1,176 @@
+import type { Page } from '@playwright/test';
+import { expect, resetAccountBeforeAll, test, uniqueName } from './fixtures';
+import { login } from './helpers';
+
+resetAccountBeforeAll();
+test.use({ actionTimeout: 10_000 });
+
+test.beforeEach(async ({ page }) => {
+  test.setTimeout(60_000);
+  await login(page);
+});
+
+function chartResponses(page: Page, range: string) {
+  return Promise.all(
+    ['totals_v2', 'chart_summary_v2'].map((endpoint) =>
+      page.waitForResponse(
+        (response) =>
+          response.url().includes(`/api/v1/charts/${endpoint}`) &&
+          response.request().method() === 'POST' &&
+          response.request().postDataJSON().date_range === range
+      )
+    )
+  );
+}
+
+function preferencesSaved(page: Page) {
+  return page.waitForResponse(
+    (response) =>
+      response.request().method() === 'PUT' &&
+      response.url().includes('/api/v1/company_users/') &&
+      response.url().includes('/preferences') &&
+      response.ok()
+  );
+}
+
+test('dashboard All time updates both charts and closes the custom picker', async ({
+  page,
+}) => {
+  await page.getByText('This Month', { exact: true }).click();
+  await page.getByRole('option', { name: 'Custom', exact: true }).click();
+  await expect(page.locator('.ant-picker')).toBeVisible();
+  const responses = chartResponses(page, 'all_time');
+  await page.getByText('Custom', { exact: true }).click();
+  await page.getByRole('option', { name: 'All Time', exact: true }).click();
+  for (const response of await responses) {
+    expect(response.ok()).toBeTruthy();
+  }
+  await expect(page.locator('.ant-picker')).toHaveCount(0);
+  await expect(page.getByText('All Time', { exact: true })).toBeVisible();
+});
+
+test('dashboard preferences saves All time after a custom range', async ({
+  page,
+}) => {
+  // The preferences trigger currently has no accessible label.
+  await page
+    .locator('div.cursor-pointer')
+    .filter({
+      has: page.locator('svg circle[cx="9"][cy="8.999"]'),
+    })
+    .last()
+    .click();
+  const dialog = page.getByRole('dialog');
+  const range = dialog
+    .locator('select')
+    .filter({ has: page.locator('option[value="all_time"]') });
+  await range.selectOption('custom');
+  await expect(dialog.locator('.ant-picker')).toBeVisible();
+  await range.selectOption('all_time');
+  await expect(dialog.locator('.ant-picker')).toHaveCount(0);
+  const saved = preferencesSaved(page);
+  await dialog.getByRole('button', { name: 'Save', exact: true }).click();
+  await saved;
+  await expect(dialog).toBeHidden();
+  const restored = chartResponses(page, 'all_time');
+  await page.reload();
+  for (const response of await restored) {
+    expect(response.ok()).toBeTruthy();
+  }
+  await expect(page.getByText('All Time', { exact: true })).toBeVisible();
+});
+
+test('client statement All time replaces custom dates and carries into scheduling', async ({
+  page,
+  api,
+}) => {
+  const client = await api.createEntity('clients', {
+    name: uniqueName('all-time-statement'),
+  });
+  // Exercise the real statement form without depending on PDF rendering services.
+  await page.route('**/api/v1/client_statement', (route) =>
+    route.fulfill({
+      contentType: 'application/pdf',
+      body: '%PDF-1.4\n%%EOF',
+    })
+  );
+  await page.goto(`/clients/${client.id}/statement`);
+  const range = page
+    .locator('select')
+    .filter({ has: page.locator('option[value="all_time"]') });
+  await range.selectOption('custom');
+  await page.locator('input[type="date"]').nth(0).fill('2025-01-01');
+  await page.locator('input[type="date"]').nth(1).fill('2025-01-31');
+  await page.locator('input[type="date"]').nth(1).press('Tab');
+  const today = await page.evaluate(() => {
+    const date = new Date();
+    return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+  });
+  const request = page.waitForRequest(
+    (request) =>
+      request.url().endsWith('/api/v1/client_statement') &&
+      request.method() === 'POST' &&
+      request.postDataJSON().dateRangeId === 'all_time'
+  );
+  await range.selectOption('all_time');
+  expect((await request).postDataJSON()).toMatchObject({
+    client_id: client.id,
+    dateRangeId: 'all_time',
+    start_date: '2000-01-01',
+    end_date: today,
+  });
+  await expect(page.locator('input[type="date"]')).toHaveCount(0);
+  await page.getByText('More Actions', { exact: true }).click();
+  await page.getByText('Schedule', { exact: true }).click();
+  await expect(page).toHaveURL(
+    /\/settings\/schedules\/create\?template=email_statement/
+  );
+  await expect(page.getByText('All Time', { exact: true })).toBeVisible();
+});
+
+test('export All time clears custom bounds in the report request', async ({
+  page,
+}) => {
+  // Capture submissions without scheduling emailed exports.
+  await page.route('**/api/v1/reports/invoices', (route) =>
+    route.fulfill({ json: { message: 'Exported' } })
+  );
+  await page.goto('/settings/import_export');
+  const field = (label: string) =>
+    page
+      .getByRole('term')
+      .filter({ hasText: new RegExp(`^${label}$`) })
+      .locator('..')
+      .getByRole('combobox');
+  await field('Export Type').click();
+  await page.getByRole('option', { name: 'Invoices', exact: true }).click();
+  await field('Date').click();
+  await page.getByRole('option', { name: 'Date', exact: true }).click();
+  await field('Date Range').click();
+  await page.getByRole('option', { name: 'Custom', exact: true }).click();
+  await page.locator('input[type="date"]').nth(0).fill('2025-01-01');
+  await page.locator('input[type="date"]').nth(0).press('Tab');
+  await page.locator('input[type="date"]').nth(1).fill('2025-01-31');
+  await page.locator('input[type="date"]').nth(1).press('Tab');
+  const customRequest = page.waitForRequest('**/api/v1/reports/invoices');
+  await page.getByRole('button', { name: 'Export', exact: true }).click();
+  expect((await customRequest).postDataJSON()).toMatchObject({
+    date_range: 'custom',
+    start_date: '2025-01-01',
+    end_date: '2025-01-31',
+  });
+  await expect(
+    page.getByRole('button', { name: 'Export', exact: true })
+  ).toBeEnabled();
+  await field('Date Range').press('ArrowDown');
+  await page.getByRole('option', { name: 'All Time', exact: true }).click();
+  await expect(page.locator('input[type="date"]')).toHaveCount(0);
+  const request = page.waitForRequest('**/api/v1/reports/invoices');
+  await page.getByRole('button', { name: 'Export', exact: true }).click();
+  expect((await request).postDataJSON()).toMatchObject({
+    date_key: 'date',
+    date_range: 'all_time',
+    start_date: '',
+    end_date: '',
+  });
+});


### PR DESCRIPTION
@beganovich @turbo124 The PR includes the addition of the "All time" date range on dashboard analytics, dashboard preferences, client statements, and the import/export page under settings. I could not find any other place where it would make sense to set this date range, so let me know if you find any. Screenshot:

<img width="564" height="447" alt="Screenshot 2026-09-09 at 20 22 43" src="https://github.com/user-attachments/assets/2839d689-31bc-438a-98a5-ed6a8c0e3e39" />

Let me know your thoughts.